### PR TITLE
Helm v3 support for NATS Server

### DIFF
--- a/helm/charts/nats/.helmignore
+++ b/helm/charts/nats/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+appVersion: "2.1.4"
+description: A Helm chart for NATS.io
+name: NATS
+version: 0.1.0
+home: http://github.com/nats-io/k8s
+maintainers:
+  - name: Waldemar Quevedo
+    email: wally@nats.io

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "2.1.4"
-description: A Helm chart for NATS.io
+description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications Technology.
 name: NATS
 version: 0.1.0
 home: http://github.com/nats-io/k8s

--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -1,6 +1,21 @@
 
+{{- if or .Values.nats.debug .Values.nats.trace }}
+*WARNING*: Keep in mind that running the server with
+debug and/or trace enabled significantly affects the
+performance of the server!
+{{- end }}
+
 You can find more info about running NATS on Kubernetes
 in the NATS documentation website:
 
   https://docs.nats.io/nats-on-kubernetes/nats-kubernetes
 
+NATS Box has been deployed into your cluster, you can
+the NATS tools within the container:
+
+  kubectl exec -n {{ .Release.Namespace }} -it {{ .Release.Name }}-box -- /bin/sh -l
+  nats-box:~# nats-sub test &
+  nats-box:~# nats-pub test hi
+  nats-box:~# nc {{ .Release.Name }} 4222
+
+Thanks for using NATS!

--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -5,11 +5,12 @@ debug and/or trace enabled significantly affects the
 performance of the server!
 {{- end }}
 
-You can find more info about running NATS on Kubernetes
+You can find more information about running NATS on Kubernetes
 in the NATS documentation website:
 
   https://docs.nats.io/nats-on-kubernetes/nats-kubernetes
 
+{{- if .Values.natsbox.enabled }}
 NATS Box has been deployed into your cluster, you can
 the NATS tools within the container:
 
@@ -17,5 +18,7 @@ the NATS tools within the container:
   nats-box:~# nats-sub test &
   nats-box:~# nats-pub test hi
   nats-box:~# nc {{ .Release.Name }} 4222
+
+{{- end }}
 
 Thanks for using NATS!

--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+You can find more info about running NATS on Kubernetes
+in the NATS documentation website:
+
+  https://docs.nats.io/nats-on-kubernetes/nats-kubernetes
+

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -6,14 +6,14 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Return the proper Nats image name
+Return the proper NATS image name
 */}}
 {{- define "nats.clusterAdvertise" -}}
 {{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc" (include "nats.name" . ) }}
 {{- end }}
 
 {{/*
-Return the proper Nats image name
+Return the proper NATS image name
 */}}
 {{- define "nats.clusterRoutes" -}}
 {{- range $i, $e := until 3 -}}

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nats.name" -}}
+{{- default .Release.Name -}}
+{{- end -}}
+
+{{/*
+Return the proper Nats image name
+*/}}
+{{- define "nats.clusterAdvertise" -}}
+{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc" (include "nats.name" . ) }}
+{{- end }}
+
+{{/*
+Return the proper Nats image name
+*/}}
+{{- define "nats.clusterRoutes" -}}
+{{- range $i, $e := until 3 -}}
+{{- printf "nats://%s-%d.%s.%s.svc:6222," $.Release.Name $i $.Release.Name $.Release.Namespace -}}
+{{- end -}}
+{{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
     http: 8222
     server_name: $POD_NAME
 
-    {{ if .Values.nats.cluster }}
+    {{ if .Values.cluster.enabled }}
     ###################################
     #                                 #
     # NATS Full Mesh Clustering Setup #

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -9,14 +9,21 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
   nats.conf: |
+    # PID file shared with configuration reloader.
     pid_file: "/var/run/nats/nats.pid"
 
+    ###############
+    #             #
+    # Monitoring  #
+    #             #
+    ###############
     http: 8222
+    server_name: $POD_NAME
 
     {{ if .Values.nats.cluster }}
     ###################################
     #                                 #
-    # NATS Full Mesh clustering setup #
+    # NATS Full Mesh Clustering Setup #
     #                                 #
     ###################################
     cluster {
@@ -31,11 +38,11 @@ data:
     }
     {{ end }}
 
-    {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
+    {{- if and .Values.nats.advertise .Values.nats.externalAccess }}
     include "advertise/client_advertise.conf"
-    {{ end }}
+    {{- end }}
 
-    {{ if .Values.leafnodes.enabled }}
+    {{- if .Values.leafnodes.enabled }}
     leafnodes {
       listen: "0.0.0.0:7422"
       {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
@@ -43,3 +50,61 @@ data:
       {{ end }}
     }
     {{ end }}
+
+    ####################
+    #                  #
+    # Logging Options  #
+    #                  #
+    ####################
+    {{- with .Values.nats.logging.debug }}
+    debug: {{ . }}
+    {{- end }}
+
+    {{- with .Values.nats.logging.trace }}
+    trace:  {{ . }}
+    {{- end }}
+
+    {{- with .Values.nats.logging.logtime }}
+    logtime: {{ . }}
+    {{- end }}
+
+    {{- with .Values.nats.logging.connectErrorReports }}
+    connect_error_reports: {{ . }}
+    {{- end }}
+
+    {{- with .Values.nats.logging.reconnectErrorReports }}
+    reconnect_error_reports: {{ . }}
+    {{- end }}
+
+    ##################
+    #                #
+    # Server Limits  #
+    #                #
+    ##################
+    {{- with .Values.nats.limits.maxConnections }}
+    max_connections: {{ . }}
+    {{- end }}
+    {{- with .Values.nats.limits.maxSubscriptions }}
+    max_subscriptions: {{ . }}
+    {{- end }}
+    {{- with .Values.nats.limits.maxPending }}
+    max_pending: {{ . }}
+    {{- end }}
+    {{- with .Values.nats.limits.maxControlLine }}
+    max_control_line: {{ . }}
+    {{- end }}
+    {{- with .Values.nats.limits.maxPayload }}
+    max_payload: {{ . }}
+    {{- end }}
+    {{- with .Values.nats.pingInterval }}
+    ping_interval: {{ . }}
+    {{- end }}
+    {{- with .Values.nats.maxPings }}
+    ping_max: {{ . }}
+    {{- end }}
+    {{- with .Values.nats.writeDeadline }}
+    write_deadline: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.nats.writeDeadline }}
+    lame_duck_duration:  {{ . | quote }}
+    {{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  metadata:
+  name: {{ template "nats.name" . }}-config
+  labels:
+    app: {{ template "nats.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+data:
+  nats.conf: |
+    pid_file: "/var/run/nats/nats.pid"
+
+    http: 8222
+
+    {{ if .Values.nats.cluster }}
+    ###################################
+    #                                 #
+    # NATS Full Mesh clustering setup #
+    #                                 #
+    ###################################
+    cluster {
+      port: 6222
+
+      routes = [
+        {{ template "nats.clusterRoutes" . }}
+      ]
+      cluster_advertise: $CLUSTER_ADVERTISE
+
+      connect_retries: {{ .Values.nats.connectRetries }}
+    }
+    {{ end }}
+
+    {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
+    include "advertise/client_advertise.conf"
+    {{ end }}
+
+    {{ if .Values.leafnodes.enabled }}
+    leafnodes {
+      listen: "0.0.0.0:7422"
+      {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
+      include "advertise/gateway_advertise.conf"
+      {{ end }}
+    }
+    {{ end }}

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.natsbox.enabled }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-box
+  labels:
+    app: {{ .Release.Name }}-box
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  containers:
+  - name: nats-box
+    image: {{ .Values.natsbox.image }}
+    imagePullPolicy: {{ .Values.natsbox.pullPolicy }}
+    env:
+    - name: NATS_URL
+      value: {{ .Release.Name }}
+    command:
+     - "tail"
+     - "-f"
+     - "/dev/null"
+{{- end }}

--- a/helm/charts/nats/templates/rbac.yaml
+++ b/helm/charts/nats/templates/rbac.yaml
@@ -1,0 +1,31 @@
+{{ if and .Values.nats.externalAccess .Values.nats.advertise }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.nats.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.nats.serviceAccount }}
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.nats.serviceAccount }}-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.nats.serviceAccount }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.nats.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nats.name" . }}
+  labels:
+    app: {{ template "nats.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    app: {{ template "nats.name" . }}
+  clusterIP: None
+  ports:
+  - name: client
+    port: 4222
+  - name: cluster
+    port: 6222
+  - name: monitor
+    port: 8222
+  - name: metrics
+    port: 7777
+  - name: leafnodes
+    port: 7422
+  - name: gateways
+    port: 7522

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -1,82 +1,77 @@
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: nats-config
-data:
-  nats.conf: |
-    pid_file: "/var/run/nats/nats.pid"
-
-    debug = false
-    trace = false
-
-    http: 8222
-
-    cluster {
-      port: 6222
-
-      routes [
-        nats://nats-0.nats.default.svc:6222
-        nats://nats-1.nats.default.svc:6222
-        nats://nats-2.nats.default.svc:6222
-      ]
-
-      cluster_advertise: $CLUSTER_ADVERTISE
-      connect_retries: 30
-    }
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: nats
-  labels:
-    app: nats
-spec:
-  selector:
-    app: nats
-  clusterIP: None
-  ports:
-  - name: client
-    port: 4222
-  - name: cluster
-    port: 6222
-  - name: monitor
-    port: 8222
-  - name: metrics
-    port: 7777
-  - name: leafnodes
-    port: 7422
-  - name: gateways
-    port: 7522
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: nats
+  name: {{ template "nats.name" . }}
   labels:
-    app: nats
+    app: {{ template "nats.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   selector:
     matchLabels:
-      app: nats
+      app: {{ template "nats.name" . }}
+  {{ if .Values.nats.cluster }}
   replicas: 3
-  serviceName: "nats"
+  {{ else }}
+  replicas: 1
+  {{ end }}
+  serviceName: {{ template "nats.name" . }}
   template:
     metadata:
       labels:
-        app: nats
+        app: {{ template "nats.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
-      # Common volumes for the containers
+      # Common volumes for the containers.
       volumes:
       - name: config-volume
         configMap:
-          name: nats-config
+          name: {{ template "nats.name" . }}-config
+
+      # Local volume shared with the reloader.
       - name: pid
         emptyDir: {}
+      {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
+      # Local volume shared with the advertise config initializer.
+      - name: advertiseconfig
+        emptyDir: {}
+      {{ end }}
 
-      # Required to be able to HUP signal and apply config reload
-      # to the server without restarting the pod.
+      {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
+      # Assume that we only use the service account in case we want to
+      # figure out what is the current external public IP from the server
+      # in order to be able to advertise correctly.
+      serviceAccountName: {{ .Values.nats.serviceAccount }}
+      {{ end }}
+
+      # Required to be able to HUP signal and apply config
+      # reload to the server without restarting the pod.
       shareProcessNamespace: true
+
+      {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
+      # Initializer container required to be able to lookup
+      # the external ip on which this node is running.
+      initContainers:
+      - name: bootconfig
+        command:
+        - nats-pod-bootconfig
+        - -f
+        - /etc/nats-config/advertise/client_advertise.conf
+        - -gf
+        - /etc/nats-config/advertise/gateway_advertise.conf
+        env:
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: {{ .Values.bootconfig.image }}
+        imagePullPolicy: {{ .Values.bootconfig.pullPolicy }}
+        volumeMounts:
+        - mountPath: /etc/nats-config/advertise
+          name: advertiseconfig
+          subPath: advertise
+      {{ end }}
 
       #################
       #               #
@@ -86,14 +81,24 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.2-alpine3.10
+        image: {{ .Values.nats.image }}
+        imagePullPolicy: {{ .Values.nats.pullPolicy }}
         ports:
         - containerPort: 4222
           name: client
+          {{- if .Values.nats.externalAccess }}
           hostPort: 4222
+          {{- end }}
         - containerPort: 7422
           name: leafnodes
+          {{- if .Values.nats.externalAccess }}
           hostPort: 7422
+          {{- end }}
+        - containerPort: 7522
+          name: gateways
+          {{- if .Values.nats.externalAccess }}
+          hostPort: 7522
+          {{- end }}
         - containerPort: 6222
           name: cluster
         - containerPort: 8222
@@ -118,14 +123,19 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CLUSTER_ADVERTISE
-          value: $(POD_NAME).nats.$(POD_NAMESPACE).svc
+          value: {{ template "nats.clusterAdvertise" . }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/nats-config
           - name: pid
             mountPath: /var/run/nats
+          {{- if and .Values.nats.externalAccess .Values.nats.advertise }}
+          - mountPath: /etc/nats-config/advertise
+            name: advertiseconfig
+            subPath: advertise
+          {{- end }}
 
-        # Liveness/Readiness probes against the monitoring
+        # Liveness/Readiness probes against the monitoring.
         #
         livenessProbe:
           httpGet:
@@ -156,8 +166,10 @@ spec:
       #  NATS Configuration Reloader  #
       #                               #
       #################################
+      {{ if .Values.reloader.enabled }}
       - name: reloader
-        image: connecteverything/nats-server-config-reloader:0.6.0
+        image: {{ .Values.reloader.image }}
+        imagePullPolicy: {{ .Values.reloader.pullPolicy }}
         command:
          - "nats-server-config-reloader"
          - "-pid"
@@ -169,14 +181,17 @@ spec:
             mountPath: /etc/nats-config
           - name: pid
             mountPath: /var/run/nats
+      {{ end }}
 
       ##############################
       #                            #
       #  NATS Prometheus Exporter  #
       #                            #
       ##############################
+      {{ if .Values.exporter.enabled }}
       - name: metrics
-        image: synadia/prometheus-nats-exporter:0.5.0
+        image: {{ .Values.exporter.image }}
+        imagePullPolicy: {{ .Values.exporter.pullPolicy }}
         args:
         - -connz
         - -routez
@@ -189,3 +204,4 @@ spec:
         ports:
         - containerPort: 7777
           name: metrics
+      {{ end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nats.name" . }}
-  {{- if .Values.nats.cluster }}
+  {{- if .Values.cluster.enabled }}
   replicas: 3
   {{- else }}
   replicas: 1

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -10,11 +10,11 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nats.name" . }}
-  {{ if .Values.nats.cluster }}
+  {{- if .Values.nats.cluster }}
   replicas: 3
-  {{ else }}
+  {{- else }}
   replicas: 1
-  {{ end }}
+  {{- end }}
   serviceName: {{ template "nats.name" . }}
   template:
     metadata:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -23,6 +23,29 @@ nats:
   # The number of connect attempts against discovered routes.
   connectRetries: 30
 
+  # How many seconds should pass before sending a PING
+  # to a client that has no activity.
+  pingInterval: 
+
+  # Server settings
+  limits:
+    maxConnections: 
+    maxSubscriptions: 
+    maxControlLine: 
+    maxPayload: 
+
+    writeDeadline: 
+    maxPending: 
+    maxPings: 
+    lameDuckDuration: 
+
+  logging:
+    debug: 
+    trace: 
+    logtime: 
+    connectErrorReports: 
+    reconnectErrorReports: 
+
 # Leafnode connections to extend a cluster:
 #
 # https://docs.nats.io/nats-server/configuration/leafnodes
@@ -35,6 +58,14 @@ leafnodes:
 # the public ips.
 bootconfig:
   image: connecteverything/nats-boot-config:0.5.2
+  pullPolicy: IfNotPresent
+
+# NATS Box
+#
+# https://github.com/nats-io/nats-box
+# 
+natsbox:
+  image: synadia/nats-box:0.3.0
   pullPolicy: IfNotPresent
 
 # The NATS config reloader image to use.

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -1,0 +1,50 @@
+# NATS Server Configuration
+nats:
+  image: nats:2.1.4-alpine3.11
+  pullPolicy: IfNotPresent
+
+  # Toggle whether to use setup a NATS Cluster of 3 nodes.
+  cluster: false
+
+  # Toggle whether to disable external access.
+  # This binds a host port for clients, gateways and leafnodes.
+  externalAccess: false
+
+  # Toggle to disable client advertisements (connect_urls),
+  # in case of running behind a load balancer (which is not recommended)
+  # it might be required to disable advertisements.
+  advertise: true
+
+  # In case both external access and advertise are enabled
+  # then a service account would be required to be able to
+  # gather the public ip from a node.
+  serviceAccount: "nats-server"
+
+  # The number of connect attempts against discovered routes.
+  connectRetries: 30
+
+# Leafnode connections to extend a cluster:
+#
+# https://docs.nats.io/nats-server/configuration/leafnodes
+#
+leafnodes:
+  enabled: false
+
+# In case of both external access and advertisements being
+# enabled, an initializer container will be used to gather
+# the public ips.
+bootconfig:
+  image: connecteverything/nats-boot-config:0.5.2
+  pullPolicy: IfNotPresent
+
+# The NATS config reloader image to use.
+reloader:
+  enabled: true
+  image: connecteverything/nats-server-config-reloader:0.6.0
+  pullPolicy: IfNotPresent
+
+# Prometheus NATS Exporter configuration.
+exporter:
+  enabled: true
+  image: synadia/prometheus-nats-exporter:0.5.0
+  pullPolicy: IfNotPresent

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -3,9 +3,6 @@ nats:
   image: nats:2.1.4-alpine3.11
   pullPolicy: IfNotPresent
 
-  # Toggle whether to use setup a NATS Cluster of 3 nodes.
-  cluster: false
-
   # Toggle whether to enable external access.
   # This binds a host port for clients, gateways and leafnodes.
   externalAccess: false
@@ -45,6 +42,10 @@ nats:
     logtime: 
     connectErrorReports: 
     reconnectErrorReports: 
+
+# Toggle whether to use setup a NATS Cluster.
+cluster:
+  enabled: false
 
 # Leafnode connections to extend a cluster:
 #

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -6,7 +6,7 @@ nats:
   # Toggle whether to use setup a NATS Cluster of 3 nodes.
   cluster: false
 
-  # Toggle whether to disable external access.
+  # Toggle whether to enable external access.
   # This binds a host port for clients, gateways and leafnodes.
   externalAccess: false
 
@@ -65,6 +65,7 @@ bootconfig:
 # https://github.com/nats-io/nats-box
 # 
 natsbox:
+  enabled: true
   image: synadia/nats-box:0.3.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Adds Helm charts for the NATS Server, sample usage:

```sh
helm install nats --debug  helm/charts/nats \
   --set cluster.enabled=true \
   --set nats.externalAccess=true \
   --set nats.advertise=true
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>