### PR TITLE
Add support for memory resolver in NATS Server chart

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.2.2
+version: 0.3.0
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -107,3 +107,15 @@ data:
     {{- with .Values.nats.writeDeadline }}
     lame_duck_duration:  {{ . | quote }}
     {{- end }}
+
+    ##################
+    #                #
+    # Authorization  #
+    #                #
+    ##################
+    {{- if .Values.auth.enabled }}
+    {{- if eq .Values.auth.resolver.type "memory" }}
+    resolver: MEMORY
+    {{ .Values.auth.resolver.preload | indent 6 }}
+    {{- end }}
+    {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -81,3 +81,10 @@ exporter:
   enabled: true
   image: synadia/prometheus-nats-exporter:0.5.0
   pullPolicy: IfNotPresent
+
+# Setup memory preload config.
+auth:
+  enabled: false
+  resolver:
+    type: memory
+    preload: ""


### PR DESCRIPTION
Played with many ideas, but the only way I see this being managed when using the mem resolver is by including the yaml preload directly, 

e.g.

```sh
nsc generate config --mem-resolver --sys-account SYS | pbcopy
# add to deploy.yaml
helm install nats-nsc-setup .  -f deploy.yaml
```

Where the deploy.yaml is: 

```yaml
auth:
  enabled: true
  resolver:
    type: memory
    preload: |
      // Operator "KO"
      operator: eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiI0U09OUjZLT05FMzNFRFhRWE5IR1JUSEg2TEhPM0dFU0xXWlJYNlNENTQ2MjQyTE80QlVRIiwiaWF0IjoxNTgzNzg1MTMyLCJpc3MiOiJPQ0RHNk9ZUFdYRlNLTEdTSFBBUkdTUllDS0xKSVFJMklORUtVVkFGMzJNVzU2VlRMTDRGV0o0SSIsIm5hbWUiOiJLTyIsInN1YiI6Ik9DREc2T1lQV1hGU0tMR1NIUEFSR1NSWUNLTEpJUUkySU5FS1VWQUYzMk1XNTZWVExMNEZXSjRJIiwidHlwZSI6Im9wZXJhdG9yIiwibmF0cyI6e319.0039eTgLj-uyYFoWB3rivGP0WyIZkb_vrrE6tnqcNgIDM59o92nw_Rvb-hrvsK30QWqwm_W8BpVZHDMEY-CiBQ

      system_account: ACLZ6OSWC7BXFT4VNVBDMWUFNBIVGHTUONOXI6TCBP3QHOD34JIDSRYW

      resolver_preload: {
        // Account "A"
        AA3NXTHTXOHCTPIBKEDHNAYAHJ4CO7ERCOJFYCXOXVEOPZTMW55WX32Z: eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiJSM0QyWUM1UVlJWk4zS0hYR1FFRTZNQTRCRVU3WkFWQk5LSElJNTNOM0tLRVRTTVZEVVRRIiwiaWF0IjoxNTgzNzg1MTMyLCJpc3MiOiJPQ0RHNk9ZUFdYRlNLTEdTSFBBUkdTUllDS0xKSVFJMklORUtVVkFGMzJNVzU2VlRMTDRGV0o0SSIsIm5hbWUiOiJBIiwic3ViIjoiQUEzTlhUSFRYT0hDVFBJQktFREhOQVlBSEo0Q083RVJDT0pGWUNYT1hWRU9QWlRNVzU1V1gzMloiLCJ0eXBlIjoiYWNjb3VudCIsIm5hdHMiOnsiZXhwb3J0cyI6W3sibmFtZSI6InRlc3QiLCJzdWJqZWN0IjoidGVzdCIsInR5cGUiOiJzZXJ2aWNlIiwicmVzcG9uc2VfdHlwZSI6IlNpbmdsZXRvbiIsInNlcnZpY2VfbGF0ZW5jeSI6eyJzYW1wbGluZyI6MTAwLCJyZXN1bHRzIjoibGF0ZW5jeS5vbi50ZXN0In19XSwibGltaXRzIjp7InN1YnMiOi0xLCJjb25uIjotMSwibGVhZiI6LTEsImltcG9ydHMiOi0xLCJleHBvcnRzIjotMSwiZGF0YSI6LTEsInBheWxvYWQiOi0xLCJ3aWxkY2FyZHMiOnRydWV9fX0.W7oEjpQA986Hai3t8UOiJwCcVDYm2sj7L545oYZhQtYbydh_ragPn8pc0f1pA1krMz_ZDuBwKHLZRgXuNSysDQ

        // Account "STAN"
        AAYNFTMTKWXZEPPSEZLECMHE3VBULMIUO2QGVY3P4VCI7NNQC3TVX2PB: eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiJRSUozV0I0MjdSVU5RSlZFM1dRVEs3TlNaVlpaNkRQT01KWkdHMlhTMzQ2WFNQTVZERElBIiwiaWF0IjoxNTgzNzg1MTMyLCJpc3MiOiJPQ0RHNk9ZUFdYRlNLTEdTSFBBUkdTUllDS0xKSVFJMklORUtVVkFGMzJNVzU2VlRMTDRGV0o0SSIsIm5hbWUiOiJTVEFOIiwic3ViIjoiQUFZTkZUTVRLV1haRVBQU0VaTEVDTUhFM1ZCVUxNSVVPMlFHVlkzUDRWQ0k3Tk5RQzNUVlgyUEIiLCJ0eXBlIjoiYWNjb3VudCIsIm5hdHMiOnsibGltaXRzIjp7InN1YnMiOi0xLCJjb25uIjotMSwibGVhZiI6LTEsImltcG9ydHMiOi0xLCJleHBvcnRzIjotMSwiZGF0YSI6LTEsInBheWxvYWQiOi0xLCJ3aWxkY2FyZHMiOnRydWV9fX0.SPyQdAFmoON577s-eZP4K3-9QXYhTn9Xqy3aDGeHvHYRE9IVD47Eu7d38ZiySPlxgkdM_WXZn241_59d07axBA

        // Account "SYS"
        ACLZ6OSWC7BXFT4VNVBDMWUFNBIVGHTUONOXI6TCBP3QHOD34JIDSRYW: eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiJGSk1TSEROVlVGUEM0U0pSRlcyV0NZT1hRWUFDM1hNNUJaWTRKQUZWUTc1V0lEUkdDN0lBIiwiaWF0IjoxNTgzNzg1MTMyLCJpc3MiOiJPQ0RHNk9ZUFdYRlNLTEdTSFBBUkdTUllDS0xKSVFJMklORUtVVkFGMzJNVzU2VlRMTDRGV0o0SSIsIm5hbWUiOiJTWVMiLCJzdWIiOiJBQ0xaNk9TV0M3QlhGVDRWTlZCRE1XVUZOQklWR0hUVU9OT1hJNlRDQlAzUUhPRDM0SklEU1JZVyIsInR5cGUiOiJhY2NvdW50IiwibmF0cyI6eyJsaW1pdHMiOnsic3VicyI6LTEsImNvbm4iOi0xLCJsZWFmIjotMSwiaW1wb3J0cyI6LTEsImV4cG9ydHMiOi0xLCJkYXRhIjotMSwicGF5bG9hZCI6LTEsIndpbGRjYXJkcyI6dHJ1ZX19fQ.owW08dIa97STqgT0ux-5sD00Ad0I3HstJKTmh1CGVpsQwelaZdrBuia-4XgCgN88zuLokPMfWI_pkxXU_iB0BA

        // Account "B"
        ADOR7Q5KMWC2XIWRRRC4MZUDCPYG3UMAIWDRX6M2MFDY5SR6HQAAMHJA: eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiJRQjdIRFg3VUZYN01KUjZPS1E2S1dRSlVUUEpWWENTNkJCWjQ3SDVVTFdVVFNRUU1NQzJRIiwiaWF0IjoxNTgzNzg1MTMyLCJpc3MiOiJPQ0RHNk9ZUFdYRlNLTEdTSFBBUkdTUllDS0xKSVFJMklORUtVVkFGMzJNVzU2VlRMTDRGV0o0SSIsIm5hbWUiOiJCIiwic3ViIjoiQURPUjdRNUtNV0MyWElXUlJSQzRNWlVEQ1BZRzNVTUFJV0RSWDZNMk1GRFk1U1I2SFFBQU1ISkEiLCJ0eXBlIjoiYWNjb3VudCIsIm5hdHMiOnsiaW1wb3J0cyI6W3sibmFtZSI6InRlc3QiLCJzdWJqZWN0IjoidGVzdCIsImFjY291bnQiOiJBQTNOWFRIVFhPSENUUElCS0VESE5BWUFISjRDTzdFUkNPSkZZQ1hPWFZFT1BaVE1XNTVXWDMyWiIsInRvIjoidGVzdCIsInR5cGUiOiJzZXJ2aWNlIn1dLCJsaW1pdHMiOnsic3VicyI6LTEsImNvbm4iOi0xLCJsZWFmIjotMSwiaW1wb3J0cyI6LTEsImV4cG9ydHMiOi0xLCJkYXRhIjotMSwicGF5bG9hZCI6LTEsIndpbGRjYXJkcyI6dHJ1ZX19fQ.r5p_sGt_hmDfWWIJGrLodAM8VfXPeUzsbRtzrMTBGGkcLdi4jqAHXRu09CmFISEzX2VKeGuOonGuAMOFotvICg
      }

```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>
