### PR TITLE
helm: Add configmap ref support for mem resolver

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.2.2
+version: 0.3.0
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -107,3 +107,15 @@ data:
     {{- with .Values.nats.writeDeadline }}
     lame_duck_duration:  {{ . | quote }}
     {{- end }}
+
+    {{- if .Values.auth.enabled }}
+    ##################
+    #                #
+    # Authorization  #
+    #                #
+    ##################
+    {{- if eq .Values.auth.resolver.type "memory" }}
+    resolver: MEMORY
+    include "accounts/{{ .Values.auth.resolver.configMap.key }}"
+    {{- end }}
+    {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -31,6 +31,16 @@ spec:
       # Local volume shared with the reloader.
       - name: pid
         emptyDir: {}
+
+      {{- if .Values.auth.enabled }}
+      {{- if eq .Values.auth.resolver.type "memory" }}
+      # Volume with the memory resolver configuration.
+      - name: resolver-volume
+        configMap:
+          name: {{ .Values.auth.resolver.configMap.name }}
+      {{- end }}
+      {{- end }}
+
       {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
       # Local volume shared with the advertise config initializer.
       - name: advertiseconfig
@@ -48,7 +58,7 @@ spec:
       # reload to the server without restarting the pod.
       shareProcessNamespace: true
 
-      {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
+      {{- if and .Values.nats.externalAccess .Values.nats.advertise }}
       # Initializer container required to be able to lookup
       # the external ip on which this node is running.
       initContainers:
@@ -71,7 +81,7 @@ spec:
         - mountPath: /etc/nats-config/advertise
           name: advertiseconfig
           subPath: advertise
-      {{ end }}
+      {{- end }}
 
       #################
       #               #
@@ -133,6 +143,13 @@ spec:
           - mountPath: /etc/nats-config/advertise
             name: advertiseconfig
             subPath: advertise
+          {{- end }}
+
+          {{- if .Values.auth.enabled }}
+          {{- if eq .Values.auth.resolver.type "memory" }}
+          - name: resolver-volume
+            mountPath: /etc/nats-config/accounts
+          {{- end }}
           {{- end }}
 
         # Liveness/Readiness probes against the monitoring.

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -81,3 +81,16 @@ exporter:
   enabled: true
   image: synadia/prometheus-nats-exporter:0.5.0
   pullPolicy: IfNotPresent
+
+# Authentication setup
+auth:
+  enabled: false
+  resolver:
+    type: memory
+    # 
+    # Use a configmap reference which will be mounted
+    # into the container.
+    # 
+    configMap:
+      name: nats-accounts
+      key: resolver.conf


### PR DESCRIPTION
Adds support for referencing a configmap to be used as a memory resolver.

Usage (requires installed `nsc`): 

```sh
curl -sSL https://nats-io.github.io/k8s/setup/nsc-setup.sh | sh
nsc generate config --mem-resolver --sys-account SYS > resolver.conf
kubectl create configmap nats-accounts --from-file resolver.conf
```

The reference the configmap as follows:

```yaml
# deploy.yaml
auth:
  enabled: true
  resolver:
    type: memory
    configMap:
      name: nats-accounts
      key: resolver.conf
```

```sh
helm install nats-with-auth nats/nats  -f deploy.yaml
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>