### PR TITLE
[helm] Add support for using NATS Account Server as the resolver

### DIFF
--- a/helm/charts/nats-account-server/Chart.yaml
+++ b/helm/charts/nats-account-server/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+appVersion: "0.8.6"
+description: A Helm chart for the NATS.io JWT Account Server
+name: nats-account-server
+keywords:
+  - nats
+  - messaging
+  - cncf
+  - jwt
+  - auth
+version: 0.3.0
+home: http://github.com/nats-io/k8s
+maintainers:
+  - name: Waldemar Quevedo
+    github: https://github.com/wallyqs
+    email: wally@nats.io
+  - name: Colin Sullivan
+    github: https://github.com/ColinSullivan1
+    email: colin@nats.io
+icon: https://nats.io/img/logo.png

--- a/helm/charts/nats-account-server/templates/_helpers.tpl
+++ b/helm/charts/nats-account-server/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Release.Name -}}
+{{- end -}}

--- a/helm/charts/nats-account-server/templates/configmap.yaml
+++ b/helm/charts/nats-account-server/templates/configmap.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "name" . }}-config
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+data:
+  accountserver.conf: |
+    # Host/Port for the NATS Account Server
+    http {
+      host: "0.0.0.0"
+      port: 9090
+    }
+
+    # Operator JWT used to validate the accounts.
+    operatorjwtpath: "/etc/nats-config/operator/{{ .Values.operator.operatorjwt.configMap.key }}"
+
+    # System Account JWT
+    systemaccountjwtpath: "/etc/nats-config/sys/{{ .Values.operator.systemaccountjwt.configMap.key }}"
+
+    # NATS Server connection
+    nats {
+      servers: [{{ .Values.nats.url }}]
+      usercredentials: "/etc/nats-config/syscreds/{{ .Values.nats.credentials.secret.key }}"
+    }
+
+    {{- if eq .Values.store.type "file"}}
+    store {
+      dir: "/store"
+    }
+    {{- end }}

--- a/helm/charts/nats-account-server/templates/configmap.yaml
+++ b/helm/charts/nats-account-server/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
     # Operator JWT used to validate the accounts.
     operatorjwtpath: "/etc/nats-config/operator/{{ .Values.operator.operatorjwt.configMap.key }}"
 
+    {{- if .Values.nats.url }}
     # System Account JWT
     systemaccountjwtpath: "/etc/nats-config/sys/{{ .Values.operator.systemaccountjwt.configMap.key }}"
 
@@ -25,6 +26,7 @@ data:
       servers: [{{ .Values.nats.url }}]
       usercredentials: "/etc/nats-config/syscreds/{{ .Values.nats.credentials.secret.key }}"
     }
+    {{- end }}
 
     {{- if eq .Values.store.type "file"}}
     store {

--- a/helm/charts/nats-account-server/templates/service.yaml
+++ b/helm/charts/nats-account-server/templates/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "name" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    app: {{ template "name" . }}
+  clusterIP: None
+  ports:
+  - name: server
+    port: 9090

--- a/helm/charts/nats-account-server/templates/statefulset.yaml
+++ b/helm/charts/nats-account-server/templates/statefulset.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "name" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+  replicas: 1
+  serviceName: {{ template "name" . }}
+  {{- if eq .Values.store.type "file"}}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "name" . }}-pvc
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.store.file.storageSize }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    spec:
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ template "name" . }}-config
+      - name: nats-sys-creds
+        secret:
+          secretName: {{ .Values.nats.credentials.secret.name }}
+      - name: system-account-jwt-volume
+        configMap:
+          name: {{ .Values.operator.systemaccountjwt.configMap.name }}
+      - name: operator-jwt-volume
+        configMap:
+          name: {{ .Values.operator.operatorjwt.configMap.name }}
+
+      ########################
+      #                      #
+      #  NATS Account Server #
+      #                      #
+      ########################
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: nats-account-server
+        image: {{ .Values.accountserver.image }}
+        imagePullPolicy: {{ .Values.accountserver.pullPolicy }}
+        ports:
+        - containerPort: 9090
+          # hostPort: 9090
+          name: server
+        command:
+         - "nats-account-server"
+         - "-c"
+         - "/etc/nats-config/conf/accountserver.conf"
+
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/nats-config/conf
+          - name: system-account-jwt-volume
+            mountPath: /etc/nats-config/sys
+          - name: operator-jwt-volume
+            mountPath: /etc/nats-config/operator
+          - name: nats-sys-creds
+            mountPath: /etc/nats-config/syscreds
+          {{- if eq .Values.store.type "file"}}
+          - name: {{ template "name" . }}-pvc
+            mountPath: /store
+          {{- end }}
+
+        # Liveness/Readiness probes against the monitoring.
+        #
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 10
+          timeoutSeconds: 5

--- a/helm/charts/nats-account-server/values.yaml
+++ b/helm/charts/nats-account-server/values.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020 The NATS Authors
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+accountserver:
+  image: "synadia/nats-account-server:0.8.4"
+  pullPolicy: IfNotPresent
+
+store:
+  type: file
+  file:
+    storageSize: 1Gi
+  
+# NATS Server connection settings.
+nats:
+  # NATS Service to which we can connect.
+  url: "nats://nats:4222"
+
+  # Credentials to connect to the NATS Server.
+  credentials:
+    secret:
+      name: nats-sys-creds
+      key: sys.creds
+
+# Trusted Operator mode settings.
+operator:
+  # Reference to the system account jwt.
+  systemaccountjwt:
+    configMap:
+      name: nats-sys-jwt
+      key: SYS.jwt
+
+  # Reference to the operator jwt.
+  operatorjwt:
+    configMap:
+      name: operator-jwt
+      key: KO.jwt

--- a/helm/charts/nats-account-server/values.yaml
+++ b/helm/charts/nats-account-server/values.yaml
@@ -22,26 +22,26 @@ store:
     storageSize: 1Gi
   
 # NATS Server connection settings.
-nats:
-  # NATS Service to which we can connect.
-  url: "nats://nats:4222"
-
-  # Credentials to connect to the NATS Server.
-  credentials:
-    secret:
-      name: nats-sys-creds
-      key: sys.creds
+# nats:
+#   # # NATS Service to which we can connect.
+#   # url: "nats://nats:4222"
+#   # 
+#   # # Credentials to connect to the NATS Server.
+#   # credentials:
+#   #   secret:
+#   #     name: nats-sys-creds
+#   #     key: sys.creds
 
 # Trusted Operator mode settings.
-operator:
-  # Reference to the system account jwt.
-  systemaccountjwt:
-    configMap:
-      name: nats-sys-jwt
-      key: SYS.jwt
-
-  # Reference to the operator jwt.
-  operatorjwt:
-    configMap:
-      name: operator-jwt
-      key: KO.jwt
+# operator:
+#   # # Reference to the system account jwt.
+#   # systemaccountjwt:
+#   #   configMap:
+#   #     name: nats-sys-jwt
+#   #     key: SYS.jwt
+#   # 
+#   # # Reference to the Operator JWT.
+#   # operatorjwt:
+#   #   configMap:
+#   #     name: operator-jwt
+#   #     key: KO.jwt

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -174,7 +174,9 @@ data:
     {{- end }}
 
     {{- if eq .Values.auth.resolver.type "URL" }}
-    resolver: URL({{ .Values.auth.resolver.url }})
+    {{- with .Values.auth.resolver.url }}
+    resolver: URL({{ . }})
+    {{- end }}
     operator: /etc/nats-config/operator/{{ .Values.auth.operatorjwt.configMap.key }}
     system_account: {{ .Values.auth.systemAccount }}
     {{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -118,4 +118,11 @@ data:
     resolver: MEMORY
     include "accounts/{{ .Values.auth.resolver.configMap.key }}"
     {{- end }}
+
+    {{- if eq .Values.auth.resolver.type "URL" }}
+    resolver: URL({{ .Values.auth.resolver.url }})
+    operator: {{ .Values.auth.operator }}
+    system_account: {{ .Values.auth.systemAccount }}
+    {{- end }}
+
     {{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -121,7 +121,7 @@ data:
 
     {{- if eq .Values.auth.resolver.type "URL" }}
     resolver: URL({{ .Values.auth.resolver.url }})
-    operator: {{ .Values.auth.operator }}
+    operator: /etc/nats-config/operator/{{ .Values.auth.operatorjwt.configMap.key }}
     system_account: {{ .Values.auth.systemAccount }}
     {{- end }}
 

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -41,12 +41,66 @@ data:
     include "advertise/client_advertise.conf"
     {{- end }}
 
+    ################# 
+    #               #
+    # NATS Leafnode #
+    #               #
+    #################
     {{- if .Values.leafnodes.enabled }}
     leafnodes {
       listen: "0.0.0.0:7422"
       {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
       {{ end }}
+      
+      remotes: [
+      {{- range .Values.leafnodes.remotes }}
+      {
+        {{- with .url }}
+        url: {{ . }}
+        {{- end }}
+
+        {{- with .credentials }}
+        credentials: "/etc/nats-creds/{{ .secret.name }}/{{ .secret.key }}"
+        {{- end }}
+      }
+      {{- end }}
+      ]
+    }
+    {{ end }}
+
+    ################# 
+    #               #
+    # NATS Gateways #
+    #               #
+    #################
+    {{- if .Values.gateway.enabled }}
+    gateway {
+      name: {{ .Values.gateway.name }}
+      port: 7522
+
+      {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
+      include "advertise/gateway_advertise.conf"
+      {{ end }}
+
+      # Gateways array here
+      gateways: [
+        {{- range .Values.gateway.gateways }}
+        {
+          {{- with .name }}
+          name: {{ . }}
+          {{- end }}
+
+          {{- with .url }}
+          url: {{ . | quote }}
+          {{- end }}
+
+          {{- with .urls }}
+          urls: {{ . | quote }}
+          {{- end }}
+        },
+        {{- end }}
+      ]
     }
     {{ end }}
 

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -8,6 +8,13 @@ metadata:
     app: {{ .Release.Name }}-box
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  volumes:
+  {{- if .Values.natsbox.credentials }}
+  - name: nats-sys-creds
+    secret:
+      secretName: {{ .Values.natsbox.credentials.secret.name }}
+  {{- end }}
+
   containers:
   - name: nats-box
     image: {{ .Values.natsbox.image }}
@@ -15,8 +22,17 @@ spec:
     env:
     - name: NATS_URL
       value: {{ .Release.Name }}
+    {{- if .Values.natsbox.credentials }}
+    - name: USER_CREDS
+      value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
+    {{- end }}
     command:
      - "tail"
      - "-f"
      - "/dev/null"
+    {{- if .Values.natsbox.credentials }}
+    volumeMounts:
+    - name: nats-sys-creds
+      mountPath: /etc/nats-config/creds
+    {{- end }}
 {{- end }}

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -25,6 +25,8 @@ spec:
     {{- if .Values.natsbox.credentials }}
     - name: USER_CREDS
       value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
+    - name: USER2_CREDS
+      value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
     {{- end }}
     command:
      - "tail"

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -43,6 +43,12 @@ spec:
         configMap:
           name: {{ .Values.auth.resolver.configMap.name }}
       {{- end }}
+
+      {{- if eq .Values.auth.resolver.type "URL" }}
+      - name: operator-jwt-volume
+        configMap:
+          name: {{ .Values.auth.operatorjwt.configMap.name }}
+      {{- end }}
       {{- end }}
 
       {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
@@ -153,6 +159,11 @@ spec:
           {{- if eq .Values.auth.resolver.type "memory" }}
           - name: resolver-volume
             mountPath: /etc/nats-config/accounts
+          {{- end }}
+
+          {{- if eq .Values.auth.resolver.type "URL" }}
+          - name: operator-jwt-volume
+            mountPath: /etc/nats-config/operator
           {{- end }}
           {{- end }}
 

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -57,6 +57,19 @@ spec:
         emptyDir: {}
       {{ end }}
 
+      {{- if .Values.leafnodes.enabled }}
+      # 
+      # Leafnode credential volumes
+      # 
+      {{- range .Values.leafnodes.remotes }}
+      {{- with .credentials }}
+      - name: {{ .secret.name }}-volume
+        secret:
+          secretName: {{ .secret.name }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+
       {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
       # Assume that we only use the service account in case we want to
       # figure out what is the current external public IP from the server
@@ -164,6 +177,18 @@ spec:
           {{- if eq .Values.auth.resolver.type "URL" }}
           - name: operator-jwt-volume
             mountPath: /etc/nats-config/operator
+          {{- end }}
+
+          {{- if .Values.leafnodes.enabled }}
+          # 
+          # Leafnode credential volumes
+          # 
+          {{- range .Values.leafnodes.remotes }}
+          {{- with .credentials }}
+          - name: {{ .secret.name }}-volume
+            mountPath: /etc/nats-creds/{{ .secret.name }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -76,6 +76,11 @@ natsbox:
   image: synadia/nats-box:0.3.0
   pullPolicy: IfNotPresent
 
+  # credentials:
+  #   secret:
+  #     name: nats-sys-creds
+  #     key: sys.creds
+
 # The NATS config reloader image to use.
 reloader:
   enabled: true
@@ -92,22 +97,34 @@ exporter:
 auth:
   enabled: false
 
-  # Operator JWT
-  operator: 
+  # Reference to the Operator JWT.
+  # operatorjwt:
+  #   configMap:
+  #     name: operator-jwt
+  #     key: KO.jwt
 
   # Public key of the System Account
-  systemAccount: 
+  # systemAccount:
 
-  resolver:
-    type: URL
-
-    # URL resolver settings
-    url: "http://nats-account-server:9090/jwt/v1/accounts/"
-
-    # 
-    # Use a configmap reference which will be mounted
-    # into the container.
-    # 
-    configMap:
-      name: nats-accounts
-      key: resolver.conf
+  # resolver:
+  #   ############################
+  #   #                          #
+  #   # Memory resolver settings #
+  #   #                          #
+  #   ##############################
+  #   # type: memory
+  #   # 
+  #   # Use a configmap reference which will be mounted
+  #   # into the container.
+  #   # 
+  #   # configMap:
+  #   #   name: nats-accounts
+  #   #   key: resolver.conf
+  #  
+  #   ##########################
+  #   #                        #
+  #   #  URL resolver settings #
+  #   #                        #
+  #   ##########################
+  #   # type: URL
+  #   # url: "http://nats-account-server:9090/jwt/v1/accounts/"

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -72,7 +72,7 @@ gateway:
   # List of remote gateways
   # gateways:
   #   - name: other
-  #     url: tls://my-gateway-url:7522
+  #     url: nats://my-gateway-url:7522
   
 # In case of both external access and advertisements being
 # enabled, an initializer container will be used to gather

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -91,8 +91,19 @@ exporter:
 # Authentication setup
 auth:
   enabled: false
+
+  # Operator JWT
+  operator: 
+
+  # Public key of the System Account
+  systemAccount: 
+
   resolver:
-    type: memory
+    type: URL
+
+    # URL resolver settings
+    url: "http://nats-account-server:9090/jwt/v1/accounts/"
+
     # 
     # Use a configmap reference which will be mounted
     # into the container.

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -1,6 +1,10 @@
-# NATS Server Configuration
+###############################
+#                             #
+#  NATS Server Configuration  #
+#                             #
+###############################
 nats:
-  image: nats:2.1.4-alpine3.11
+  image: nats:2.1.6-alpine3.11
   pullPolicy: IfNotPresent
 
   # Toggle whether to enable external access.

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -59,7 +59,21 @@ cluster:
 #
 leafnodes:
   enabled: false
+  # remotes:
+  #   - url: "tls://connect.ngs.global:7422"
 
+# Gateway connections to create a super cluster
+#
+# https://docs.nats.io/nats-server/configuration/gateways
+#
+gateway:
+  enabled: false
+  name: 'default'
+  # List of remote gateways
+  # gateways:
+  #   - name: other
+  #     url: tls://my-gateway-url:7522
+  
 # In case of both external access and advertisements being
 # enabled, an initializer container will be used to gather
 # the public ips.


### PR DESCRIPTION
This adds a Helm chart for the account server and support for the NATS Helm chart to use the same secrets.  Flow to use both charts would like this:

- First, create an NSC setup locally 

```sh
export NKEYS_PATH=$(pwd)/nsc/nkeys
export NSC_HOME=$(pwd)/nsc/accounts
curl -sSL https://nats-io.github.io/k8s/setup/nsc-setup.sh | sh
nsc edit operator --account-jwt-server-url http://nats-account-server:9090/jwt/v1/ --service-url nats://nats:4222
```

- Upload the shared secrets and configmaps

```sh
kubectl create configmap operator-jwt --from-file ./nsc/accounts/nats/KO/KO.jwt
kubectl create configmap nats-sys-jwt --from-file ./nsc/accounts/nats/KO/accounts/SYS/SYS.jwt
kubectl create secret generic nats-sys-creds --from-file ./nsc/nkeys/creds/KO/SYS/sys.creds
```

- Create the Helm deploy yaml for the NATS Server
```sh
echo '
# NATS Server connection settings.
nats:
  # NATS Service to which we can connect.
  url: "nats://nats:4222"

  # Credentials to connect to the NATS Server.
  credentials:
    secret:
      name: nats-sys-creds
      key: sys.creds

# Trusted Operator mode settings.
operator:
  # Reference to the system account jwt.
  systemaccountjwt:
    configMap:
      name: nats-sys-jwt
      key: SYS.jwt

  # Reference to the Operator JWT.
  operatorjwt:
    configMap:
      name: operator-jwt
      key: KO.jwt
' > deploy-account-server.yaml
```

- Create the NATS Account Server with file storage and a persistent volume

```sh
helm install nats-account-server -f deploy-account-server.yaml ./helm/charts/nats-account-server/
```
- Now need to first feed into the NATS Account Server the current set of accounts
  NOTE: This requires to `sudo vi /etc/hosts` to add localhost temporarily so that it resolves 127.0.0.1 as the K8S service domain.

```
# 
# 127.0.0.1 nats-account-server
# 
```

- Open the port for the nats-account-server so that can feed the accounts locally

```sh
kubectl port-forward nats-account-server-0 9090:9090 &
nsc push -A
```

- Get the public key of system account from the NATS server

```sh
nsc list accounts
╭─────────────────────────────────────────────────────────────────╮
│                            Accounts                             │
├──────┬──────────────────────────────────────────────────────────┤
│ Name │ Public Key                                               │
├──────┼──────────────────────────────────────────────────────────┤
│ A    │ ADR5DUK5TCFGAUHQ76QP4V7GXIEBYTQ26STXCRTP4X2BJDMUMSBXWPWS │
│ B    │ ABIDLGSR6YZBDGH3C4FK6WI6MMVR7U7M6MR3RI3GKEUCJD27UFHMOKY5 │
│ STAN │ AAF5E33YN7DIKFQVR3R52XOM5GOM7SIILPITZXW3DFVU743QICIN3Z3J │
│ SYS  │ ADHUAQZ7UEXIVAXNI6B4VUU4IBV2ZUXMQMSIYDFQQ5BFTSMWTKK2NWJN │ < this one
╰──────┴──────────────────────────────────────────────────────────╯
```

```sh
# Helm config for NATS
echo '
# Authentication setup
auth:
  enabled: true

  # Reference to the Operator JWT which will be mounted as a volume,
  # shared with the account server in this case.
  operatorjwt:
    configMap:
      name: operator-jwt
      key: KO.jwt

  # Public key of the System Account
  systemAccount: ADHUAQZ7UEXIVAXNI6B4VUU4IBV2ZUXMQMSIYDFQQ5BFTSMWTKK2NWJN

  resolver:
    type: URL
    url: "http://nats-account-server:9090/jwt/v1/accounts/"

# Add system credentials to the nats-box instance for example
natsbox:
  enabled: true

  credentials:
    secret:
      name: nats-sys-creds
      key: sys.creds
' > deploy-nats.yaml
```

- Now deploy the NATS Server with the URL resolver configuration against the NATS Account Server running in the same cluster

```sh
helm install nats -f deploy-nats.yaml ./helm/charts/nats/
```

- Can use nats-box with the injected system credentials accounts now as well:

```sh
kubectl exec -n default -it nats-box -- /bin/sh -l
nats-sub -creds /etc/nats-config/syscreds/sys.creds '>'
nats-sub '>' # also works since $USER_CREDS env var is set automatically
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>