### PR TITLE
[helm] Adding support for gateways and leafnodes

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -41,12 +41,66 @@ data:
     include "advertise/client_advertise.conf"
     {{- end }}
 
+    ################# 
+    #               #
+    # NATS Leafnode #
+    #               #
+    #################
     {{- if .Values.leafnodes.enabled }}
     leafnodes {
       listen: "0.0.0.0:7422"
       {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
       {{ end }}
+      
+      remotes: [
+      {{- range .Values.leafnodes.remotes }}
+      {
+        {{- with .url }}
+        url: {{ . }}
+        {{- end }}
+
+        {{- with .credentials }}
+        credentials: "/etc/nats-creds/{{ .secret.name }}/{{ .secret.key }}"
+        {{- end }}
+      }
+      {{- end }}
+      ]
+    }
+    {{ end }}
+
+    ################# 
+    #               #
+    # NATS Gateways #
+    #               #
+    #################
+    {{- if .Values.gateway.enabled }}
+    gateway {
+      name: {{ .Values.gateway.name }}
+      port: 7522
+
+      {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
+      include "advertise/gateway_advertise.conf"
+      {{ end }}
+
+      # Gateways array here
+      gateways: [
+        {{- range .Values.gateway.gateways }}
+        {
+          {{- with .name }}
+          name: {{ . }}
+          {{- end }}
+
+          {{- with .url }}
+          url: {{ . | quote }}
+          {{- end }}
+
+          {{- with .urls }}
+          urls: {{ . | quote }}
+          {{- end }}
+        },
+        {{- end }}
+      ]
     }
     {{ end }}
 

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -25,6 +25,8 @@ spec:
     {{- if .Values.natsbox.credentials }}
     - name: USER_CREDS
       value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
+    - name: USER2_CREDS
+      value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
     {{- end }}
     command:
      - "tail"

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -53,6 +53,19 @@ spec:
         emptyDir: {}
       {{ end }}
 
+      {{- if .Values.leafnodes.enabled }}
+      # 
+      # Leafnode credential volumes
+      # 
+      {{- range .Values.leafnodes.remotes }}
+      {{- with .credentials }}
+      - name: {{ .secret.name }}-volume
+        secret:
+          secretName: {{ .secret.name }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+
       {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
       # Assume that we only use the service account in case we want to
       # figure out what is the current external public IP from the server
@@ -160,6 +173,18 @@ spec:
           {{- if eq .Values.auth.resolver.type "URL" }}
           - name: operator-jwt-volume
             mountPath: /etc/nats-config/operator
+          {{- end }}
+
+          {{- if .Values.leafnodes.enabled }}
+          # 
+          # Leafnode credential volumes
+          # 
+          {{- range .Values.leafnodes.remotes }}
+          {{- with .credentials }}
+          - name: {{ .secret.name }}-volume
+            mountPath: /etc/nats-creds/{{ .secret.name }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -53,7 +53,21 @@ cluster:
 #
 leafnodes:
   enabled: false
+  # remotes:
+  #   - url: "tls://connect.ngs.global:7422"
 
+# Gateway connections to create a super cluster
+#
+# https://docs.nats.io/nats-server/configuration/gateways
+#
+gateway:
+  enabled: false
+  name: 'default'
+  # List of remote gateways
+  # gateways:
+  #   - name: other
+  #     url: tls://my-gateway-url:7522
+  
 # In case of both external access and advertisements being
 # enabled, an initializer container will be used to gather
 # the public ips.

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -66,7 +66,7 @@ gateway:
   # List of remote gateways
   # gateways:
   #   - name: other
-  #     url: tls://my-gateway-url:7522
+  #     url: nats://my-gateway-url:7522
   
 # In case of both external access and advertisements being
 # enabled, an initializer container will be used to gather


### PR DESCRIPTION
Makes it possible to setup remote leafnodes and gateways as follows:

```yaml

# Authentication setup
auth:
  enabled: true

  # Reference to the Operator JWT which will be mounted as a volume,
  # shared with the account server in this case.
  operatorjwt:
    configMap:
      name: operator-jwt
      key: KO.jwt

  # Public key of the System Account
  systemAccount: AAITGVORQ4VHOQ32A7XMEKUIDMJ5GSAYSUGOV6GZAVSQWYFAL72DIXLC

  resolver:
    type: URL
    url: "http://nats-account-server:9090/jwt/v1/accounts/"

nats:
  externalAccess: true
  logging:
    debug: true
    trace: true

leafnodes:
  enabled: true
  remotes:
    - url: tls://connect.ngs.global:7422
      credentials:
        secret:
          name: ngs-creds
          key: NGS.creds

gateway:
  enabled: true
  name: aws-useast2
  gateways:
    - name: euwest1
      url: tls://euwest1.aws.ngs.global:7522

# Add system credentials to the nats-box instance for example
natsbox:
  enabled: true

  credentials:
    secret:
      name: nats-sys-creds
      key: sys.creds
```

```
kubectl create secret generic ngs-creds --from-file ./.nkeys/creds/synadia/NGS/NGS.creds
helm install nats -f deploy-nats-gateways.yaml ./helm/charts/nats/
```