### PR TITLE
[helm] Add support for TLS config blocks

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.1.4"
+appVersion: "2.1.6"
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications Technology.
 name: nats
 keywords:

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -19,6 +19,50 @@ data:
     http: 8222
     server_name: $POD_NAME
 
+    {{- if .Values.nats.tls }}
+    #####################
+    #                   #
+    # TLS Configuration #
+    #                   #
+    #####################
+    {{- with .Values.nats.tls }}
+    {{ $secretName := .secret.name }}
+    tls {
+       {{- with .cert }}
+       cert_file: /etc/nats-certs/clients/{{ $secretName }}/{{ . }}
+       {{- end }}
+
+       {{- with .key }}
+       key_file: /etc/nats-certs/clients/{{ $secretName }}/{{ . }}
+       {{- end }}
+
+       {{- with .ca }}
+       ca_file: /etc/nats-certs/clients/{{ $secretName }}/{{ . }}
+       {{- end }}
+
+       {{- with .insecure }}
+       insecure: {{ . }}
+       {{- end }}
+
+       {{- with .verify }}
+       verify: {{ . }}
+       {{- end }}
+
+       {{- with .verifyAndMap }}
+       verify_and_map: {{ . }}
+       {{- end }}
+
+       {{- with .curvePreferences }}
+       curve_preferences: {{ . }}
+       {{- end }}
+
+       {{- with .timeout }}
+       timeout: {{ . }}
+       {{- end }}
+    }
+    {{- end }}
+    {{- end }}
+
     {{ if .Values.cluster.enabled }}
     ###################################
     #                                 #
@@ -27,6 +71,43 @@ data:
     ###################################
     cluster {
       port: 6222
+
+      {{- with .Values.cluster.tls }}
+      {{ $secretName := .secret.name }}
+      tls {
+         {{- with .cert }}
+         cert_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .key }}
+         key_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .ca }}
+         ca_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .insecure }}
+         insecure: {{ . }}
+         {{- end }}
+
+         {{- with .verify }}
+         verify: {{ . }}
+         {{- end }}
+
+         {{- with .verifyAndMap }}
+         verify_and_map: {{ . }}
+         {{- end }}
+
+         {{- with .curvePreferences }}
+         curve_preferences: {{ . }}
+         {{- end }}
+
+         {{- with .timeout }}
+         timeout: {{ . }}
+         {{- end }}
+      }
+      {{- end }}
 
       routes = [
         {{ template "nats.clusterRoutes" . }}
@@ -52,7 +133,44 @@ data:
       {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
       {{ end }}
-      
+
+      {{- with .Values.leafnodes.tls }}
+      {{ $secretName := .secret.name }}
+      tls {
+         {{- with .cert }}
+         cert_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .key }}
+         key_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .ca }}
+         ca_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .insecure }}
+         insecure: {{ . }}
+         {{- end }}
+
+         {{- with .verify }}
+         verify: {{ . }}
+         {{- end }}
+
+         {{- with .verifyAndMap }}
+         verify_and_map: {{ . }}
+         {{- end }}
+
+         {{- with .curvePreferences }}
+         curve_preferences: {{ . }}
+         {{- end }}
+
+         {{- with .timeout }}
+         timeout: {{ . }}
+         {{- end }}
+      }
+      {{- end }}
+
       remotes: [
       {{- range .Values.leafnodes.remotes }}
       {
@@ -82,6 +200,43 @@ data:
       {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
       {{ end }}
+
+      {{- with .Values.gateway.tls }}
+      {{ $secretName := .secret.name }}
+      tls {
+         {{- with .cert }}
+         cert_file: /etc/nats-certs/gateways/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .key }}
+         key_file: /etc/nats-certs/gateways/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .ca }}
+         ca_file: /etc/nats-certs/gateways/{{ $secretName }}/{{ . }}
+         {{- end }}
+
+         {{- with .insecure }}
+         insecure: {{ . }}
+         {{- end }}
+
+         {{- with .verify }}
+         verify: {{ . }}
+         {{- end }}
+
+         {{- with .verifyAndMap }}
+         verify_and_map: {{ . }}
+         {{- end }}
+
+         {{- with .curvePreferences }}
+         curve_preferences: {{ . }}
+         {{- end }}
+
+         {{- with .timeout }}
+         timeout: {{ . }}
+         {{- end }}
+      }
+      {{- end }}
 
       # Gateways array here
       gateways: [

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -14,6 +14,12 @@ spec:
     secret:
       secretName: {{ .Values.natsbox.credentials.secret.name }}
   {{- end }}
+  {{- with .Values.nats.tls }}
+  {{ $secretName := .secret.name }}
+  - name: {{ $secretName }}-clients-volume
+    secret:
+      secretName: {{ $secretName }}
+  {{- end }}
 
   containers:
   - name: nats-box
@@ -28,6 +34,16 @@ spec:
     - name: USER2_CREDS
       value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
     {{- end }}
+    {{- with .Values.nats.tls }}
+    {{ $secretName := .secret.name }}
+    lifecycle:
+      postStart:
+        exec:
+          command:
+          - /bin/sh
+          - -c
+          - cp /etc/nats-certs/clients/{{ $secretName }}/* /usr/local/share/ca-certificates && update-ca-certificates
+    {{- end }}
     command:
      - "tail"
      - "-f"
@@ -36,5 +52,15 @@ spec:
     volumeMounts:
     - name: nats-sys-creds
       mountPath: /etc/nats-config/creds
+    {{- end }}
+    #######################
+    #                     #
+    #  TLS Volumes Mounts #
+    #                     #
+    #######################
+    {{- with .Values.nats.tls }}
+    {{ $secretName := .secret.name }}
+    - name: {{ $secretName }}-clients-volume
+      mountPath: /etc/nats-certs/clients/{{ $secretName }}
     {{- end }}
 {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -53,6 +53,36 @@ spec:
         emptyDir: {}
       {{ end }}
 
+      #################
+      #               #
+      #  TLS Volumes  #
+      #               #
+      #################
+      {{- with .Values.nats.tls }}
+      {{ $secretName := .secret.name }}
+      - name: {{ $secretName }}-clients-volume
+        secret:
+          secretName: {{ $secretName }}
+      {{- end }}
+      {{- with .Values.cluster.tls }}
+      {{ $secretName := .secret.name }}
+      - name: {{ $secretName }}-cluster-volume
+        secret:
+          secretName: {{ $secretName }}
+      {{- end }}
+      {{- with .Values.leafnodes.tls }}
+      {{ $secretName := .secret.name }}
+      - name: {{ $secretName }}-leafnodes-volume
+        secret:
+          secretName: {{ $secretName }}
+      {{- end }}
+      {{- with .Values.gateway.tls }}
+      {{ $secretName := .secret.name }}
+      - name: {{ $secretName }}-gateways-volume
+        secret:
+          secretName: {{ $secretName }}
+      {{- end }}
+
       {{- if .Values.leafnodes.enabled }}
       # 
       # Leafnode credential volumes
@@ -173,6 +203,32 @@ spec:
           {{- if eq .Values.auth.resolver.type "URL" }}
           - name: operator-jwt-volume
             mountPath: /etc/nats-config/operator
+          {{- end }}
+
+          #######################
+          #                     #
+          #  TLS Volumes Mounts #
+          #                     #
+          #######################
+          {{- with .Values.nats.tls }}
+          {{ $secretName := .secret.name }}
+          - name: {{ $secretName }}-clients-volume
+            mountPath: /etc/nats-certs/clients/{{ $secretName }}
+          {{- end }}
+          {{- with .Values.cluster.tls }}
+          {{ $secretName := .secret.name }}
+          - name: {{ $secretName }}-cluster-volume
+            mountPath: /etc/nats-certs/cluster/{{ $secretName }}
+          {{- end }}
+          {{- with .Values.leafnodes.tls }}
+          {{ $secretName := .secret.name }}
+          - name: {{ $secretName }}-leafnodes-volume
+            mountPath: /etc/nats-certs/leafnodes/{{ $secretName }}
+          {{- end }}
+          {{- with .Values.gateway.tls }}
+          {{ $secretName := .secret.name }}
+          - name: {{ $secretName }}-gateways-volume
+            mountPath: /etc/nats-certs/gateways/{{ $secretName }}
           {{- end }}
 
           {{- if .Values.leafnodes.enabled }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -48,6 +48,12 @@ nats:
   #  TLS Configuration  #
   #                     #
   #######################
+  # 
+  #  # You can find more on how to setup and trouble shoot TLS connnections at:
+  # 
+  #  # https://docs.nats.io/nats-server/configuration/securing_nats/tls
+  # 
+
   # tls:
   #   secret:
   #     name: nats-client-tls
@@ -73,6 +79,12 @@ leafnodes:
   #  TLS Configuration  #
   #                     #
   #######################
+  # 
+  #  # You can find more on how to setup and trouble shoot TLS connnections at:
+  # 
+  #  # https://docs.nats.io/nats-server/configuration/securing_nats/tls
+  # 
+
   #
   # tls:
   #   secret:
@@ -103,6 +115,10 @@ gateway:
   #  TLS Configuration  #
   #                     #
   #######################
+  # 
+  #  # You can find more on how to setup and trouble shoot TLS connnections at:
+  # 
+  #  # https://docs.nats.io/nats-server/configuration/securing_nats/tls
   #
   # tls:
   #   secret:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -43,6 +43,18 @@ nats:
     connectErrorReports: 
     reconnectErrorReports: 
 
+  #######################
+  #                     #
+  #  TLS Configuration  #
+  #                     #
+  #######################
+  # tls:
+  #   secret:
+  #     name: nats-client-tls
+  #   ca: "ca.crt"
+  #   cert: "tls.crt"
+  #   key: "tls.key"
+
 # Toggle whether to use setup a NATS Cluster.
 cluster:
   enabled: false
@@ -56,6 +68,19 @@ leafnodes:
   # remotes:
   #   - url: "tls://connect.ngs.global:7422"
 
+  #######################
+  #                     #
+  #  TLS Configuration  #
+  #                     #
+  #######################
+  #
+  # tls:
+  #   secret:
+  #     name: nats-client-tls
+  #   ca: "ca.crt"
+  #   cert: "tls.crt"
+  #   key: "tls.key"
+
 # Gateway connections to create a super cluster
 #
 # https://docs.nats.io/nats-server/configuration/gateways
@@ -63,10 +88,28 @@ leafnodes:
 gateway:
   enabled: false
   name: 'default'
-  # List of remote gateways
+
+  #############################
+  #                           #
+  #  List of remote gateways  #
+  #                           #
+  #############################
   # gateways:
   #   - name: other
   #     url: nats://my-gateway-url:7522
+
+  #######################
+  #                     #
+  #  TLS Configuration  #
+  #                     #
+  #######################
+  #
+  # tls:
+  #   secret:
+  #     name: nats-client-tls
+  #   ca: "ca.crt"
+  #   cert: "tls.crt"
+  #   key: "tls.key"
   
 # In case of both external access and advertisements being
 # enabled, an initializer container will be used to gather


### PR DESCRIPTION
Example:

```sh
helm install nats -f ../deploy-nats-gateways.yaml ./charts/nats
```

where the yaml is:

```yaml
nats:
  externalAccess: true
  logging:
    debug: true
    trace: true
  tls:
    secret:
      name: nats-client-tls
    ca: "ca.crt"
    cert: "tls.crt"
    key: "tls.key"

cluster:
  enabled: true
  tls:
    secret:
      name: nats-server-tls
    ca: "ca.crt"
    cert: "tls.crt"
    key: "tls.key"

leafnodes:
  enabled: true

  tls:
    secret:
      name: nats-server-tls
    ca: "ca.crt"
    cert: "tls.crt"
    key: "tls.key"

  remotes:
    - url: tls://connect.ngs.global:7422
      credentials:
        secret:
          name: ngs-creds
          key: NGS.creds

gateway:
  enabled: true
  name: aws-useast2

  # Shared for all gateways
  tls:
    secret:
      name: nats-server-tls
    ca: "ca.crt"
    cert: "tls.crt"
    key: "tls.key"

# Add system credentials to the nats-box instance for example
natsbox:
  enabled: true

  credentials:
    secret:
      name: nats-sys-creds
      key: sys.creds
```