### PR TITLE
Added the enabled option to the exporter

### DIFF
--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -72,6 +72,7 @@ spec:
           - name: {{ template "stan.name" . }}-pvc
             mountPath: {{ .Values.store.file.path }}
           {{- end }}
+        {{ if .Values.exporter.enabled }}
         - name: metrics
           image: {{ .Values.exporter.image }}
           args:
@@ -85,6 +86,7 @@ spec:
           ports:
           - containerPort: 7777
             name: metrics
+        {{ end }}
   {{- if eq .Values.store.type "file"}}
   volumeClaimTemplates:
   - metadata:

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -97,6 +97,7 @@ store:
 #                                     #
 #######################################
 exporter:
+  enabled: true
   image: synadia/prometheus-nats-exporter:0.6.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The README indicates that there is an enabled attribute on the exporter sidecar for the stan chart.   This PR adds that to the actual chart and sets the default value to `true`