### PR TITLE
Fix clustered file storage example

### DIFF
--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -102,7 +102,7 @@ In case of using file storage, this sets up a 3 node cluster,
 each with its own backed persistence volume.
 
 ```yaml
-stan:
+store:
   cluster:
     enabled: true
     logPath: /data/stan/log


### PR DESCRIPTION
It was referencing stan.cluster.enabled, but the helm chart is configured to use store.cluster.enabled.