### PR TITLE
add integration of stan with nats-operator

### DIFF
--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -17,15 +17,34 @@ Listening on [foo], clientID=[stan-sub], qgroup=[] durable=[]
 
 ## Basic Configuration
 
-### NATS URL
+### Connecting to NATS Server
 
-A NATS Streaming server **requires a connection to a NATS Server**, you
-can set it as follows:
+A NATS Streaming server **requires a connection to a NATS Server**.
+There are few ways to configure connection to NATS:
 
-```
+#### Without credentials
+
+```yaml
 stan:
   nats:
     url: "nats://my-nats:4222"
+```
+
+#### Authenticate using NatsServiceRole
+
+When using NATS Operator you can configure NATS Service Roles to
+generate credentials for your clients in NATS config. 
+https://github.com/nats-io/nats-operator#using-serviceaccounts
+This will create ServiceAccount and NatsServiceRole and enable
+authentication using "bound-token":
+
+```yaml
+stan:
+  nats:
+    url: "my-nats.nats-namespace:4222" # Do not pass here `nats://` prefix
+    serviceRoleAuth:
+      enabled: "true"
+      natsClusterName: my-nats # Name of NATS cluster created by NATS Operator
 ```
 
 ### Server Image
@@ -41,7 +60,7 @@ stan:
 By default the cluster ID will be the same as the release of the
 NATS Streaming cluster, but you can set a custom one as follows:
 
-```console
+```yaml
 stan:
   clusterID: my-cluster-name
 ```
@@ -52,7 +71,7 @@ This means that in order to connect,
 
 *NOTE*: It is recommended to not enable debug/trace logging in production.
 
-```console
+```yaml
 stan:
   logging:
     debug: true

--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -11,8 +11,10 @@ data:
     http: 8222
 
     streaming {
-      {{- with .Values.stan.nats.url }}
-      ns: {{ . }}
+      {{- if .Values.stan.nats.serviceRoleAuth.enabled }}
+      ns: $NATS_URL
+      {{ else }}
+      ns: {{ .Values.stan.nats.url }}
       {{- end }}
 
       {{- if .Values.stan.clusterID }}

--- a/helm/charts/stan/templates/natsservicerole.yaml
+++ b/helm/charts/stan/templates/natsservicerole.yaml
@@ -1,0 +1,18 @@
+---
+{{- if .Values.stan.nats.serviceRoleAuth.enabled }}
+apiVersion: nats.io/v1alpha2
+kind: NatsServiceRole
+metadata:
+  name: nats-streaming
+  labels:
+    nats_cluster: {{ .Values.stan.nats.serviceRoleAuth.natsClusterName }}
+spec:
+  permissions:
+    publish: [">"]
+    subscribe: [">"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-streaming
+{{- end }}

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -26,6 +26,9 @@ spec:
         app: {{ template "stan.name" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
+      {{- if .Values.stan.nats.serviceRoleAuth.enabled }}
+      serviceAccountName: "nats-streaming"
+      {{- end }}
 {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}
@@ -63,6 +66,21 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.stan.nats.serviceRoleAuth.enabled }}
+          - name: NATS_OPERATOR_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: NATS_OPERATOR_BOUND_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: nats-streaming-{{ .Values.stan.nats.serviceRoleAuth.natsClusterName }}-bound-token
+                key: token
+          - name: NATS_SERVICE
+            value: {{ .Values.stan.nats.url }}
+          - name: NATS_URL
+            value: nats://$(NATS_OPERATOR_SERVICE_ACCOUNT):$(NATS_OPERATOR_BOUND_TOKEN)@$(NATS_SERVICE)
+          {{- end }}
           ports:
           - containerPort: 8222
             name: monitor

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -19,6 +19,9 @@ stan:
   # an URL for NATS is required.
   nats:
     url:
+    serviceRoleAuth:
+      enabled: false
+      natsClusterName:
 
 # Toggle whether to use setup a Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
I'm using `NATS Operator` to setup `NATS cluster` inside `k8s`. I'm using `NatsServiceRoles` to give credentials for pods to NATS.
This change adds capability to authenticate `nats-streaming` with `nats-cluster` using `NatsServiceRoles`.
This is useful when you are storing configuration of your infrastructure inside `git` and don't want to compromise credentials.

Initial idea how to integrate `streaming` with `operator` was made by @wallyqs 
Thanks! 