### PR TITLE
helm: stan, volumeClaim configuration

### DIFF
--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -89,9 +89,9 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/stan-config
-          {{- if eq .Values.store.type "file"}}
+          {{- if .Values.store.volume.enabled }}
           - name: {{ template "stan.name" . }}-pvc
-            mountPath: {{ .Values.store.file.path }}
+            mountPath: {{ .Values.store.volume.mount }}
           {{- end }}
         {{ if .Values.exporter.enabled }}
         - name: metrics
@@ -108,14 +108,17 @@ spec:
           - containerPort: 7777
             name: metrics
         {{ end }}
-  {{- if eq .Values.store.type "file"}}
+  {{- if .Values.store.volume.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: {{ template "stan.name" . }}-pvc
     spec:
+      {{- with .Values.store.volume.storageClass }}
+      storageClassName: {{ . }}
+      {{- end }}
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ .Values.store.file.storageSize }}
+          storage: {{ .Values.store.volume.storageSize }}
   {{- end }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -61,12 +61,21 @@ store:
   # 
   limits: {}
 
+  #
+  # Volume claim configuration. Required if the store type is `file` or if
+  # cluster it's enabled.
+  #
+  volume:
+    enabled: true
+    mount: /data/stan
+    storageSize: 100Gi
+    storageClass:
+
   # 
   # File storage settings.
   # 
   file:
     path: /data/stan/store
-    storageSize: 1Gi
 
   # In case of using file or sql storage, sets up a 3 node cluster.
   cluster:


### PR DESCRIPTION
This allows to use the volumeClaimTemplate for the logs and the store. Otherwise, the cluster cannot recover their state, see https://github.com/nats-io/nats-streaming-server/issues/547

https://github.com/nats-io/nats-streaming-server/pull/548/files

Also, the support for choosing the storageClass has been introducing, and the default size has been changed to something more performance since usually small disk have low I/O in cloud platforms.