### PR TITLE
[helm] Add access mode and replicas for FT mode

### DIFF
--- a/helm/charts/stan/Chart.yaml
+++ b/helm/charts/stan/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - replay
   - statefulset
   - cncf
-version: 0.3.10
+version: 0.4.0
 maintainers:
   - name: Waldemar Quevedo
     github: https://github.com/wallyqs

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -47,6 +47,21 @@ stan:
       natsClusterName: my-nats # Name of NATS cluster created by NATS Operator
 ```
 
+### Number of replicas
+
+In case of using fault tolerance mode, you can set the number of replicas
+to be usef in the FT group.
+
+```
+stan:
+  replicas: 2
+
+# Note: in case of using clustering you will always get 3 replicas.
+store:
+  cluster:
+    enabled: true
+```
+
 ### Server Image
 
 ```yaml
@@ -98,6 +113,11 @@ In case of using a shared volume that supports a `readwritemany`,
 you can enable fault tolerance as follows.
 
 ```yaml
+stan:
+  replicas: 2
+  nats:
+    url: "nats://my-nats:4222"
+
 store:
   type: file
 
@@ -105,14 +125,21 @@ store:
   # Fault tolerance group
   # 
   ft:
-    group: 
+    group: foo
 
   # 
   # File storage settings.
   # 
   file:
     path: /data/stan/store
+
+  # volume for EFS
+  volume:
+    mount: /data/stan
     storageSize: 1Gi
+    storageClass: aws-efs
+    accessModes: ReadWriteMany
+
 ```
 
 #### Clustered File Storage

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -50,13 +50,16 @@ stan:
 ### Number of replicas
 
 In case of using fault tolerance mode, you can set the number of replicas
-to be usef in the FT group.
+to be used in the FT group.
 
 ```
 stan:
   replicas: 2
+```
 
-# Note: in case of using clustering you will always get 3 replicas.
+Note: in case of using clustering you will always get exactly 3 replicas.
+
+```
 store:
   cluster:
     enabled: true
@@ -114,7 +117,7 @@ you can enable fault tolerance as follows.
 
 ```yaml
 stan:
-  replicas: 2
+  replicas: 2 # One replica will be active, other one in standby.
   nats:
     url: "nats://my-nats:4222"
 
@@ -125,7 +128,7 @@ store:
   # Fault tolerance group
   # 
   ft:
-    group: foo
+    group: my-group
 
   # 
   # File storage settings.
@@ -136,7 +139,7 @@ store:
   # volume for EFS
   volume:
     mount: /data/stan
-    storageSize: 1Gi
+    storageSize: 100Gi
     storageClass: aws-efs
     accessModes: ReadWriteMany
 

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -112,6 +112,7 @@ spec:
           - containerPort: 7777
             name: metrics
         {{ end }}
+  {{- if eq .Values.store.type "file" }}
   {{- if .Values.store.volume.enabled }}
   volumeClaimTemplates:
   - metadata:
@@ -127,4 +128,5 @@ spec:
       resources:
         requests:
           storage: {{ .Values.store.volume.storageSize }}
+  {{- end }}
   {{- end }}

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -91,9 +91,11 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/stan-config
+          {{- if eq .Values.store.type "file" }}
           {{- if .Values.store.volume.enabled }}
           - name: {{ template "stan.name" . }}-pvc
             mountPath: {{ .Values.store.volume.mount }}
+          {{- end }}
           {{- end }}
         {{ if .Values.exporter.enabled }}
         - name: metrics

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -14,7 +14,9 @@ spec:
   {{- if .Values.store.cluster.enabled }}
   replicas: 3
   {{- else }}
-  replicas: 1
+  {{- with .Values.stan.replicas }}
+  replicas: {{ . }}
+  {{- end }}
   {{- end }}
 
   # NATS Streaming service name
@@ -117,7 +119,9 @@ spec:
       storageClassName: {{ . }}
       {{- end }}
       accessModes:
-      - ReadWriteOnce
+      {{- with .Values.store.volume.accessModes }}
+      - {{ . }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.store.volume.storageSize }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -69,9 +69,9 @@ store:
   volume:
     enabled: true
     mount: /data/stan
-    storageSize: 100Gi
-    storageClass: 
+    storageSize: 1Gi
     accessModes: ReadWriteOnce
+    storageClass: 
 
   # 
   # File storage settings.

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -6,6 +6,7 @@
 stan:
   image: nats-streaming:0.17.0
   pullPolicy: IfNotPresent
+  replicas: 1
 
   # Cluster name, generated into a name from the
   # release name by default.
@@ -63,13 +64,14 @@ store:
 
   #
   # Volume claim configuration. Required if the store type is `file` or if
-  # cluster it's enabled.
+  # cluster is enabled.
   #
   volume:
     enabled: true
     mount: /data/stan
     storageSize: 100Gi
-    storageClass:
+    storageClass: 
+    accessModes: ReadWriteOnce
 
   # 
   # File storage settings.


### PR DESCRIPTION
It should be possible to set in ReadWriteMany mode to support FT groups using volumes.

Example:

```yaml
stan:
  replicas: 2
  nats:
    url: "nats://my-nats:4222"

store:
  type: file

  # 
  # Fault tolerance group
  # 
  ft:
    group: foo

  # 
  # File storage settings.
  # 
  file:
    path: /data/stan/store

  # volume for EFS
  volume:
    mount: /data/stan
    storageSize: 1Gi
    storageClass: aws-efs
    accessModes: ReadWriteMany
```
Signed-off-by: Waldemar Quevedo <wally@synadia.com>