### PR TITLE
Fix location of server binary in preStop command

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -276,7 +276,7 @@ spec:
               # the same amount as the terminationGracePeriodSeconds to allow
               # the NATS Server to gracefully terminate the client connections.
               #
-              command: ["/bin/sh", "-c", "/nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"]
+              command: ["/bin/sh", "-c", "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"]
 
       #################################
       #                               #


### PR DESCRIPTION
Server was not entering lame duck mode when the pod was terminated because the path to the nats-server binary was incorrect.

CC: @wallyqs 