### PR TITLE
Allow override name of resources

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.4.0
+version: 0.4.1
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "nats.name" -}}
-{{- default .Release.Name -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -65,6 +65,8 @@ nats:
   #   cert: "tls.crt"
   #   key: "tls.key"
 
+nameOverride: ""
+
 # Toggle whether to use setup a Pod Security Context
 # ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: null

--- a/helm/charts/stan/Chart.yaml
+++ b/helm/charts/stan/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - replay
   - statefulset
   - cncf
-version: 0.4.0
+version: 0.4.1
 maintainers:
   - name: Waldemar Quevedo
     github: https://github.com/wallyqs

--- a/helm/charts/stan/templates/_helpers.tpl
+++ b/helm/charts/stan/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "stan.name" -}}
-{{- default .Release.Name -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -24,6 +24,8 @@ stan:
       enabled: false
       natsClusterName:
 
+nameOverride: ""
+
 # Toggle whether to use setup a Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: null


### PR DESCRIPTION
Hi, I was trying to use helm charts as requirement for my chart like this:

```
dependencies:
  - name: nats
    repository: https://nats-io.github.io/k8s/helm/charts/
    version: 0.4.0
  - name: stan
    repository: https://nats-io.github.io/k8s/helm/charts/
    version: 0.4.0
```
However because `.Release.Name` is used as a name for all resources it fails with "resource already exists" error because both nats and stan chart is trying to create resource `MY-RELEASE-config` and the rest.

This change doesn't break anything and allows to override name of each chart with values.yaml. It is widely used approach.