### PR TITLE
Support imagePullSecrets

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ template "nats.name" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
 {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -66,6 +66,7 @@ nats:
   #   key: "tls.key"
 
 nameOverride: ""
+imagePullSecrets: []
 
 # Toggle whether to use setup a Pod Security Context
 # ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -31,6 +31,10 @@ spec:
       {{- if .Values.stan.nats.serviceRoleAuth.enabled }}
       serviceAccountName: "nats-streaming"
       {{- end }}
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
 {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -25,6 +25,7 @@ stan:
       natsClusterName:
 
 nameOverride: ""
+imagePullSecrets: []
 
 # Toggle whether to use setup a Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION

this small change allows to deploy nats/stan on environments using a private registry
(and without the permission to change the service account to have default docker credentails)



having this in the helm value file:
```
imagePullSecrets:
  - name: myRegistry
```

adds this in the stateful set:

```yaml
    spec:
      imagePullSecrets:
        - name: myRegistry
```

would be great to consider this pull request - or bringing up another approach

cheers,
adrian