### PR TITLE
Added support for podAnnotations and cluster replicas

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -80,6 +80,7 @@ https://docs.nats.io/nats-server/configuration/clustering#nats-server-clustering
 ```yaml
 cluster:
   enabled: false
+  replicas: 3
 
   tls:
     secret:
@@ -363,3 +364,14 @@ affinity:
                 - nats
                 - stan
         topologyKey: "kubernetes.io/hostname"
+```
+
+#### Annotations
+
+<https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations>
+
+```yaml
+podAnnotations:
+  key1 : "value1",
+  key2 : "value2"
+```

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -11,13 +11,19 @@ spec:
     matchLabels:
       app: {{ template "nats.name" . }}
   {{- if .Values.cluster.enabled }}
-  replicas: 3
+  replicas: {{ .Values.cluster.replicas }}
   {{- else }}
   replicas: 1
   {{- end }}
   serviceName: {{ template "nats.name" . }}
   template:
     metadata:
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app: {{ template "nats.name" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -80,8 +80,14 @@ securityContext: null
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+# Annotations to add to the NATS pods
+# ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# key: "value"
+
 cluster:
   enabled: false
+  replicas: 3
 
 # Leafnode connections to extend a cluster:
 #


### PR DESCRIPTION
This change introduces 2 new values.

We can now set the number of replicas we want by editing `cluster.replicas`:
```yaml
cluster:
  enabled: false
  replicas: 3
```

We can also set an annotation per pod. This is quite useful for my use-case (we scrape metrics with Datadog). Also, this annotation is already present in [nats-operator helm chart](https://github.com/nats-io/nats-operator/tree/master/helm/nats-operator).

```yaml
podAnnotations: {}
# key: "value"
```

This change does not break anything.