### PR TITLE
Improve Helm Chart for NATS Streaming

### DIFF
--- a/helm/charts/stan/templates/_helpers.tpl
+++ b/helm/charts/stan/templates/_helpers.tpl
@@ -9,7 +9,15 @@ Expand the name of the chart.
 Return the list of peers in a NATS Streaming cluster.
 */}}
 {{- define "stan.clusterPeers" -}}
-{{- range $i, $e := until 3 -}}
-{{- printf "'%s-%d'," $.Release.Name $i -}}
+{{- range $i, $e := until (int $.Values.stan.replicas) -}}
+{{- printf "'%s-%d'," (include "stan.name" $) $i -}}
 {{- end -}}
 {{- end }}
+
+{{- define "stan.replicaCount" -}}
+{{- $replicas := (int $.Values.stan.replicas) -}}
+{{- if and $.Values.store.cluster.enabled (lt $replicas 3) -}}
+{{- $replicas = "" -}}
+{{- end -}}
+{{ print $replicas }}
+{{- end -}}

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -11,24 +11,23 @@ spec:
     matchLabels:
       app: {{ template "stan.name" . }}
 
-  {{- if .Values.store.cluster.enabled }}
-  replicas: 3
-  {{- else }}
-  {{- with .Values.stan.replicas }}
-  replicas: {{ . }}
-  {{- end }}
-  {{- end }}
+  replicas: {{ include "stan.replicaCount" .  | required ".Values.stan.replicas should be greater or equal to 3 in clustered mode" }}
 
   # NATS Streaming service name
   serviceName: {{ template "stan.name" . }}
 
   template:
     metadata:
-      {{- if .Values.exporter.enabled }}
+      {{- if or .Values.podAnnotations .Values.exporter.enabled }}
       annotations:
+      {{- if .Values.exporter.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
         prometheus.io/scrape: "true"
+      {{- end }}
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       {{- end }}
       labels:
         app: {{ template "stan.name" . }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -4,7 +4,7 @@
 #                                #
 ##################################
 stan:
-  image: nats-streaming:0.17.0
+  image: nats-streaming:0.18.0
   pullPolicy: IfNotPresent
   replicas: 1
 
@@ -26,6 +26,8 @@ stan:
 
 nameOverride: ""
 imagePullSecrets: []
+
+podAnnotations: {}
 
 # Toggle whether to use setup a Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -120,7 +122,7 @@ store:
 #######################################
 exporter:
   enabled: true
-  image: synadia/prometheus-nats-exporter:0.6.0
+  image: synadia/prometheus-nats-exporter:0.6.2
   pullPolicy: IfNotPresent
 
 ##################################


### PR DESCRIPTION
Hi,

Thanks a lot for providing charts for both NATS and NATS Streaming ! When using them I noticed some areas of improvement. Please let me know if something looks wrong to you, or you don't think those changes are relevant at all.

**Version upgrade**

* Bump up the version of NATS Streaming to 0.18.0
* Bump up the patch version of the metrics exporter 0.6.2

**Pod annotations**

As recently merged into the NATS chart in https://github.com/nats-io/k8s/pull/72, add the ability to annotate pods. In my case very useful for Istio.

**Clustering**

Nowadays there is no opportunity to deploy a StatefulSet of more than 3 nodes. I don't think there is a reason for that but please let me know if I'm wrong. This PR allows to explicitely define the cluster size, with a validation error if less than 3.

**Bug fix**

When templating `stan.clusterPeers`, `.Release.Name` is being used. However when defining `nameOverride`, `stan.clusterPeers` should make use of it as well. Using `stan.name` instead of `.Release.Name` handles both the cases.

Thanks in advance for reading