### PR TITLE
Enable clustering in snippet in nats helm chart readme

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -79,7 +79,7 @@ https://docs.nats.io/nats-server/configuration/clustering#nats-server-clustering
 
 ```yaml
 cluster:
-  enabled: false
+  enabled: true
   replicas: 3
 
   tls:


### PR DESCRIPTION
In the clustering section of the nats helm chart readme, the clustering option is actually disabled in the values snippet. It seems to me that the enabled value should be set to true.