### PR TITLE
Add option to use persistent volume claim for STAN pods

### DIFF
--- a/helm/charts/stan/Chart.yaml
+++ b/helm/charts/stan/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - replay
   - statefulset
   - cncf
-version: 0.5.0
+version: 0.5.2
 maintainers:
   - name: Waldemar Quevedo
     github: https://github.com/wallyqs

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -199,6 +199,24 @@ store:
       claimName: stan-efs
 ```
 
+Where the persistent volume claim is something like the following for example (using `ReadWriteMany`):
+
+```yaml
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: stan-efs
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "aws-efs"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+```
+
 #### Clustered File Storage
 
 In case of using file storage, this sets up a 3 node cluster,

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -211,6 +211,35 @@ store:
     logPath: /data/stan/log
 ```
 
+Example that will use a volume claim for each pod:
+
+```yaml
+stan:
+  image: nats-streaming:alpine
+  replicas: 3 # At least 3 required.
+  nats:
+    url: "nats://nats:4222"
+
+store:
+  type: file
+
+  cluster:
+    enabled: true
+
+  #
+  # File storage settings.
+  #
+  file:
+    path: /data/stan/store
+
+  # Volume for each pod.
+  volume:
+    enabled: true
+
+    # Mount path for the volume.
+    mount: /data/stan
+```
+
 ### SQL Storage
 
 ```yaml

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -114,8 +114,15 @@ store:
 
 ```yaml
 stan:
-  image: nats-streaming:0.17.0
+  image: nats-streaming:0.18.0
   pullPolicy: IfNotPresent
+```
+
+For the alpine image:
+
+```
+stan:
+  image: nats-streaming:alpine
 ```
 
 ### Custom Cluster ID
@@ -156,13 +163,14 @@ store:
 #### Fault Tolerance mode
 
 In case of using a shared volume that supports a `readwritemany`,
-you can enable fault tolerance as follows.
+you can enable fault tolerance as follows.  More info on how to 
+set this up can be found [here]()
 
 ```yaml
 stan:
   replicas: 2 # One replica will be active, other one in standby.
   nats:
-    url: "nats://my-nats:4222"
+    url: "nats://nats:4222"
 
 store:
   type: file
@@ -179,13 +187,16 @@ store:
   file:
     path: /data/stan/store
 
-  # volume for EFS
+  # Volume for EFS
   volume:
-    mount: /data/stan
-    storageSize: 100Gi
-    storageClass: aws-efs
-    accessModes: ReadWriteMany
+    enabled: true
 
+    # Mount path for the volume.
+    mount: /data/stan
+
+    # FT mode requires a single shared ReadWriteMany PVC volume.
+    persistentVolumeClaim:
+      claimName: stan-efs
 ```
 
 #### Clustered File Storage

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -164,7 +164,7 @@ store:
 
 In case of using a shared volume that supports a `readwritemany`,
 you can enable fault tolerance as follows.  More info on how to 
-set this up can be found [here]()
+set this up can be found [here](https://docs.nats.io/nats-on-kubernetes/stan-ft-k8s-aws)
 
 ```yaml
 stan:

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -141,7 +141,7 @@ spec:
         {{ end }}
   {{- if eq .Values.store.type "file" }}
   {{- if .Values.store.volume.enabled }}
-  {{- if not .Values.store.volume.persistentVolumeClaim -}}
+  {{- if not .Values.store.volume.persistentVolumeClaim }}
   volumeClaimTemplates:
   - metadata:
       name: {{ template "stan.name" . }}-pvc

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -54,6 +54,15 @@ spec:
         secret:
           secretName: {{ .Values.stan.tls.secretName }}
       {{- end }}
+
+      {{- if .Values.store.volume.enabled }}
+      {{- if .Values.store.volume.persistentVolumeClaim }}
+      - name: {{ template "stan.name" . }}-pvc
+        persistentVolumeClaim:
+          claimName: {{ .Values.store.volume.persistentVolumeClaim.claimName }}
+      {{- end }}
+      {{- end }}
+
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -132,6 +141,7 @@ spec:
         {{ end }}
   {{- if eq .Values.store.type "file" }}
   {{- if .Values.store.volume.enabled }}
+  {{- if not .Values.store.volume.persistentVolumeClaim -}}
   volumeClaimTemplates:
   - metadata:
       name: {{ template "stan.name" . }}-pvc
@@ -146,5 +156,6 @@ spec:
       resources:
         requests:
           storage: {{ .Values.store.volume.storageSize }}
+  {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Using a single persistent volume claim would be the right way to setup the FT mode when using a readwritemany volume, so this makes it possible setting it up that way.

```yaml
stan:
  image: nats-streaming:alpine
  replicas: 2 # One replica will be active, other one in standby.
  nats:
    url: "nats://nats:4222"

store:
  type: file

  # 
  # Fault tolerance group
  # 
  ft:
    group: my-group

  # 
  # File storage settings.
  # 
  file:
    path: /data/stan/store

  # volume for EFS
  volume:
    enabled: true

    # Mount path for the volume.
    mount: /data/stan

    # FT mode requires a single shared ReadWriteMany PVC volume.
    persistentVolumeClaim:
      claimName: stan-efs
```