### PR TITLE
Upgrade/nats k8s 2.1.7

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -15,7 +15,7 @@ helm install my-nats nats/nats
 
 ```yaml
 nats:
-  image: nats:2.1.6-alpine3.11
+  image: nats:2.1.7-alpine3.11
   pullPolicy: IfNotPresent
 ```
 

--- a/nats-server/nats-server-plain.yml
+++ b/nats-server/nats-server-plain.yml
@@ -86,7 +86,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.2-alpine3.10
+        image: nats:2.1.7-alpine3.11
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/nats-server-with-auth-and-tls.yml
+++ b/nats-server/nats-server-with-auth-and-tls.yml
@@ -160,7 +160,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.2-alpine3.10
+        image: nats:2.1.7-alpine3.11
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/nats-server-with-auth.yml
+++ b/nats-server/nats-server-with-auth.yml
@@ -133,7 +133,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.0-alpine3.10
+        image: nats:2.1.7-alpine3.11
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/nats-server-without-auth.yml
+++ b/nats-server/nats-server-without-auth.yml
@@ -133,7 +133,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.0-alpine3.10
+        image: nats:2.1.7-alpine3.11
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/single-server-nats.yml
+++ b/nats-server/single-server-nats.yml
@@ -69,7 +69,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.0-alpine3.10
+        image: nats:2.1.7-alpine3.11
         ports:
         - containerPort: 4222
           name: client


### PR DESCRIPTION
- Upgrade from version nats:2.1.2-alpine3.10 to nats:2.1.7-alpine3.11 all nats-server kubernetes spec
- Update HELM charts README with the latest version