### PR TITLE
helm: ReadinessProbe for clustering mode

### DIFF
--- a/helm/charts/stan/Chart.yaml
+++ b/helm/charts/stan/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - replay
   - statefulset
   - cncf
-version: 0.5.2
+version: 0.5.3
 maintainers:
   - name: Waldemar Quevedo
     github: https://github.com/wallyqs

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -305,6 +305,41 @@ podAnnotations:
   iam.amazonaws.com/role: "stan-backups"
 ```
 
+#### Readiness Probe for clustering
+
+In case of using an nats-streaming alpine image, the `clusterReadinessProbe` can be enabled to try to ensure that during server upgrades the pods in the statefulsets in the pod are restarted one by one until there is consensus in the quorum.
+
+```yaml
+clusterReadinessProbe:
+  enabled: true
+  # probe: <-- can add custom readinessProbe parameters here.
+
+stan:
+  image: nats-streaming:alpine
+  replicas: 3
+  nats:
+    url: "nats://my-nats:4222"
+
+store:
+  type: file
+
+  cluster:
+    enabled: true
+
+  #
+  # File storage settings.
+  #
+  file:
+    path: /data/stan/store
+
+  # Volume for each pod.
+  volume:
+    enabled: true
+
+    # Mount path for the volume.
+    mount: /data/stan
+```
+
 ### SQL Storage
 
 ```yaml

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -103,6 +103,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: STAN_SERVICE_NAME
+            value: {{ template "stan.name" . }}
+          - name: STAN_REPLICAS
+            value: "{{ .Values.stan.replicas }}"
           {{- if .Values.stan.nats.serviceRoleAuth.enabled }}
           - name: NATS_OPERATOR_SERVICE_ACCOUNT
             valueFrom:
@@ -127,10 +131,19 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+
+          {{- if and .Values.store.cluster.enabled .Values.clusterReadinessProbe.enabled }}
+          {{- with .Values.clusterReadinessProbe.probe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- end }}
+
           volumeMounts:
           - name: config-volume
             mountPath: /etc/stan-config

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -81,8 +81,8 @@ clusterReadinessProbe:
   enabled: false
   probe:
     exec:
-      command: ["/bin/sh", "-c", "n=$(($STAN_REPLICAS-1)); for i in `seq 0 $n`; do wget -qO-  $STAN_SERVICE_NAME-$i.$STAN_SERVICE_NAME:8222/streaming/serverz 2> /dev/null > /dev/null; done; if [[ $? -ne 0 ]]; then exit 0; fi; wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Follower\\|Leader\\)'"]
-    initialDelaySeconds: 10
+      command: ["/bin/sh", "-c", "n=$(($STAN_REPLICAS-1)); for i in `seq 0 $n`; do wget -qO- $STAN_SERVICE_NAME-$i.$STAN_SERVICE_NAME:8222/streaming/serverz 2> /dev/null > /dev/null; done; if [[ $? -ne 0 ]]; then wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Candidate\\|Follower\\|Leader\\)'; else wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Follower\\|Leader\\)'; fi;"]
+    initialDelaySeconds: 
     periodSeconds: 10
 
 ###########################

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -73,6 +73,18 @@ readinessProbe:
     port: monitor
   timeoutSeconds: 2
 
+# Readiness probe to determine when nats-streaming cluster is ready.
+# Overrides the readinessProbe in case present.
+# NOTE: Only works with the nats-streaming alpine image.
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+clusterReadinessProbe:
+  enabled: false
+  probe:
+    exec:
+      command: ["/bin/sh", "-c", "n=$(($STAN_REPLICAS-1)); for i in `seq 0 $n`; do wget -qO-  $STAN_SERVICE_NAME-$i.$STAN_SERVICE_NAME:8222/streaming/serverz 2> /dev/null > /dev/null; done; if [[ $? -ne 0 ]]; then exit 0; fi; wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Follower\\|Leader\\)'"]
+    initialDelaySeconds: 10
+    periodSeconds: 10
+
 ###########################
 #                         #
 #  Storage configuration  #


### PR DESCRIPTION
This adds another readinessprobe option which can be used to wait until there is quorum each time that a pod is restarted during upgrades.  This requires using the `nats-streaming:alpine` image so currently not enabled by default and have to opt-in with `clusterReadinessProbe.enabled=true`, but this may change in the future.

/cc @drpebcak @kozlovic 

Example:

```yaml
clusterReadinessProbe:
  enabled: true

stan:
  image: nats-streaming:alpine
  replicas: 3
  nats:
    url: "nats://my-nats:4222"

store:
  type: file

  cluster:
    enabled: true

  #
  # File storage settings.
  #
  file:
    path: /data/stan/store

  # Volume for each pod.
  volume:
    enabled: true

    # Mount path for the volume.
    mount: /data/stan
```
