### PR TITLE
Add jetstream single node example

### DIFF
--- a/nats-server/nats-js-leaf.yaml
+++ b/nats-server/nats-js-leaf.yaml
@@ -2,37 +2,37 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nats-config
+  name: nats-js-config
 data:
   nats.conf: |
     pid_file: "/var/run/nats/nats.pid"
     http: 8222
+    
+    debug: true
+    trace: true
 
-    cluster {
-      port: 6222
-      routes [
-        nats://nats-0.nats.default.svc:6222
-        nats://nats-1.nats.default.svc:6222
-        nats://nats-2.nats.default.svc:6222
-      ]
-
-      cluster_advertise: $CLUSTER_ADVERTISE
-      connect_retries: 30
+    jetstream {
+      store_dir: "/data/jetstream/store"
+      max_file_store: 1G
     }
 
     leafnodes {
-      port: 7422
+      remotes [
+        {
+          url: "nats://nats:7422"
+        }
+      ]
     }
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: nats
+  name: nats-js
   labels:
-    app: nats
+    app: nats-js
 spec:
   selector:
-    app: nats
+    app: nats-js
   clusterIP: None
   ports:
   - name: client
@@ -51,25 +51,35 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: nats
+  name: nats-js
   labels:
-    app: nats
+    app: nats-js
 spec:
   selector:
     matchLabels:
-      app: nats
-  replicas: 3
-  serviceName: "nats"
+      app: nats-js
+  replicas: 1
+  serviceName: "nats-js"
+  volumeClaimTemplates:
+  - metadata:
+      name: nats-js-sts-vol
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      volumeMode: "Filesystem"
+      resources:
+        requests:
+          storage: 1Gi
   template:
     metadata:
       labels:
-        app: nats
+        app: nats-js
     spec:
       # Common volumes for the containers
       volumes:
       - name: config-volume
         configMap:
-          name: nats-config
+          name: nats-js-config
       - name: pid
         emptyDir: {}
 
@@ -85,14 +95,12 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.7-alpine3.11
+        image: synadia/nats-server:nightly
         ports:
         - containerPort: 4222
           name: client
-          hostPort: 4222
         - containerPort: 7422
           name: leafnodes
-          hostPort: 7422
         - containerPort: 6222
           name: cluster
         - containerPort: 8222
@@ -117,12 +125,14 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CLUSTER_ADVERTISE
-          value: $(POD_NAME).nats.$(POD_NAMESPACE).svc
+          value: $(POD_NAME).nats-js.$(POD_NAMESPACE).svc
         volumeMounts:
           - name: config-volume
             mountPath: /etc/nats-config
           - name: pid
             mountPath: /var/run/nats
+          - name: nats-js-sts-vol
+            mountPath: /data/jetstream
 
         # Liveness/Readiness probes against the monitoring
         #


### PR DESCRIPTION
Adds a couple of examples for a simple quickstart of JetStream using the nightly images:

```sh
kubectl apply -f nats-server/simple-nats.yml 
kubectl apply -f nats-server/nats-js-leaf.yaml

kubectl port-forward nats-0 4222:4222
nats str add ORDERS --subjects "ORDERS.*" --ack --max-msgs=-1 --max-bytes=-1 --max-age=1y --storage file --retention limits --max-msg-size=-1 --discard=old
nats con add ORDERS NEW --filter ORDERS.received --ack explicit --pull --deliver all --max-deliver=-1 --sample 100
nats con add ORDERS DISPATCH --filter ORDERS.processed --ack explicit --pull --deliver all --max-deliver=-1 --sample 100
nats con add ORDERS MONITOR --filter '' --ack none --target monitor.ORDERS --deliver last --replay instant
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>