### PR TITLE
Support for no_advertise in client/leaf connections

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -127,6 +127,8 @@ leafnodes:
 
 ## Setting up External Access
 
+### Using HostPorts
+
 In case of both external access and advertisements being enabled, an
 initializer container will be used to gather the public ips.  This
 container will required to have enough RBAC policy to be able to make a
@@ -191,6 +193,54 @@ The container image of the initializer can be customized via:
 bootconfig:
   image: connecteverything/nats-boot-config:0.5.2
   pullPolicy: IfNotPresent
+```
+
+### Using LoadBalancers
+
+In case of using a load balancer for external access, it is recommended to disable no advertise 
+so that internal ips from the NATS Servers are not advertised to the clients connecting through
+the load balancer.
+
+```yaml
+nats:
+  image: nats:alpine
+
+cluster:
+  enabled: true
+  noAdvertise: true
+
+leafnodes:
+  enabled: true
+  noAdvertise: true
+
+natsbox:
+  enabled: true
+```
+
+Then could use an L4 enabled load balancer to connect to NATS, for example:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats-lb
+spec:
+  type: LoadBalancer
+  selector:
+    app: nats
+  ports:
+    - protocol: TCP
+      port: 4222
+      targetPort: 4222
+      name: nats
+    - protocol: TCP
+      port: 7422
+      targetPort: 7422
+      name: leafnodes
+    - protocol: TCP
+      port: 7522
+      targetPort: 7522
+      name: gateways
 ```
 
 ## Gateways

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -114,6 +114,10 @@ data:
       ]
       cluster_advertise: $CLUSTER_ADVERTISE
 
+      {{- with .Values.cluster.noAdvertise }}      
+      no_advertise: {{ . }}
+      {{- end }}
+
       connect_retries: {{ .Values.nats.connectRetries }}
     }
     {{ end }}
@@ -133,6 +137,10 @@ data:
       {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
       {{ end }}
+
+      {{- with .Values.leafnodes.noAdvertise }}      
+      no_advertise: {{ . }}
+      {{- end }}
 
       {{- with .Values.leafnodes.tls }}
       {{ $secretName := .secret.name }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -88,6 +88,7 @@ podAnnotations: {}
 cluster:
   enabled: false
   replicas: 3
+  noAdvertise: false
 
 # Leafnode connections to extend a cluster:
 #
@@ -95,6 +96,7 @@ cluster:
 #
 leafnodes:
   enabled: false
+  noAdvertise: false
   # remotes:
   #   - url: "tls://connect.ngs.global:7422"
 


### PR DESCRIPTION
Example:

```yaml
nats:
  image: nats:alpine

  logging:
    debug: false
    trace: false

cluster:
  enabled: true
  noAdvertise: true

leafnodes:
  enabled: true
  noAdvertise: true

natsbox:
  enabled: true
```

Example load balancer given an install like:

```sh
helm install nats nats/nats -f values.yaml
```

```
apiVersion: v1
kind: Service
metadata:
  name: nats-lb
spec:
  type: LoadBalancer
  selector:
    app: nats
  ports:
    - protocol: TCP
      port: 4222
      targetPort: 4222
      name: nats
    - protocol: TCP
      port: 7422
      targetPort: 7422
      name: leafnodes
    - protocol: TCP
      port: 7522
      targetPort: 7522
      name: gateways
```

Fixes #81 
Signed-off-by: Waldemar Quevedo <wally@synadia.com>