### PR TITLE
fix: reference NATS_URL of nats-box to the correct release name

### DIFF
--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -19,7 +19,7 @@ now use the NATS tools within the container as follows:
 
   nats-box:~# nats-sub test &
   nats-box:~# nats-pub test hi
-  nats-box:~# nc {{ .Release.Name }} 4222
+  nats-box:~# nc {{ template "nats.name" . }} 4222
 
 {{- end }}
 

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: {{ .Values.natsbox.pullPolicy }}
     env:
     - name: NATS_URL
-      value: {{ .Release.Name }}
+      value: {{ template "nats.name" . }}
     {{- if .Values.natsbox.credentials }}
     - name: USER_CREDS
       value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}


### PR DESCRIPTION
Use the correct NATS_URL for nats-box to be able to connect NATS instance when resource names are overridden in the helper template.