### PR TITLE
First pass support for NATS JetStream via CRDs

### DIFF
--- a/helm/charts/index.yaml
+++ b/helm/charts/index.yaml
@@ -660,4 +660,24 @@ entries:
     urls:
     - https://github.com/nats-io/k8s/releases/download/v0.3.0/nats-account-server-0.3.0.tgz
     version: 0.3.0
-generated: "2020-03-04T12:58:26.609239-08:00"
+  nack:
+  - apiVersion: v2
+    appVersion: 0.1.0
+    created: "2020-10-05T16:32:32.445402-07:00"
+    description: A Helm chart for NACK
+    digest: 055a3b2ca3c23fbdbc72d5657dc55c213a561779daacfda43d8f13dcc1faf0ef
+    icon: https://nats.io/img/nats-icon-color.png
+    keywords:
+    - nats
+    - jetstream
+    - cncf
+    maintainers:
+    - email: wally@nats.io
+      name: Waldemar Quevedo
+    - email: jaime@nats.io
+      name: Jaime Piña
+    name: nack
+    urls:
+    - https://github.com/nats-io/k8s/releases/download/v0.5.6/nack-0.5.6.tgz
+    version: 0.5.6
+generated: "2020-10-05T12:58:26.609239-08:00"

--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+appVersion: "0.1.0"
+description: A Helm chart for NACK
+name: nack
+keywords:
+  - nats
+  - jetstream
+  - cncf
+version: 0.5.6
+maintainers:
+  - name: Waldemar Quevedo
+    github: https://github.com/wallyqs
+    email: wally@nats.io
+  - name: Jaime Piña
+    github: https://github.com/variadico
+    email: jaime@nats.io
+icon: https://nats.io/img/nats-icon-color.png

--- a/helm/charts/nack/README.md
+++ b/helm/charts/nack/README.md
@@ -1,0 +1,146 @@
+# NATS JetStream Controller (NACK)
+
+## TL;DR;
+
+```console
+helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+helm install nats nats/nats
+helm install nack-jsc nats/nack --set jetstream.nats.url=nats://nats:4222
+```
+
+The JetStream controllers allows you to manage [NATS JetStream](https://github.com/nats-io/jetstream) [Streams](https://github.com/nats-io/jetstream#streams-1) and [Consumers](https://github.com/nats-io/jetstream#consumers-1) via K8S CRDs.
+
+### Getting started
+
+First, we'll need to NATS cluster that has enabled JetStream.  You can install one as follows:
+
+```sh
+# Creates cluster of NATS Servers that are not JetStream enabled
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/k8s/master/nats-server/simple-nats.yml
+
+# Creates NATS Server with JetStream enabled as a leafnode connection
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/k8s/master/nats-server/nats-js-leaf.yml
+```
+
+Now install the JetStream CRDs and Controller:
+
+```sh
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/crds.yml
+customresourcedefinition.apiextensions.k8s.io/streams.jetstream.nats.io configured
+customresourcedefinition.apiextensions.k8s.io/consumers.jetstream.nats.io configured
+customresourcedefinition.apiextensions.k8s.io/streamtemplates.jetstream.nats.io configured
+
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/rbac.yml
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/deployment.yml
+```
+
+Now we can create some Streams and Consumers.
+
+```sh
+# Create a stream.
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/examples/stream.yml
+
+# Check if it was successfully created.
+$ kubectl get streams
+NAME       STATE     STREAM NAME   SUBJECTS
+mystream   Created   mystream      [orders.*]
+
+# Create a push-based consumer
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/examples/consumer_push.yml
+
+# Create a pull based consumer
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/examples/consumer_pull.yml
+
+# Check if they were successfully created.
+$ kubectl get consumers
+NAME               STATE     STREAM     CONSUMER           ACK POLICY
+my-pull-consumer   Created   mystream   my-pull-consumer   explicit
+my-push-consumer   Created   mystream   my-push-consumer   none
+
+# If you end up in an Errored state, run kubectl describe for more info.
+#     kubectl describe streams mystream
+#     kubectl describe consumers my-pull-consumer
+```
+
+Now we're ready to use Streams and Consumers. Let's start off with writing some
+data into `mystream`.
+
+```sh
+# Run nats-box that includes the NATS management utilities.
+$ kubectl apply -f https://nats-io.github.io/k8s/tools/nats-box.yml
+$ kubectl exec -it nats-box -- /bin/sh -l
+
+# Publish a couple of messages
+$ nats context save jetstream -s nats://nats:4222
+$ nats context select jetstream
+
+$ nats pub orders.received "order 1"
+$ nats pub orders.received "order 2"
+```
+
+First, we'll read the data using a pull-based consumer. In `consumer_pull.yml`
+we set:
+
+```yaml
+filterSubject: orders.received
+```
+
+so that's the subject my-pull-consumer` will pull messages from.
+
+```sh
+# Pull first message.
+$ nats consumer next mystream my-pull-consumer
+--- subject: orders.received / delivered: 1 / stream seq: 1 / consumer seq: 1
+
+order 1
+
+Acknowledged message
+
+# Pull next message.
+$ nats consumer next mystream my-pull-consumer
+--- subject: orders.received / delivered: 1 / stream seq: 2 / consumer seq: 2
+
+order 2
+
+Acknowledged message
+```
+
+Next, let's read data using a push-based consumer. In `consumer_push.yml` we set:
+
+```yaml
+deliverSubject: my-push-consumer.orders
+```
+
+so pushed messages will arrive on that subject. This time all messages arrive automatically.
+
+```sh
+$ nats sub my-push-consumer.orders
+17:57:24 Subscribing on my-push-consumer.orders
+[#1] Received JetStream message: consumer: mystream > my-push-consumer / subject: orders.received /
+delivered: 1 / consumer seq: 1 / stream seq: 1 / ack: false
+order 1
+
+[#2] Received JetStream message: consumer: mystream > my-push-consumer / subject: orders.received /
+delivered: 1 / consumer seq: 2 / stream seq: 2 / ack: false
+order 2
+```
+
+### Local Development
+
+```sh
+# First, build the jetstream controller.
+make jetstream-controller
+
+# Next, run the controller like this
+./jetstream-controller -kubeconfig ~/.kube/config -s nats://localhost:4222
+
+# Pro tip: jetstream-controller uses klog just like kubectl or kube-apiserver.
+# This means you can change the verbosity of logs with the -v flag.
+#
+# For example, this prints raw HTTP requests and responses.
+#     ./jetstream-controller -v=10
+
+# You'll probably want to start a local Jetstream-enabled NATS server, unless
+# you use a public one.
+nats-server -DV -js
+```

--- a/helm/charts/nack/README.md
+++ b/helm/charts/nack/README.md
@@ -8,11 +8,15 @@ helm install nats nats/nats
 helm install nack-jsc nats/nack --set jetstream.nats.url=nats://nats:4222
 ```
 
-The JetStream controllers allows you to manage [NATS JetStream](https://github.com/nats-io/jetstream) [Streams](https://github.com/nats-io/jetstream#streams-1) and [Consumers](https://github.com/nats-io/jetstream#consumers-1) via K8S CRDs.
+The JetStream controllers allows you to manage
+[NATS JetStream](https://github.com/nats-io/jetstream)
+[Streams](https://github.com/nats-io/jetstream#streams-1) and
+[Consumers](https://github.com/nats-io/jetstream#consumers-1) via K8S CRDs.
 
 ### Getting started
 
-First, we'll need to NATS cluster that has enabled JetStream.  You can install one as follows:
+First, we'll need to NATS cluster that has enabled JetStream.  You can install
+one as follows:
 
 ```sh
 # Creates cluster of NATS Servers that are not JetStream enabled
@@ -85,7 +89,7 @@ we set:
 filterSubject: orders.received
 ```
 
-so that's the subject my-pull-consumer` will pull messages from.
+so that's the subject my-pull-consumer will pull messages from.
 
 ```sh
 # Pull first message.
@@ -111,7 +115,8 @@ Next, let's read data using a push-based consumer. In `consumer_push.yml` we set
 deliverSubject: my-push-consumer.orders
 ```
 
-so pushed messages will arrive on that subject. This time all messages arrive automatically.
+so pushed messages will arrive on that subject. This time all messages arrive
+automatically.
 
 ```sh
 $ nats sub my-push-consumer.orders

--- a/helm/charts/nack/crds/jetstream.yml
+++ b/helm/charts/nack/crds/jetstream.yml
@@ -1,0 +1,382 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: streams.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Stream
+    singular: stream
+    plural: streams
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                description: A unique name for the Stream.
+                type: string
+                pattern: '^[^.*>]*$'
+                minLength: 1
+              subjects:
+                description: A list of subjects to consume, supports wildcards.
+                type: array
+                minLength: 1
+                items:
+                  type: string
+                  minLength: 1
+              retention:
+                description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                type: string
+                enum:
+                - limits
+                - interest
+                - workqueue
+                default: limits
+              maxConsumers:
+                description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxMsgs:
+                description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxBytes:
+                description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxAge:
+                description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                type: string
+                default: ''
+              maxMsgSize:
+                description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              storage:
+                description: The storage backend to use for the Stream.
+                type: string
+                enum:
+                - file
+                - memory
+                default: memory
+              replicas:
+                description: How many replicas to keep for each message.
+                type: integer
+                minimum: 1
+                default: 1
+              noAck:
+                description: Disables acknowledging messages that are received by the Stream.
+                type: boolean
+                default: false
+              discard:
+                description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                type: string
+                enum:
+                - old
+                - new
+                default: old
+              duplicateWindow:
+                description: The duration window to track duplicate messages for.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the stream.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream Name
+      type: string
+      description: The name of the Jetstream Stream.
+      jsonPath: .spec.name
+    - name: Subjects
+      type: string
+      description: The subjects this Stream produces.
+      jsonPath: .spec.subjects
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: consumers.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Consumer
+    singular: consumer
+    plural: consumers
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              streamName:
+                description: The name of the Stream to create the Consumer in.
+                type: string
+              deliverPolicy:
+                type: string
+                enum:
+                - all
+                - last
+                - new
+                # Requires optStartSeq
+                - byStartSequence
+                # Requires optStartTime
+                - byStartTime
+                default: all
+              optStartSeq:
+                type: integer
+                minimum: 0
+              optStartTime:
+                description: Time format must be RFC3339.
+                type: string
+              durableName:
+                description: The name of the Consumer.
+                type: string
+                pattern: '^[^.*>]+$'
+                minLength: 1
+              deliverSubject:
+                description: The subject to deliver observed messages, when not set, a pull-based Consumer is created.
+                type: string
+              ackPolicy:
+                description: How messages should be acknowledged.
+                type: string
+                enum:
+                - none
+                - all
+                - explicit
+                default: none
+              ackWait:
+                description: How long to allow messages to remain un-acknowledged before attempting redelivery.
+                type: string
+                default: 1ns
+              maxDeliver:
+                type: integer
+                minimum: -1
+              filterSubject:
+                description: Select only a specific incoming subjects, supports wildcards.
+                type: string
+              replayPolicy:
+                description: How messages are sent.
+                type: string
+                enum:
+                - instant
+                - original
+                default: instant
+              sampleFreq:
+                description: What percentage of acknowledgements should be samples for observability.
+                type: string
+              rateLimitBps:
+                description: rate at which messages will be delivered to clients, expressed in bit per second.
+                type: integer
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the consumer.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream
+      type: string
+      description: The name of the Jetstream Stream.
+      jsonPath: .spec.streamName
+    - name: Consumer
+      type: string
+      description: The name of the Jetstream Consumer.
+      jsonPath: .spec.durableName
+    - name: Ack Policy
+      type: string
+      description: The ack policy.
+      jsonPath: .spec.ackPolicy
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: streamtemplates.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: StreamTemplate
+    singular: streamtemplate
+    plural: streamtemplates
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                description: A unique name for the Stream Template.
+                type: string
+                pattern: '^[^.*>]*$'
+                minLength: 1
+              maxStreams:
+                description: The maximum number of Streams this Template can create, -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              subjects:
+                description: A list of subjects to consume, supports wildcards.
+                type: array
+                minLength: 1
+                items:
+                  type: string
+                  minLength: 1
+              retention:
+                description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                type: string
+                enum:
+                - limits
+                - interest
+                - workqueue
+                default: limits
+              maxConsumers:
+                description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxMsgs:
+                description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxBytes:
+                description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxAge:
+                description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                type: string
+                default: ''
+              maxMsgSize:
+                description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              storage:
+                description: The storage backend to use for the Stream.
+                type: string
+                enum:
+                - file
+                - memory
+                default: memory
+              replicas:
+                description: How many replicas to keep for each message.
+                type: integer
+                minimum: 1
+                default: 1
+              noAck:
+                description: Disables acknowledging messages that are received by the Stream.
+                type: boolean
+                default: false
+              discard:
+                description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                type: string
+                enum:
+                - old
+                - new
+                default: old
+              duplicateWindow:
+                description: The duration window to track duplicate messages for.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the stream.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream Template Name
+      type: string
+      description: The name of the Jetstream Stream Template.
+      jsonPath: .spec.name
+    - name: Subjects
+      type: string
+      description: The subjects this Stream produces.
+      jsonPath: .spec.subjects

--- a/helm/charts/nack/templates/NOTES.txt
+++ b/helm/charts/nack/templates/NOTES.txt
@@ -1,0 +1,7 @@
+
+You can find more information about running NATS JetStream Controller on
+Kubernetes here:
+
+  https://github.com/nats-io/nack
+
+Thanks for using NATS JetStream Controller!

--- a/helm/charts/nack/templates/_helpers.tpl
+++ b/helm/charts/nack/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jsc.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Define the serviceaccountname
+*/}}
+{{- define "jsc.serviceAccountName" -}}
+{{- default "jetstream-controller" .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -1,0 +1,98 @@
+{{- if .Values.jetstream.nats.url }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "jsc.name" . }}
+  labels:
+    app: {{ template "jsc.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "jsc.name" . }}
+
+  # Singleton Replica per JetStream controller
+  replicas: 1
+
+  template:
+    metadata:
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      labels:
+        app: {{ template "jsc.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.secretName }}
+      - name: jsc-client-tls-volume
+        secret:
+          secretName: {{ .Values.jetstream.tls.secretName }}
+      {{- end }}
+
+      {{- if .Values.jetstream.credentials }}
+      - name: jsc-sys-creds
+        secret:
+          secretName: {{ .Values.jetstream.credentials.secret.name }}
+      {{- end }}
+
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ template "jsc.name" . }}
+            topologyKey: kubernetes.io/hostname
+{{- with .Values.affinity }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+
+      serviceAccountName: {{ template "jsc.serviceAccountName" . }}
+
+      containers:
+        - name: jsc
+          image: {{ .Values.jetstream.image }}
+          command:
+          - /jetstream-controller
+          - -s={{ .Values.jetstream.nats.url }}
+
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          volumeMounts:
+          {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.secretName }}
+          - name: jsc-client-tls-volume
+            mountPath: /etc/nats/certs
+          {{- end }}
+          {{- if .Values.jetstream.credentials }}
+          - name: jsc-sys-creds
+            mountPath: /etc/jsc-creds
+          {{- end }}
+{{- end }}

--- a/helm/charts/nack/templates/rbac-jetstream-controller.yml
+++ b/helm/charts/nack/templates/rbac-jetstream-controller.yml
@@ -1,0 +1,54 @@
+{{- if .Values.jetstream.nats.url }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "jsc.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "jsc.serviceAccountName" . }}-cluster-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - jetstream.nats.io
+  resources:
+  - streams
+  - streams/status
+  - consumers
+  - consumers/status
+  - streamtemplates
+  - streamtemplates/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "jsc.serviceAccountName" . }}-cluster-role-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "jsc.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "jsc.serviceAccountName" . }}-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -1,0 +1,56 @@
+###############################
+#                             #
+#  NACK JetStream Controller  #
+#                             #
+###############################
+jetstream:
+  enabled: true
+  image: connecteverything/jetstream-controller:0.1.0
+  pullPolicy: IfNotPresent
+  replicas: 1
+
+  # NATS URL
+  nats:
+    url:
+
+  # TLS
+  # Enabled must be true, and a secret name specified for this to work
+  tls:
+    enabled: false
+    # the secret containing the client ca.crt, tls.crt, and tls.key for NATS
+    secretName:
+    # Reference
+    # https://docs.nats.io/nats-streaming-server/configuring/cfgfile#tls-configuration
+    settings:
+      client_cert: "/etc/nats/certs/tls.crt"
+      client_key: "/etc/nats/certs/tls.key"
+      client_ca: "/etc/nats/certs/ca.crt"
+      timeout: 3
+
+  # The credentials file to load in to connect to the nats server.
+  #credentials:
+  #  secret:
+  #    name: nats-sys-creds
+  #    key: sys.creds
+
+nameOverride: ""
+imagePullSecrets: []
+serviceAccountName: ""
+
+podAnnotations: {}
+
+# Toggle whether to use setup a Pod Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: null
+# securityContext:
+#   fsGroup: 1000
+#   runAsUser: 1000
+#   runAsNonRoot: true
+
+# Affinity for pod assignment
+# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# Resource requests and limits for primary stan container
+# ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+resources: {}

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.6.0
+version: 0.5.6
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.5.6
+version: 0.6.0
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -63,6 +63,15 @@ data:
     {{- end }}
     {{- end }}
 
+    {{- if .Values.nats.jetstream.enabled }}
+    ###################################
+    #                                 #
+    # NATS JetStream                  #
+    #                                 #
+    ###################################
+    jetstream: {{ .Values.nats.jetstream.enabled }}
+    {{- end }}
+
     {{ if .Values.cluster.enabled }}
     ###################################
     #                                 #

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -47,6 +47,9 @@ nats:
     connectErrorReports: 
     reconnectErrorReports: 
 
+  jetstream:
+    enabled: true
+
   #######################
   #                     #
   #  TLS Configuration  #


### PR DESCRIPTION
This adds a Helm chart to install a special controller that can manage JetStream Streams/Consumers via CRDs:

To install NATS with JetStream (memory mode) and the JetStream CRDs Controller:

```
helm install nats     ./helm/charts/nats --set nats.jetstream.enabled=true --set nats.image=synadia/nats-server:nightly
helm install nack-jsc ./helm/charts/nack --set jetstream.nats.url=nats://nats:4222
```

Then can do: 

```sh
echo '
---
apiVersion: jetstream.nats.io/v1beta1
kind: Stream
metadata:
  name: mystream
spec:
  name: mystream
  subjects: ["orders.*"]
  storage: memory
  maxAge: 1h
---
apiVersion: jetstream.nats.io/v1beta1
kind: Consumer
metadata:
  name: my-push-consumer
spec:
  streamName: mystream
  durableName: my-push-consumer
  deliverSubject: my-push-consumer.orders
  deliverPolicy: last
  ackPolicy: none
  replayPolicy: instant
---
apiVersion: jetstream.nats.io/v1beta1
kind: Consumer
metadata:
  name: my-pull-consumer
spec:
  streamName: mystream
  durableName: my-pull-consumer
  deliverPolicy: all
  filterSubject: orders.received
  maxDeliver: 20
  ackPolicy: explicit
' | kubectl apply -f -
```

And manage streams/consumers:

```sh
$ kubectl get streams
NAME       STATE     STREAM NAME   SUBJECTS
mystream   Created   mystream      [orders.*]

$ kubectl get consumers
NAME               STATE     STREAM     CONSUMER           ACK POLICY
my-pull-consumer   Created   mystream   my-pull-consumer   explicit
my-push-consumer   Created   mystream   my-push-consumer   none
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>