### PR TITLE
Add basic auth support for NATS + NATS Streaming charts

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -81,6 +81,10 @@ data:
     cluster {
       port: 6222
 
+      {{- with .Values.cluster.name }}
+      name: {{ . }}
+      {{- end }}
+
       {{- with .Values.cluster.tls }}
       {{ $secretName := .secret.name }}
       tls {
@@ -135,12 +139,12 @@ data:
     include "advertise/client_advertise.conf"
     {{- end }}
 
+    {{- if .Values.leafnodes }}
     ################# 
     #               #
     # NATS Leafnode #
     #               #
     #################
-    {{- if .Values.leafnodes }}
     leafnodes {
       {{- if .Values.leafnodes.enabled }}
       listen: "0.0.0.0:7422"
@@ -207,12 +211,12 @@ data:
     }
     {{ end }}
 
+    {{- if .Values.gateway.enabled }}
     ################# 
     #               #
     # NATS Gateways #
     #               #
     #################
-    {{- if .Values.gateway.enabled }}
     gateway {
       name: {{ .Values.gateway.name }}
       port: 7522
@@ -279,11 +283,6 @@ data:
     }
     {{ end }}
 
-    ####################
-    #                  #
-    # Logging Options  #
-    #                  #
-    ####################
     {{- with .Values.nats.logging.debug }}
     debug: {{ . }}
     {{- end }}
@@ -304,11 +303,6 @@ data:
     reconnect_error_reports: {{ . }}
     {{- end }}
 
-    ##################
-    #                #
-    # Server Limits  #
-    #                #
-    ##################
     {{- with .Values.nats.limits.maxConnections }}
     max_connections: {{ . }}
     {{- end }}
@@ -343,6 +337,7 @@ data:
     # Authorization  #
     #                #
     ##################
+    {{- if .Values.auth.resolver }}
     {{- if eq .Values.auth.resolver.type "memory" }}
     resolver: MEMORY
     include "accounts/{{ .Values.auth.resolver.configMap.key }}"
@@ -353,7 +348,33 @@ data:
     resolver: URL({{ . }})
     {{- end }}
     operator: /etc/nats-config/operator/{{ .Values.auth.operatorjwt.configMap.key }}
-    system_account: {{ .Values.auth.systemAccount }}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.auth.systemAccount }}
+    system_account: {{ . }}
+    {{- end }}
+
+    {{- with .Values.auth.basic }}
+
+    {{- with .noAuthUser }}
+    no_auth_user: {{ . }}
+    {{- end }}
+
+    {{- with .users }}
+    authorization {
+      users: [
+      {{- range . }}
+      {{- toPrettyJson . | nindent 4 }},
+      {{- end }}
+      ]
+    }
+    {{- end }}
+
+    {{- with .accounts }}
+    accounts: {{- toJson . }}
+    {{- end }}
+
     {{- end }}
 
     {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       - name: pid
         emptyDir: {}
 
-      {{- if .Values.auth.enabled }}
+      {{- if and .Values.auth.enabled .Values.auth.resolver }}
       {{- if eq .Values.auth.resolver.type "memory" }}
       # Volume with the memory resolver configuration.
       - name: resolver-volume
@@ -217,7 +217,7 @@ spec:
             subPath: advertise
           {{- end }}
 
-          {{- if .Values.auth.enabled }}
+          {{- if and .Values.auth.enabled .Values.auth.resolver }}
           {{- if eq .Values.auth.resolver.type "memory" }}
           - name: resolver-volume
             mountPath: /etc/nats-config/accounts

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -193,6 +193,16 @@ exporter:
 auth:
   enabled: false
 
+  # basic:
+  #   noAuthUser:
+  #   # List of users that can connect with basic auth,
+  #   # that belong to the global account.
+  #   users:
+
+  #   # List of accounts with users that can connect
+  #   # using basic auth.
+  #   accounts:
+
   # Reference to the Operator JWT.
   # operatorjwt:
   #   configMap:

--- a/helm/charts/stan/templates/nats-configmap.yaml
+++ b/helm/charts/stan/templates/nats-configmap.yaml
@@ -65,6 +65,10 @@ tls {
 cluster {
   port: 6222
 
+  {{- with .Values.cluster.name }}
+  name: {{ . }}
+  {{- end }}
+
   {{- with .Values.cluster.tls }}
   {{ $secretName := .secret.name }}
   tls {
@@ -121,12 +125,12 @@ cluster {
 include "advertise/client_advertise.conf"
 {{- end }}
 
+{{- if .Values.leafnodes }}
 ################# 
 #               #
 # NATS Leafnode #
 #               #
 #################
-{{- if .Values.leafnodes }}
 leafnodes {
   {{- if .Values.leafnodes.enabled }}
   listen: "0.0.0.0:7422"
@@ -193,12 +197,12 @@ leafnodes {
 }
 {{ end }}
 
+{{- if .Values.gateway.enabled }}
 ################# 
 #               #
 # NATS Gateways #
 #               #
 #################
-{{- if .Values.gateway.enabled }}
 gateway {
   name: {{ .Values.gateway.name }}
   port: 7522
@@ -265,11 +269,6 @@ gateway {
 }
 {{ end }}
 
-####################
-#                  #
-# Logging Options  #
-#                  #
-####################
 {{- with .Values.nats.logging.debug }}
 debug: {{ . }}
 {{- end }}
@@ -290,11 +289,6 @@ connect_error_reports: {{ . }}
 reconnect_error_reports: {{ . }}
 {{- end }}
 
-##################
-#                #
-# Server Limits  #
-#                #
-##################
 {{- with .Values.nats.limits.maxConnections }}
 max_connections: {{ . }}
 {{- end }}
@@ -329,6 +323,8 @@ lame_duck_duration:  {{ . | quote }}
 # Authorization  #
 #                #
 ##################
+{{- if .Values.auth.resolver }}
+
 {{- if eq .Values.auth.resolver.type "memory" }}
 resolver: MEMORY
 include "accounts/{{ .Values.auth.resolver.configMap.key }}"
@@ -339,7 +335,33 @@ include "accounts/{{ .Values.auth.resolver.configMap.key }}"
 resolver: URL({{ . }})
 {{- end }}
 operator: /etc/nats-config/operator/{{ .Values.auth.operatorjwt.configMap.key }}
-system_account: {{ .Values.auth.systemAccount }}
+{{- end }}
+
+{{- end }}
+
+{{- with .Values.auth.systemAccount }}
+system_account: {{ . }}
+{{- end }}
+
+{{- with .Values.auth.basic }}
+
+{{- with .noAuthUser }}
+no_auth_user: {{ . }}
+{{- end }}
+
+{{- with .users }}
+authorization {
+  users: [
+  {{- range . }}
+  {{- toPrettyJson . | nindent 4 }},
+  {{- end }}
+  ]
+}
+{{- end }}
+
+{{- with .accounts }}
+accounts: {{- toJson . }}
+{{- end }}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
Now NATS users and accounts can be defined in the `values.yaml`:

### NATS Example

```yaml
nats:
  image: synadia/nats-server:nightly
cluster:
  enabled: true
  name: toomuchyaml
auth:
  enabled: true
  systemAccount: SYS
  basic:
    noAuthUser: secret
    users:
    - user: secret
    accounts: 
      A:
        imports: []
        exports: []
        users:
        - user: a
          pass: a
      B:
        imports: []
        exports: []
        users:
        - user: b 
          pass: b
      SYS:
        imports: []
        exports: []
        users:
        - user: sys
          pass: sys
```

### STAN example

```yaml
cluster:
  enabled: false

store:
  cluster:
    enabled: false
  file:
    options:
      sync: true

stan:
  logging:
   debug: true
   trace: true

nats:
  logging:
    debug: true
    trace: true

auth:
  enabled: true
  systemAccount: SYS

  basic:
    noAuthUser: stan

    accounts: 
      STAN:
        imports: []
        exports: []
        users:
        - user: stan
          pass: stan
      ACME:
        imports: []
        exports: []
        users:
        - user: acme
          pass: acme
      SYS:
        imports: []
        exports: []
        users:
        - user: sys
          pass: sys
```