### PR TITLE
Add support for STAN partitions in FT mode

### DIFF
--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -232,6 +232,85 @@ spec:
       storage: 100Mi
 ```
 
+#### Partitioning
+
+You can enable partitioning as follows:
+
+```
+store:
+  type: file
+
+  partitioning:
+    enabled: true
+```
+
+For example to have two partitions under the same NATS/NATS Streaming
+cluster named `stan` with two Fault Tolerant groups managing different
+channels under the same shared filesystem.
+
+```yaml
+# 
+stan:
+  image: nats-streaming:alpine
+  replicas: 2
+  clusterID: stan
+
+store:
+  type: file
+  ft:
+    group: A
+  file:
+    path: /data/stan/store/A
+
+  partitioning:
+    enabled: true
+
+  limits:
+    channels:
+      foo.>:
+
+  volume:
+    enabled: true
+
+    # Mount path for the volume.
+    mount: /data/stan
+
+    # FT mode requires a single shared ReadWriteMany PVC volume.
+    persistentVolumeClaim:
+      claimName: stan-efs
+```
+
+```yaml
+stan:
+  image: nats-streaming:alpine
+  replicas: 2
+  clusterID: stan
+
+store:
+  type: file
+  ft:
+    group: B
+  file:
+    path: /data/stan/store/B
+
+  partitioning:
+    enabled: true
+
+  limits:
+    channels:
+      bar.>:
+
+  volume:
+    enabled: true
+
+    # Mount path for the volume.
+    mount: /data/stan
+
+    # FT mode requires a single shared ReadWriteMany PVC volume.
+    persistentVolumeClaim:
+      claimName: stan-efs
+```
+
 #### Clustered File Storage
 
 In case of using file storage, this sets up a 3 node cluster,

--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -66,10 +66,10 @@ data:
       {{- end }}
       {{- end }}
 
+      {{- if .Values.store.cluster.enabled }}
       ###############################
       #  NATS Streaming Clustering  #
       ###############################
-      {{- if .Values.store.cluster.enabled }}
       cluster {
         node_id: $POD_NAME
         {{- with .Values.store.cluster.logPath }}
@@ -83,8 +83,67 @@ data:
       }
       {{- end }}
 
+      {{- with .Values.store.partitioning }}
+      partitioning: {{ .enabled }}
+      {{- end }}
+
       {{- with .Values.store.limits }}
-      store_limits: {{ toPrettyJson . | indent 6 }}
+      store_limits: {
+        {{- if .max_channels }}
+        max_channels: {{ .max_channels }}
+        {{- end }}
+
+        {{- if .max_msgs }}
+        max_msgs: {{ .max_msgs }}
+        {{- end }}
+
+        {{- if .max_bytes }}
+        max_bytes: {{ .max_bytes }}
+        {{- end }}
+
+        {{- if .max_age }}
+        max_age: {{ .max_age }}
+        {{- end }}
+
+        {{- if .max_subs }}
+        max_subs: {{ .max_subs }}
+        {{- end }}
+
+        {{- if .max_inactivity }}
+        max_inactivity: {{ .max_inactivity }}
+        {{- end }}
+
+        {{- if .channels }}
+
+        channels {
+        {{- range $channel, $limits := .channels }}
+          {{ $channel }}: {
+            {{- if $limits }}
+            {{- with $limits.max_subs }}
+            max_subs: {{ . }}
+            {{- end }}
+
+            {{- with $limits.max_msgs }}
+            max_msgs: {{ . }}
+            {{- end }}
+
+            {{- with $limits.max_bytes }}
+            max_bytes: {{ . }}
+            {{- end }}
+
+            {{- with $limits.max_age }}
+            max_age: {{ . }}
+            {{- end }}
+
+            {{- with $limits.max_inactivity }}
+            max_inactivity: {{ . }}
+            {{- end }}
+          {{- end }}
+          }
+        {{- end }}
+        }
+        {{- end }}
+      }
       {{- end }}
     }
 

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -102,7 +102,7 @@ store:
   ft:
     group:
 
-  # Configures streaming/store_limits as is.
+  # Configures streaming/store_limits.
   #
   # NOTE: Section in snake case since they will become
   # the same objects.
@@ -112,6 +112,13 @@ store:
   # https://docs.nats.io/nats-streaming-server/configuring/cfgfile#store-limits-configuration
   #
   limits: {}
+
+  # Enables streaming/partitioning
+  # 
+  # https://docs.nats.io/nats-streaming-concepts/partitioning
+  # 
+  partitioning:
+    enabled: false
 
   #
   # Volume claim configuration. Required if the store type is `file` or if
@@ -285,10 +292,13 @@ nats:
   #   key: "tls.key"
 
 cluster:
+  # NOTE: NATS Server service is enabled by default, but will get disabled
+  # if a NATS url is defined.
   enabled: true
+
   # NOTE: Recommended to enable if running behind a load balancer.
   noAdvertise: false
-
+  
 # Leafnode connections to extend a cluster:
 #
 # https://docs.nats.io/nats-server/configuration/leafnodes


### PR DESCRIPTION
Enables partitions and also makes store limits explicit.  Examples:

```
helm install nats nats/nats
```

```yaml
stan:
  image: nats-streaming:alpine
  replicas: 2
  clusterID: stan
  nats:
   url: nats://nats:4222

store:
  type: file
  ft:
    group: A
  file:
    path: /data/stan/store/A

  partitioning:
    enabled: true

  limits:
    channels:
      foo.>:

  volume:
    enabled: true

    # Mount path for the volume.
    mount: /data/stan

    # FT mode requires a single shared ReadWriteMany PVC volume.
    persistentVolumeClaim:
      claimName: stan-efs
```

```yaml
stan:
  image: nats-streaming:alpine
  replicas: 2
  clusterID: stan
  nats:
    url: nats://nats:4222

store:
  type: file
  ft:
    group: B
  file:
    path: /data/stan/store/B

  partitioning:
    enabled: true

  limits:
    channels:
      bar.>:

  volume:
    enabled: true

    # Mount path for the volume.
    mount: /data/stan

    # FT mode requires a single shared ReadWriteMany PVC volume.
    persistentVolumeClaim:
      claimName: stan-efs
```

```
helm install stan-a ./helm/charts/stan -f examples/stan-ft-partitions-ft-A.yaml 
helm install stan-b ./helm/charts/stan -f examples/stan-ft-partitions-ft-B.yaml 
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>