### PR TITLE
Misc fixes to STAN chart

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -365,14 +365,14 @@ data:
     authorization {
       users: [
       {{- range . }}
-      {{- toPrettyJson . | nindent 4 }},
+      {{- toRawJson . | nindent 4 }},
       {{- end }}
       ]
     }
     {{- end }}
 
     {{- with .accounts }}
-    accounts: {{- toJson . }}
+    accounts: {{- toRawJson . }}
     {{- end }}
 
     {{- end }}

--- a/helm/charts/stan/templates/nats-configmap.yaml
+++ b/helm/charts/stan/templates/nats-configmap.yaml
@@ -354,14 +354,14 @@ no_auth_user: {{ . }}
 authorization {
   users: [
   {{- range . }}
-  {{- toPrettyJson . | nindent 4 }},
+  {{- toRawJson . | nindent 4 }},
   {{- end }}
   ]
 }
 {{- end }}
 
 {{- with .accounts }}
-accounts: {{- toJson . }}
+accounts: {{- toRawJson . }}
 {{- end }}
 {{- end }}
 

--- a/helm/charts/stan/templates/nats-configmap.yaml
+++ b/helm/charts/stan/templates/nats-configmap.yaml
@@ -1,6 +1,6 @@
 {{- define "nats-configmap" }}
 # PID file shared with configuration reloader.
-pid_file: "/var/run/nats/nats.pid"
+pid_file: "/var/run/stan/stan.pid"
 
 ###############
 #             #

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
             mountPath: /etc/stan-creds
           {{- end }}
           - name: pid
-            mountPath: /var/run/nats
+            mountPath: /var/run/stan
 
         {{- if eq .Values.store.type "file" }}
         {{- if .Values.store.backup.enabled }}
@@ -225,7 +225,7 @@ spec:
         {{- end }}
         {{- end }}
 
-        {{ if .Values.exporter.enabled }}
+        {{- if .Values.exporter.enabled }}
         #################################
         #                               #
         #  NATS Prometheus Exporter     #
@@ -244,29 +244,31 @@ spec:
           ports:
           - containerPort: 7777
             name: metrics
-        {{ end }}
+        {{- end }}
 
+        {{- if not .Values.stan.nats.url }}
+        {{- if .Values.reloader.enabled }}
         #################################
         #                               #
         #  NATS Configuration Reloader  #
         #                               #
         #################################
-        {{ if .Values.reloader.enabled }}
         - name: reloader
           image: {{ .Values.reloader.image }}
           imagePullPolicy: {{ .Values.reloader.pullPolicy }}
           command:
            - "nats-server-config-reloader"
            - "-pid"
-           - "/var/run/nats/nats.pid"
+           - "/var/run/stan/stan.pid"
            - "-config"
            - "/etc/stan-config/stan.conf"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/stan-config
             - name: pid
-              mountPath: /var/run/nats
-        {{ end }}
+              mountPath: /var/run/stan
+        {{- end }}
+        {{- end }}
 
   {{- if eq .Values.store.type "file" }}
   {{- if .Values.store.volume.enabled }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -371,7 +371,7 @@ bootconfig:
 
 # The NATS config reloader image to use.
 reloader:
-  enabled: true
+  enabled: false
   image: connecteverything/nats-server-config-reloader:0.6.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
- Stop using toPrettyJson since it escapes html which affects nats wildcards symbols
- Disable reloader for STAN and only when not using embedded NATS Server