### PR TITLE
Add websocket support

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -331,6 +331,33 @@ data:
     lame_duck_duration:  {{ . | quote }}
     {{- end }}
 
+    {{- if .Values.websocket.enabled }}
+    ##################
+    #                #
+    # Websocket      #
+    #                #
+    ##################
+    ws {
+      port: {{ .Values.websocket.port }}
+      {{- with .Values.websocket.tls }}
+        {{ $secretName := .secret.name }}
+        tls {
+        {{- with .cert }}
+        cert_file: /etc/nats-certs/ws/{{ $secretName }}/{{ . }}
+        {{- end }}
+
+        {{- with .key }}
+        key_file: /etc/nats-certs/ws/{{ $secretName }}/{{ . }}
+        {{- end }}
+
+        {{- with .ca }}
+        ca_file: /etc/nats-certs/ws/{{ $secretName }}/{{ . }}
+        {{- end }}
+        }
+      {{- end }}
+    }
+    {{- end }}
+
     {{- if .Values.auth.enabled }}
     ##################
     #                #
@@ -340,6 +367,10 @@ data:
     {{- if .Values.auth.resolver }}
     {{- if eq .Values.auth.resolver.type "memory" }}
     resolver: MEMORY
+    include "accounts/{{ .Values.auth.resolver.configMap.key }}"
+    {{- end }}
+
+    {{- if eq .Values.auth.resolver.type "full" }}
     include "accounts/{{ .Values.auth.resolver.configMap.key }}"
     {{- end }}
 

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -63,6 +63,12 @@ spec:
           name: {{ .Values.auth.resolver.configMap.name }}
       {{- end }}
 
+      {{- if eq .Values.auth.resolver.type "full" }}
+      - name: resolver-volume
+        configMap:
+          name: {{ .Values.auth.resolver.configMap.name }}
+      {{- end }}
+
       {{- if eq .Values.auth.resolver.type "URL" }}
       - name: operator-jwt-volume
         configMap:
@@ -105,7 +111,12 @@ spec:
         secret:
           secretName: {{ $secretName }}
       {{- end }}
-
+      {{- with .Values.websocket.tls }}
+      {{ $secretName := .secret.name }}
+      - name: {{ $secretName }}-ws-volume
+        secret:
+          secretName: {{ $secretName }}
+      {{- end }}
       {{- if .Values.leafnodes.enabled }}
       # 
       # Leafnode credential volumes
@@ -187,6 +198,13 @@ spec:
           name: monitor
         - containerPort: 7777
           name: metrics
+        {{- if .Values.websocket.enabled }}
+        - containerPort: {{ .Values.websocket.port }}
+          name: websocket
+          {{- if .Values.nats.externalAccess }}
+          hostPort: {{ .Values.websocket.port }}
+          {{- end }}
+        {{- end }}
         command:
          - "nats-server"
          - "--config"
@@ -223,6 +241,11 @@ spec:
             mountPath: /etc/nats-config/accounts
           {{- end }}
 
+          {{- if eq .Values.auth.resolver.type "full" }}
+          - name: resolver-volume
+            mountPath: /etc/nats-config/accounts
+          {{- end }}
+
           {{- if eq .Values.auth.resolver.type "URL" }}
           - name: operator-jwt-volume
             mountPath: /etc/nats-config/operator
@@ -253,6 +276,12 @@ spec:
           {{ $secretName := .secret.name }}
           - name: {{ $secretName }}-gateways-volume
             mountPath: /etc/nats-certs/gateways/{{ $secretName }}
+          {{- end }}
+
+          {{- with .Values.websocket.tls }}
+          {{ $secretName := .secret.name }}
+          - name: {{ $secretName }}-ws-volume
+            mountPath: /etc/nats-certs/ws/{{ $secretName }}
           {{- end }}
 
           {{- if .Values.leafnodes.enabled }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -234,3 +234,7 @@ auth:
   #   ##########################
   #   # type: URL
   #   # url: "http://nats-account-server:9090/jwt/v1/accounts/"
+
+websocket:
+  enabled: false
+  port: 443


### PR DESCRIPTION
Add support for websocket and embedded NATS Account server (full)

```yaml
nats:
  image: synadia/nats-server:nightly

  # Bind a host port from the host for each one of the pods.
  externalAccess: true

  logging:
    debug: false
    trace: false

  tls:
    secret:
      name: nats-tls
    cert: "fullchain.pem"
    key: "privkey.pem"

cluster:
  enabled: true

auth:
  enabled: true

  resolver:
    # Use the NATS Account embedded server.
    type: full

    configMap:
      name: nats-accounts
      key: resolver.conf

natsbox:
  enabled: false

websocket:
  enabled: true
  port: 443

  tls:
    secret:
      name: nats-tls
    cert: "fullchain.pem"
    key: "privkey.pem"
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>