### PR TITLE
Add NATS ans STAN prometheus operator ServiceMonitor support

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -370,7 +370,7 @@ reloader:
   pullPolicy: IfNotPresent
 ```
 
-### Prometheus Exporter sidecar 
+### Prometheus Exporter sidecar
 
 You can toggle whether to start the sidecar that can be used to feed metrics to Prometheus:
 
@@ -379,6 +379,19 @@ exporter:
   enabled: true
   image: synadia/prometheus-nats-exporter:0.5.0
   pullPolicy: IfNotPresent
+```
+
+### Prometheus operator ServiceMonitor support
+
+You can enable prometheus operator ServiceMonitor:
+
+```yaml
+exporter:
+  # You have to enable exporter first
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    # ...
 ```
 
 ### Pod Customizations

--- a/helm/charts/nats/templates/serviceMonitor.yaml
+++ b/helm/charts/nats/templates/serviceMonitor.yaml
@@ -1,0 +1,32 @@
+{{ if and .Values.exporter.enabled .Values.exporter.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "nats.name" . }}
+  {{- if .Values.exporter.serviceMonitor.labels }}
+  labels:
+    {{ .Values.exporter.serviceMonitor.labels }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.annotations }}
+  annotations:
+    {{ .Values.exporter.serviceMonitor.annotations }}
+  {{- end }}
+spec:
+  endpoints:
+  - port: metrics
+  {{- if .Values.exporter.serviceMonitor.path }}
+    path: {{ .Values.exporter.serviceMonitor.path }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.interval }}
+    interval: {{ .Values.exporter.serviceMonitor.interval }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.exporter.serviceMonitor.scrapeTimeout }}
+  {{- end }}
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: {{ template "nats.name" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -188,6 +188,14 @@ exporter:
   enabled: true
   image: synadia/prometheus-nats-exporter:0.5.0
   pullPolicy: IfNotPresent
+  # Prometheus operator ServiceMonitor support. Exporter has to be enabled
+  serviceMonitor:
+    enabled: false
+    labels: {}
+    annotations: {}
+    path: /metrics
+    # interval:
+    # scrapeTimeout:
 
 # Authentication setup
 auth:

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -507,6 +507,19 @@ exporter:
   pullPolicy: IfNotPresent
 ```
 
+### Prometheus operator ServiceMonitor support
+
+You can enable prometheus operator ServiceMonitor:
+
+```yaml
+exporter:
+  # You have to enable exporter first
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    # ...
+```
+
 ### Pod Customizations
 
 #### Security Context

--- a/helm/charts/stan/templates/serviceMonitor.yaml
+++ b/helm/charts/stan/templates/serviceMonitor.yaml
@@ -1,0 +1,32 @@
+{{ if and .Values.exporter.enabled .Values.exporter.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "stan.name" . }}
+  {{- if .Values.exporter.serviceMonitor.labels }}
+  labels:
+    {{ .Values.exporter.serviceMonitor.labels }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.annotations }}
+  annotations:
+    {{ .Values.exporter.serviceMonitor.annotations }}
+  {{- end }}
+spec:
+  endpoints:
+  - port: metrics
+  {{- if .Values.exporter.serviceMonitor.path }}
+    path: {{ .Values.exporter.serviceMonitor.path }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.interval }}
+    interval: {{ .Values.exporter.serviceMonitor.interval }}
+  {{- end }}
+  {{- if .Values.exporter.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.exporter.serviceMonitor.scrapeTimeout }}
+  {{- end }}
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: {{ template "stan.name" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -219,6 +219,14 @@ exporter:
   enabled: true
   image: synadia/prometheus-nats-exporter:0.6.2
   pullPolicy: IfNotPresent
+  # Prometheus operator ServiceMonitor support. Exporter has to be enabled
+  serviceMonitor:
+    enabled: false
+    labels: {}
+    annotations: {}
+    path: /metrics
+    # interval:
+    # scrapeTimeout:
 
 #  
 #  Embedded NATS Configuration


### PR DESCRIPTION
Issue: https://github.com/nats-io/k8s/issues/79

<details>
<summary>Templated NATS</summary>

```yaml
---
# Source: nats/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-release-config
  labels:
    app: test-release
    chart: nats-0.6.2
data:
  nats.conf: |
    # PID file shared with configuration reloader.
    pid_file: "/var/run/nats/nats.pid"

    ###############
    #             #
    # Monitoring  #
    #             #
    ###############
    http: 8222
    server_name: $POD_NAME
---
# Source: nats/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-release
  labels:
    app: test-release
    chart: nats-0.6.2
spec:
  selector:
    app: test-release
  clusterIP: None
  ports:
  - name: client
    port: 4222
  - name: cluster
    port: 6222
  - name: monitor
    port: 8222
  - name: metrics
    port: 7777
  - name: leafnodes
    port: 7422
  - name: gateways
    port: 7522
---
# Source: nats/templates/nats-box.yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-release-box
  labels:
    app: test-release-box
    chart: nats-0.6.2
spec:
  volumes:

  containers:
  - name: nats-box
    image: synadia/nats-box:0.4.0
    imagePullPolicy: IfNotPresent
    env:
    - name: NATS_URL
      value: test-release
    command:
     - "tail"
     - "-f"
     - "/dev/null"
    volumeMounts:
---
# Source: nats/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test-release
  labels:
    app: test-release
    chart: nats-0.6.2
spec:
  selector:
    matchLabels:
      app: test-release
  replicas: 1
  serviceName: test-release
  template:
    metadata:
      annotations:
        prometheus.io/path: /metrics
        prometheus.io/port: "7777"
        prometheus.io/scrape: "true"
      labels:
        app: test-release
        chart: nats-0.6.2
    spec:
      # Common volumes for the containers.
      volumes:
      - name: config-volume
        configMap:
          name: test-release-config

      # Local volume shared with the reloader.
      - name: pid
        emptyDir: {}

      

      #################
      #               #
      #  TLS Volumes  #
      #               #
      #################

      

      # Required to be able to HUP signal and apply config
      # reload to the server without restarting the pod.
      shareProcessNamespace: true

      #################
      #               #
      #  NATS Server  #
      #               #
      #################
      terminationGracePeriodSeconds: 60
      containers:
      - name: nats
        image: nats:2.1.7-alpine3.11
        imagePullPolicy: IfNotPresent
        ports:
        - containerPort: 4222
          name: client
        - containerPort: 7422
          name: leafnodes
        - containerPort: 7522
          name: gateways
        - containerPort: 6222
          name: cluster
        - containerPort: 8222
          name: monitor
        - containerPort: 7777
          name: metrics
        command:
         - "nats-server"
         - "--config"
         - "/etc/nats-config/nats.conf"

        # Required to be able to define an environment variable
        # that refers to other environment variables.  This env var
        # is later used as part of the configuration file.
        env:
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: CLUSTER_ADVERTISE
          value: $(POD_NAME).test-release.$(POD_NAMESPACE).svc
        volumeMounts:
          - name: config-volume
            mountPath: /etc/nats-config
          - name: pid
            mountPath: /var/run/nats

        # Liveness/Readiness probes against the monitoring.
        #
        livenessProbe:
          httpGet:
            path: /
            port: 8222
          initialDelaySeconds: 10
          timeoutSeconds: 5
        readinessProbe:
          httpGet:
            path: /
            port: 8222
          initialDelaySeconds: 10
          timeoutSeconds: 5

        # Gracefully stop NATS Server on pod deletion or image upgrade.
        #
        lifecycle:
          preStop:
            exec:
              # Using the alpine based NATS image, we add an extra sleep that is
              # the same amount as the terminationGracePeriodSeconds to allow
              # the NATS Server to gracefully terminate the client connections.
              #
              command: ["/bin/sh", "-c", "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"]

      #################################
      #                               #
      #  NATS Configuration Reloader  #
      #                               #
      #################################
      
      - name: reloader
        image: connecteverything/nats-server-config-reloader:0.6.0
        imagePullPolicy: IfNotPresent
        command:
         - "nats-server-config-reloader"
         - "-pid"
         - "/var/run/nats/nats.pid"
         - "-config"
         - "/etc/nats-config/nats.conf"
        volumeMounts:
          - name: config-volume
            mountPath: /etc/nats-config
          - name: pid
            mountPath: /var/run/nats
      

      ##############################
      #                            #
      #  NATS Prometheus Exporter  #
      #                            #
      ##############################
      
      - name: metrics
        image: synadia/prometheus-nats-exporter:0.5.0
        imagePullPolicy: IfNotPresent
        args:
        - -connz
        - -routez
        - -subz
        - -varz
        - -prefix=nats
        - -use_internal_server_id
        - http://localhost:8222/
        ports:
        - containerPort: 7777
          name: metrics
---
# Source: nats/templates/serviceMonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: test-release
spec:
  endpoints:
  - port: metrics
    path: /metrics
  namespaceSelector:
    any: true
  selector:
    matchLabels:
      app: test-release
      chart: nats-0.6.2
```
</details>

<details>
<summary>Templated STAN</summary>

```yaml
---
# Source: stan/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-release-config
  labels:
    app: test-release
    chart: stan-0.6.2
data:
  stan.conf: |-
    #########################
    # NATS Streaming Config #
    #########################
    streaming {
      id: test-release

      ###############################
      #  Store Config               #
      ###############################
      store: "file"
      dir: /data/stan/store
      partitioning: false
    }

    ###############################################
    #                                             #
    #            Embedded NATS Config             #
    #                                             #
    ###############################################
    
    
    # PID file shared with configuration reloader.
    pid_file: "/var/run/stan/stan.pid"
    
    ###############
    #             #
    # Monitoring  #
    #             #
    ###############
    http: 8222
    server_name: $POD_NAME
---
# Source: stan/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-release
  labels:
    app: test-release
    chart: stan-0.6.2
spec:
  selector:
    app: test-release
  clusterIP: None
  ports:
  - name: metrics
    port: 7777
  - name: monitor
    port: 8222
  - name: client
    port: 4222
---
# Source: stan/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test-release
  labels:
    app: test-release
    chart: stan-0.6.2
spec:
  selector:
    matchLabels:
      app: test-release

  replicas: 1

  # NATS Streaming service name
  serviceName: test-release

  template:
    metadata:
      annotations:
        prometheus.io/path: /metrics
        prometheus.io/port: "7777"
        prometheus.io/scrape: "true"
      labels:
        app: test-release
        chart: stan-0.6.2
    spec:
      terminationGracePeriodSeconds: 30
      volumes:
      - configMap:
          name: test-release-config
          defaultMode: 0755
        name: config-volume

      # Local volume shared with the reloader.
      - name: pid
        emptyDir: {}

      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: In
                values:
                - test-release
            topologyKey: kubernetes.io/hostname
      containers:
        ####################
        #  NATS Streaming  #
        ####################
        - name: stan
          image: nats-streaming:0.18.0
          args:
          - -sc
          - /etc/stan-config/stan.conf
          env:
          - name: POD_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: CLUSTER_ADVERTISE
            value: $(POD_NAME).test-release.$(POD_NAMESPACE).svc
          - name: STAN_SERVICE_NAME
            value: test-release
          - name: STAN_REPLICAS
            value: "1"
          ports:
          - containerPort: 8222
            name: monitor
          - containerPort: 7777
            name: metrics
          readinessProbe:
            httpGet:
              path: /streaming/serverz
              port: monitor
            timeoutSeconds: 2

          volumeMounts:
          - name: config-volume
            mountPath: /etc/stan-config
          - name: test-release-pvc
            mountPath: /data/stan
          - name: pid
            mountPath: /var/run/stan
        #################################
        #                               #
        #  NATS Prometheus Exporter     #
        #                               #
        #################################
        - name: metrics
          image: synadia/prometheus-nats-exporter:0.6.2
          args:
          - -connz
          - -routez
          - -subz
          - -varz
          - -channelz
          - -serverz
          - http://localhost:8222/
          ports:
          - containerPort: 7777
            name: metrics
  volumeClaimTemplates:
  - metadata:
      name: test-release-pvc
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi
---
# Source: stan/templates/serviceMonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: test-release
spec:
  endpoints:
  - port: metrics
    path: /metrics
  namespaceSelector:
    any: true
  selector:
    matchLabels:
      app: test-release
      chart: stan-0.6.2
```
</details>

(Is not tested for now)