### PR TITLE
Add Jetstream file storage options with persistent volume to NATS server helm chart

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -69,7 +69,19 @@ data:
     # NATS JetStream                  #
     #                                 #
     ###################################
-    jetstream: {{ .Values.nats.jetstream.enabled }}
+    jetstream {
+      {{- if .Values.nats.jetstream.fileStorage.enabled }}
+      store_dir: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
+      
+      max_file_store: 
+      {{- if .Values.nats.jetstream.fileStorage.existingClaim }}
+      {{- .Values.nats.jetstream.fileStorage.claimStorageSize | int }}
+      {{- else }}
+      {{- .Values.nats.jetstream.fileStorage.size | int }}
+      {{- end }}
+
+      {{- end }}
+    }
     {{- end }}
 
     {{ if .Values.cluster.enabled }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -76,11 +76,18 @@ spec:
       {{- end }}
       {{- end }}
 
-      {{ if and .Values.nats.externalAccess .Values.nats.advertise }}
+      {{- if and .Values.nats.externalAccess .Values.nats.advertise }}
       # Local volume shared with the advertise config initializer.
       - name: advertiseconfig
         emptyDir: {}
-      {{ end }}
+      {{- end }}
+
+      {{- if and .Values.nats.jetstream.fileStorage.enabled .Values.nats.jetstream.fileStorage.existingClaim }}
+      # Persistent volume for jetstream running with file storage option
+      - name: jetstream-volume
+        persistentVolumeClaim:
+          claimName: {{ .Values.nats.jetstream.fileStorage.existingClaim | quote }}
+      {{- end }}
 
       #################
       #               #
@@ -252,6 +259,11 @@ spec:
           {{- end }}
           {{- end }}
 
+          {{- if .Values.nats.jetstream.fileStorage.enabled }}
+          - name: jetstream-volume
+            mountPath: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
+          {{- end }}
+
           {{- with .Values.nats.tls }}
           #######################
           #                     #
@@ -365,3 +377,29 @@ spec:
         - containerPort: 7777
           name: metrics
       {{ end }}
+  
+  {{- if and .Values.nats.jetstream.fileStorage.enabled (not .Values.nats.jetstream.fileStorage.existingClaim) }}
+  #####################################
+  #                                   #
+  #  Jetstream New Persistent Volume  #
+  #                                   #
+  #####################################
+  volumeClaimTemplates:
+    - metadata:
+        name: jetstream-volume
+        {{- if .Values.nats.jetstream.fileStorage.annotations }}
+        annotations:
+        {{- range $key, $value := .Values.nats.jetstream.fileStorage.annotations }}
+          {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.nats.jetstream.fileStorage.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.nats.jetstream.fileStorage.size }}
+        storageClassName: {{ .Values.nats.jetstream.fileStorage.storageClassName | quote }}
+  {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -49,6 +49,27 @@ nats:
 
   jetstream:
     enabled: false
+    ############################
+    #                          #
+    #  Jetstream File Storage  #
+    #                          #
+    ############################
+    fileStorage:
+      enabled: false
+      storageDirectory: /data
+
+      # # set for use with existing PVC
+      # existingClaim: jetstream-pvc
+      # claimStorageSize: 1000000000 #bytes
+      
+      # # use below block to create new persistent volume
+      # # only used if existingClaim is not specified
+      size: 1000000000 #bytes
+      storageClassName: default
+      accessModes:
+        - ReadWriteOnce
+      annotations:
+        # key: "value"
 
   #######################
   #                     #


### PR DESCRIPTION
Adds support to deploy nats server with Jetstream file storage mounted to a volume. Volume can be created from a PVC or from options defined in `values.yaml`