### PR TITLE
Add NATS Operator chart

### DIFF
--- a/helm/charts/nats-operator/.helmignore
+++ b/helm/charts/nats-operator/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+
+# Chart specific files
+README.md

--- a/helm/charts/nats-operator/Chart.yaml
+++ b/helm/charts/nats-operator/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: nats-operator
+version: 0.7.4
+appVersion: 0.7.4
+description: Nats operator creates/configures/manages nats clusters atop Kubernetes
+keywords:
+- addressing
+- discovery
+- messaging
+- nats
+- operator
+- pubsub
+home: https://github.com/nats-io/nats-operator
+sources:
+- https://github.com/nats-io/nats-operator
+maintainers:
+- name: richerlariviere
+  email: richerlariviere@gmail.com
+icon: https://bitnami.com/assets/stacks/nats/img/nats-stack-110x117.png

--- a/helm/charts/nats-operator/README.md
+++ b/helm/charts/nats-operator/README.md
@@ -1,0 +1,175 @@
+# NATS Operator Helm Chart
+
+NATS is an open-source, cloud-native messaging system. Companies like Apcera,
+Baidu, Siemens, VMware, HTC, and Ericsson rely on NATS for its highly performant
+and resilient messaging capabilities.
+
+## TL;DR
+
+```bash
+$ helm install .
+```
+
+## Introduction
+
+NATS Operator manages [NATS](https://nats.io/) clusters atop
+[Kubernetes](http://kubernetes.io), automating their creation and
+administration. With the NATS Operator you can benefits from the flexibility
+brought by the Kubernetes operator pattern. It means less juggling between
+manifests and a few handy features like automatic configuration reload.
+
+If you want to manage NATS entirely by yourself and have more control over your
+NATS cluster, you can always use the original
+[NATS](https://github.com/helm/charts/tree/master/stable/nats) Helm chart.
+
+## Prerequisites
+
+- Kubernetes 1.8+ (1.12 for some functionality)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release .
+```
+
+The command deploys NATS and the NATS Operator on the Kubernetes cluster in the
+default configuration. The [configuration](#configuration) section lists the
+parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+> **Tip**: If you want to RE-INSTALL the NATS Operator, please ensure you deleted `*.nats.io` custom resource definitions
+> ```shell 
+> $ kubectl delete crd/natsserviceroles.nats.io
+> $ kubectl delete crd/natsclusters.nats.io   
+> ```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+# Delete Helm release
+$ helm delete my-release --purge
+
+# Delete CRDs
+$ kubectl delete crd/natsserviceroles.nats.io
+$ kubectl delete crd/natsclusters.nats.io
+
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the NATS chart and
+their default values.
+
+| Parameter                            | Description                                                                                  | Default                                         |
+| ------------------------------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `rbacEnabled`                                | Switch to enable/disable RBAC for this chart                                                 | `true`                                          |
+| `clusterScoped`                              | Enable cluster scoped installation (read carefully the warnings)                             | `false`                                         |
+| `image.registry`                             | NATS Operator image registry                                                                 | `docker.io`                                     |
+| `image.repository`                           | NATS Operator image name                                                                     | `connecteverything/nats-operator`               |
+| `image.tag`                                  | NATS Operator image tag                                                                      | `0.4.3-v1alpha2`                                |
+| `image.pullPolicy`                           | Image pull policy                                                                            | `Always`                                        |
+| `image.pullSecrets`                          | Specify image pull secrets                                                                   | `nil`                                           |
+| `securityContext.enabled`                    | Enable security context                                                                      | `true`                                          |
+| `securityContext.fsGroup`                    | Group ID for the container                                                                   | `1001`                                          |
+| `securityContext.runAsUser`                  | User ID for the container                                                                    | `1001`                                          |
+| `nodeSelector`                               | Node labels for pod assignment                                                               | `nil`                                           |
+| `tolerations`                                | Toleration labels for pod assignment                                                         | `nil`                                           |
+| `schedulerName`                              | Name of an alternate scheduler                                                               | `nil`                                           |
+| `antiAffinity`                               | Anti-affinity for pod assignment (values: soft or hard)                                      | `soft`                                          |
+| `podAnnotations`                             | Annotations to be added to pods                                                              | `{}`                                            |
+| `podLabels`                                  | Additional labels to be added to pods                                                        | `{}`                                            |
+| `updateStrategy`                             | Replicaset Update strategy                                                                   | `OnDelete`                                      |
+| `rollingUpdatePartition`                     | Partition for Rolling Update strategy                                                        | `nil`                                           |
+| `resources`                                  | CPU/Memory resource requests/limits                                                          | `{}`                                            |
+| `livenessProbe.enabled`                      | Enable liveness probe                                                                        | `true`                                          |
+| `livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                                                     | `30`                                            |
+| `livenessProbe.periodSeconds`                | How often to perform the probe                                                               | `10`                                            |
+| `livenessProbe.timeoutSeconds`               | When the probe times out                                                                     | `5`                                             |
+| `livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                             |
+| `livenessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                             |
+| `readinessProbe.enabled`                     | Enable readiness probe                                                                       | `true`                                          |
+| `readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated                                                    | `5`                                             |
+| `readinessProbe.periodSeconds`               | How often to perform the probe                                                               | `10`                                            |
+| `readinessProbe.timeoutSeconds`              | When the probe times out                                                                     | `5`                                             |
+| `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                             |
+| `readinessProbe.successThreshold`            | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                             |
+| `cluster.create`                             | Create and deploy a NATS Cluster togheter with the operator                                  | `true`                                          |
+| `cluster.name`                               | Name of NATS Cluster                                                                         | `nats-cluster`                                  |
+| `cluster.namespace`                          | Namespace to deploy the NATS Cluster in, only possible if `clusterScoped` is set to `true`   | `nats-io`                                       |
+| `cluster.version`                            | Version of NATS Cluster                                                                      | `1.4.1`                                         |
+| `cluster.size`                               | Number of NATS Cluster nodes                                                                 | `3`                                             |
+| `cluster.annotations`                        | Optional custom annotations to add to Pods in the cluster                                    | `{}`                                            |
+| `cluster.resources`                          | Optional CPU/Memory resource requests/limits to set on Pods in the cluster                   | `{}`                                            |
+| `cluster.auth.enabled`                       | Switch to enable/disable client authentication                                               | `true`                                          |
+| `cluster.auth.enableServiceAccounts`         | Enable ServiceAccounts permissions                                                           | `false`                                         |
+| `cluster.auth.username`                      | Client authentication username                                                               | `true`                                          |
+| `cluster.auth.password`                      | Client authentication password                                                               | `true`                                          |
+| `cluster.auth.users`                         | Allows multi-user authentication of 2 or more user                                           | `[]`                                            |
+| `cluster.auth.defaultPermissions`            | Enable default permissions for users                                                         | `{}`                                            |
+| `cluster.auth.defaultPermissions.publish`    | Default permission for publish requests                                                      | `nil`                                           |
+| `cluster.auth.defaultPermissions.subscribe`  | Default permission for subscribe requests                                                    | `nil`                                           |
+| `cluster.tls.enabled`                        | Enable TLS                                                                                   | `false`                                         |
+| `cluster.tls.serverSecret`                   | Certificates to secure the NATS client connections (type: kubernetes.io/tls)                 | `nil`                                           |
+| `cluster.tls.routesSecret`                   | Certificates to secure the routes. (type: kubernetes.io/tls)                                 | `nil`                                           |
+| `cluster.configReload.enabled`               | Enable configuration reload                                                                  | `false`                                         |
+| `cluster.configReload.registry`              | Reload configuration image registry                                                          | `docker.io`                                     |
+| `cluster.configReload.repository`            | Reload configuration image name                                                              | `connecteverything/nats-server-config-reloader` |
+| `cluster.configReload.tag`                   | Reload configuration image tag                                                               | `0.2.2-v1alpha2`                                |
+| `cluster.configReload.pullPolicy`            | Reload configuration image pull policy                                                       | `IfNotPresent`                                  |
+| `cluster.metrics.enabled`                    | Enable prometheus metrics exporter                                                           | `false`                                         |
+| `cluster.metrics.registry`                   | Prometheus metrics exporter image registry                                                   | `docker.io`                                     |
+| `cluster.metrics.repository`                 | Prometheus metrics exporter image name                                                       | `synadia/prometheus-nats-exporter`              |
+| `cluster.metrics.tag`                        | Prometheus metrics exporter image tag                                                        | `0.1.0`                                         |
+| `cluster.metrics.pullPolicy`                 | Prometheus metrics exporter image pull policy                                                | `IfNotPresent`                                  |
+
+### Example
+
+Here is an example of how to setup a NATS cluster with client authentication.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```bash
+$ helm install --name my-release --set cluster.auth.enabled=true,cluster.auth.username=my-user,cluster.auth.password=T0pS3cr3t .
+```
+
+You can also specify more than 1 user using this way:
+
+```bash
+$ helm install --name my-release --set cluster.auth.enabled=true,cluster.auth.users[0]=my-user,cluster.auth.users[0].password=T0pS3cr3t,cluster.auth.users[1]=my-user-2,cluster.auth.users[1].password=MyS3cr3tP4ssw0rd .
+```
+You can consider editing the default values.yaml as it is easier to manage:
+
+```yaml
+...
+cluster:
+  auth:
+    enabled: true
+
+    # username:
+    # password:
+
+    # values.yaml
+    users:
+      - username: "my-user"
+        password: "T0pS3cr3t"
+      - username: "my-user-2"
+        password: "MyS3cr3tP4ssw0rd"
+...
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example,
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+```bash
+$ helm install --name my-release -f values.yaml .
+```

--- a/helm/charts/nats-operator/config/client-auth.json
+++ b/helm/charts/nats-operator/config/client-auth.json
@@ -1,0 +1,25 @@
+{
+  "users": [
+    {{- if and (.Values.cluster.auth.username) (not .Values.cluster.auth.users) }}
+    {
+      "username": "{{ .Values.cluster.auth.username }}",
+      "password": "{{ .Values.cluster.auth.password }}"
+    }
+    {{- end }}
+
+    {{- if .Values.cluster.auth.users }}
+    {{ $length := len .Values.cluster.auth.users }}
+    {{- range $index, $user := .Values.cluster.auth.users }}
+    {
+      "username": "{{ $user.username }}",
+      "password": "{{ $user.password }}"
+      {{- if $user.permissions }},
+      "permissions": {{ toJson $user.permissions | replace "\\u003e" ">"}}
+      {{- end}}
+    }{{- if lt (add1 $index) $length }},{{ end }}
+    {{- end}}
+    {{- end }}
+  ]{{- if .Values.cluster.auth.defaultPermissions }},
+  "default_permissions": {{ toJson .Values.cluster.auth.defaultPermissions | replace "\\u003e" ">" }}
+  {{- end}}
+}

--- a/helm/charts/nats-operator/crds/customresourcedefinition.yaml
+++ b/helm/charts/nats-operator/crds/customresourcedefinition.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: natsclusters.nats.io
+  annotations:
+    "helm.sh/hook": "crd-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: nats.io
+  names:
+    kind: NatsCluster
+    listKind: NatsClusterList
+    plural: natsclusters
+    shortNames:
+    - nats
+    singular: natscluster
+  scope: Namespaced
+  version: v1alpha2
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: natsserviceroles.nats.io
+  annotations:
+    "helm.sh/hook": "crd-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: nats.io
+  names:
+    kind: NatsServiceRole
+    listKind: NatsServiceRoleList
+    plural: natsserviceroles
+    singular: natsservicerole
+  scope: Namespaced
+  version: v1alpha2

--- a/helm/charts/nats-operator/templates/NOTES.txt
+++ b/helm/charts/nats-operator/templates/NOTES.txt
@@ -1,0 +1,26 @@
+** Please be patient while the chart is being deployed **
+{{- if .Values.clusterScoped }}
+
+** WARNING ! **: You've installed a cluster-scoped NATS Operator. Make sure that there are no other deployments of NATS Operator in the Kubernetes cluster.
+{{- if not (eq .Release.Namespace "nats-io") }}
+
+** WARNING ! **: The namespace must be "nats-io" however you used "{{ .Release.Namespace }}" !
+{{- end }}
+{{- end}}
+
+NATS can be accessed via port 4222 on the following DNS name from within your cluster:
+
+   nats-cluster.{{ .Release.Namespace }}.svc.cluster.local
+
+NATS monitoring service can be accessed via port 8222 on the following DNS name from within your cluster:
+
+    nats-cluster-mgmt.{{ .Release.Namespace }}.svc.cluster.local
+
+To access the Monitoring svc from outside the cluster, follow the steps below:
+
+1. Get the name of a pod from the cluster that was deployed, then use port-forward to connect top it. For example:
+
+    kubectl get pods -l nats_cluster=nats-cluster
+    kubectl port-forward nats-cluster-1 8222
+
+2. Open a browser and access the NATS monitoring browsing to the Monitoring URL

--- a/helm/charts/nats-operator/templates/_helpers.tpl
+++ b/helm/charts/nats-operator/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nats.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nats.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "nats.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/charts/nats-operator/templates/deployment.yaml
+++ b/helm/charts/nats-operator/templates/deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "nats.fullname" . }}
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
+
+  labels:
+    app: {{ template "nats.name" . }}
+    chart: {{ template "nats.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.updateStrategy }}
+    {{- if eq .Values.updateStrategy "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable }}
+        {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "nats.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "nats.name" . }}
+        release: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+        {{ .Values.podLabels}}
+      {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{ .Values.podAnnotations }}
+      {{- end }}
+    spec:
+      {{- if .Values.rbacEnabled }}
+      serviceAccountName: nats-operator
+      {{- end }}
+      containers:
+      - name: nats-operator
+        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy  }}
+        {{- if .Values.clusterScoped }}
+        args:
+        - nats-operator
+        - --feature-gates=ClusterScoped=true
+        {{- end }}
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - name: readyz
+          containerPort: 8080
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: readyz
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: readyz
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10}}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName}}"
+      {{- end }}
+      {{- if eq .Values.antiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nats.name" . }}"
+                  release: {{ .Release.Name | quote }}
+      {{- else if eq .Values.antiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nats.name" . }}"
+                  release: "{{ .Release.Name }}"
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{ .Values.image.pullSecrets}}
+      {{- end }}

--- a/helm/charts/nats-operator/templates/natscluster.yaml
+++ b/helm/charts/nats-operator/templates/natscluster.yaml
@@ -1,0 +1,70 @@
+---
+{{- if .Values.cluster.create }}
+apiVersion: "nats.io/v1alpha2"
+kind: "NatsCluster"
+metadata:
+  name: {{ .Values.cluster.name }}
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
+spec:
+  size: {{ .Values.cluster.size }}
+  version: {{ .Values.cluster.version }}
+
+  pod:
+    {{- if .Values.cluster.annotations }}
+    annotations: {{ .Values.cluster.annotations | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if .Values.cluster.resources }}
+    resources: {{ .Values.cluster.resources | toYaml | nindent 6 }}
+    {{- end }}
+    enableConfigReload: {{ .Values.cluster.configReload.enabled }}
+    reloaderImage: {{ .Values.cluster.configReload.repository }}
+    reloaderImageTag: {{ .Values.cluster.configReload.tag }}
+    reloaderImagePullPolicy: {{ .Values.cluster.configReload.pullPolicy }}
+    {{- if .Values.cluster.configReload.resources }}
+    reloaderResources: {{ .Values.cluster.configReload.resources | toYaml | nindent 6 }}
+    {{- end }}
+    enableMetrics: {{ .Values.cluster.metrics.enabled }}
+    metricsImage: {{ .Values.cluster.metrics.repository }}
+    metricsImageTag: {{ .Values.cluster.metrics.tag }}
+    metricsImagePullPolicy: {{ .Values.cluster.metrics.pullPolicy }}
+  {{- if .Values.cluster.auth.enabled }}
+  auth:
+    enableServiceAccounts: {{ .Values.cluster.auth.enableServiceAccounts }}
+    clientsAuthSecret: {{ .Values.cluster.name }}-clients-auth
+    clientsAuthTimeout: 5
+  {{- end }}
+
+  {{- if .Values.cluster.tls.enabled }}
+  tls:
+    # Certificates to secure the NATS client connections:
+    serverSecret: {{ .Values.cluster.tls.serverSecret }}
+
+    # Certificates to secure the routes.
+    routesSecret: {{ .Values.cluster.tls.routesSecret }}
+  {{- end }}
+---
+{{- if and .Values.cluster.metrics.enabled .Values.cluster.metrics.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.cluster.name }}
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
+  labels:
+    app: nats
+    nats_cluster: {{ .Values.cluster.name }}
+    prometheus: {{ .Values.cluster.metrics.servicemonitor.prometheusInstance }}
+spec:
+  jobLabel: nats-{{ .Values.cluster.name }}
+  selector:
+    matchLabels:
+      app: nats
+      nats_cluster: {{ .Values.cluster.name }}
+  endpoints:
+  - port: metrics
+    interval: 60s
+{{- end }}
+{{- end }}

--- a/helm/charts/nats-operator/templates/rbac.yaml
+++ b/helm/charts/nats-operator/templates/rbac.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.rbacEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-io-nats-operator-crd
+rules:
+# Allow creating CRDs
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "create", "update", "watch"]
+# Allow all actions on NatsClusters
+- apiGroups:
+  - nats.io
+  resources:
+  - natsclusters
+  - natsserviceroles
+  verbs: ["*"]
+# Allowed actions on Pods
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-io:nats-operator-crd-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-io-nats-operator-crd
+subjects:
+- kind: ServiceAccount
+  name: nats-operator
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.clusterScoped }}
+kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
+metadata:
+  name: nats-io-nats-operator
+rules:
+# Allowed actions on Pods
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
+
+# Allowed actions on Services
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
+
+# Allowed actions on Secrets
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
+
+# Allow all actions on some special subresources
+- apiGroups: [""]
+  resources:
+  - pods/exec
+  - pods/log
+  - serviceaccounts/token
+  - events
+  verbs: ["*"]
+
+# Allow listing Namespaces and ServiceAccounts
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - serviceaccounts
+  verbs: ["list", "get", "watch"]
+
+# Allow actions on Endpoints
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.clusterScoped }}
+kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
+metadata:
+  name: nats-io-nats-operator-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.clusterScoped }}
+  kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
+  name: nats-io-nats-operator
+subjects:
+- kind: ServiceAccount
+  name: nats-operator
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/charts/nats-operator/templates/secret.yaml
+++ b/helm/charts/nats-operator/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.cluster.create .Values.cluster.auth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.cluster.name }}-clients-auth
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
+type: Opaque
+data:
+  clients-auth.json: {{ (tpl (.Files.Get "config/client-auth.json") . ) | b64enc }}
+{{- end }}

--- a/helm/charts/nats-operator/templates/serviceaccount.yaml
+++ b/helm/charts/nats-operator/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.rbacEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-operator
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
+{{- end }}

--- a/helm/charts/nats-operator/values.yaml
+++ b/helm/charts/nats-operator/values.yaml
@@ -1,0 +1,191 @@
+## Specify if RBAC authorization is enabled.
+## ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+##
+rbacEnabled: true
+
+## Operator scope
+## NOTE: If true
+## * Make sure that no othe NATS operator is running in the cluster
+## * The Release namespace must be "nats-io"
+clusterScoped: false
+
+## Set default Replica Coint for the Operator
+replicaCount: 1
+
+image:
+# connecteverything/nats-operator:0.7.4
+  registry: docker.io
+  repository: connecteverything/nats-operator
+  tag: 0.7.4
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: Always
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+## NATS Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
+## NATS Node selector and tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations
+##
+# nodeSelector: {}
+# tolerations: []
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## Pods anti-affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+## Possible values: soft, hard
+antiAffinity: soft
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Additional pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Update strategy, can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+
+updateStrategy: RollingUpdate
+# rollingUpdateMaxSurge: 25%
+# rollingUpdateMaxUnavailable: "25% 
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+# limits:
+#   cpu: 100m
+#   memory: 64Mi
+# requests:
+#   cpu: 10m
+#   memory: 64Mi
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+cluster:
+  ## Create a NATS Cluster when installing the operator
+  create: true
+
+  name: nats-cluster
+
+  ## Choose namespace for cluster deployment if clusterScoped is set to true
+  namespace: "nats-io"
+
+  ## Nats version
+  ## Image tags are listed here: https://hub.docker.com/_/nats?tab=tags
+  version: 1.4.1
+
+  ## Cluster Size
+  size: 3
+
+  ## Optional custom annotations to add to Pods in the cluster
+  annotations: {}
+
+  resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+  ## Client Authentication
+  ## ref: https://github.com/nats-io/gnatsd#authentication
+  ## note: token not supported only user/password will work with this chart version
+  ##
+  auth:
+    enabled: true
+
+    # NOTE: Only supported in Kubernetes v1.12+ clusters having the "TokenRequest" API enabled.
+    enableServiceAccounts: false
+
+    ## This is where you enter a username/password for 1 user
+    username: "my-user"
+    password: "T0pS3cr3t"
+
+    ## This is a where you can specify 2 or more users
+    users: []
+    #- username: "another-user-1"
+    #  password: "another-password-1"
+    #- username: "another-user-2"
+    #  password: "another-password-2"
+    #  permissions:
+    #    publish: ["hello.*"]
+    #    subscribe: ["hello.world"]
+
+    defaultPermissions: {}
+      #publish: ["SANDBOX.*"]
+      #subscribe: ["PUBLIC.>"]
+
+  tls:
+    enabled: false
+    #serverSecret:
+    #routesSecret:
+
+  ## Configuration Reload
+  ## NOTE: Only supported in Kubernetes v1.12+.
+  configReload:
+    enabled: false
+    registry: "docker.io"
+    repository: "connecteverything/nats-server-config-reloader"
+    tag: "0.2.2-v1alpha2"
+    pullPolicy: "IfNotPresent"
+    resources: {}
+    # limits:
+    #   cpu: 50m
+    #   memory: 32Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
+  ## Prometheus Metrics Exporter
+  ##
+  metrics:
+    enabled: false
+    registry: "docker.io"
+    repository: "synadia/prometheus-nats-exporter"
+    tag: "0.6.2"
+    pullPolicy: "IfNotPresent"
+
+    # Prometheus Operator ServiceMonitor config
+    ##
+    servicemonitor:
+      enabled: false
+      prometheusInstance: default


### PR DESCRIPTION
This adds the NATS Operator chart, copied from the nats-operator repo.

I updated the chart API version and ran `helm lint`. Then I deployed it on a cluster and verified that I was able to connect to NATS.