### PR TITLE
helm: Add support for SI units in JS storage blocks

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -71,7 +71,7 @@ data:
     ###################################
     jetstream {
       {{- if .Values.nats.jetstream.memStorage.enabled }}
-      max_mem: {{- .Values.nats.jetstream.memStorage.size | int }}
+      max_mem: {{- .Values.nats.jetstream.memStorage.size }}
       {{- end }}
 
       {{- if .Values.nats.jetstream.fileStorage.enabled }}
@@ -81,7 +81,7 @@ data:
       {{- if .Values.nats.jetstream.fileStorage.existingClaim }}
       {{- .Values.nats.jetstream.fileStorage.claimStorageSize | int }}
       {{- else }}
-      {{- .Values.nats.jetstream.fileStorage.size | int }}
+      {{- .Values.nats.jetstream.fileStorage.size }}
       {{- end }}
 
       {{- end }}


### PR DESCRIPTION
Using latest nats-server:nightly now can use SI units like in K8S: https://github.com/nats-io/nats-server/pull/1678

```yaml
nats:
  image: synadia/nats-server:nightly

  jetstream:
    enabled: true

    memStorage:
      enabled: true
      size: 2Gi

    fileStorage:
      enabled: true
      storageDirectory: /data/
      size: 1Gi
      storageClassName: default

natsbox:
  enabled: false

```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>