### PR TITLE
Add support for embedded NATS Account Server persistence

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.6.2
+version: 0.7.0
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -387,7 +387,32 @@ data:
     {{- end }}
 
     {{- if eq .Values.auth.resolver.type "full" }}
+
+    {{- if .Values.auth.resolver.configMap }}
     include "accounts/{{ .Values.auth.resolver.configMap.key }}"
+    {{- else }}
+
+    {{- with .Values.auth.resolver }}
+    operator: {{ .operator }}
+
+    system_account: {{ .systemAccount }}
+    {{- end }}
+
+    resolver: {
+      type: full
+      {{- with .Values.auth.resolver }}
+      dir: {{ .store.dir | quote }}
+
+      allow_delete: {{ .allowDelete }}
+
+      interval: {{ .interval | quote }}
+      {{- end }}
+    }
+    {{- end }}
+    {{- end }}
+
+    {{- if .Values.auth.resolver.resolverPreload }}
+    resolver_preload: {{ toRawJson .Values.auth.resolver.resolverPreload }}
     {{- end }}
 
     {{- if eq .Values.auth.resolver.type "URL" }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -56,14 +56,7 @@ spec:
         emptyDir: {}
 
       {{- if and .Values.auth.enabled .Values.auth.resolver }}
-      {{- if eq .Values.auth.resolver.type "memory" }}
-      # Volume with the memory resolver configuration.
-      - name: resolver-volume
-        configMap:
-          name: {{ .Values.auth.resolver.configMap.name }}
-      {{- end }}
-
-      {{- if eq .Values.auth.resolver.type "full" }}
+      {{- if .Values.auth.resolver.configMap }}
       - name: resolver-volume
         configMap:
           name: {{ .Values.auth.resolver.configMap.name }}
@@ -84,7 +77,7 @@ spec:
 
       {{- if and .Values.nats.jetstream.fileStorage.enabled .Values.nats.jetstream.fileStorage.existingClaim }}
       # Persistent volume for jetstream running with file storage option
-      - name: jetstream-volume
+      - name: {{ template "nats.name" . }}-js-pvc
         persistentVolumeClaim:
           claimName: {{ .Values.nats.jetstream.fileStorage.existingClaim | quote }}
       {{- end }}
@@ -249,8 +242,14 @@ spec:
           {{- end }}
 
           {{- if eq .Values.auth.resolver.type "full" }}
+          {{- if .Values.auth.resolver.configMap }}
           - name: resolver-volume
             mountPath: /etc/nats-config/accounts
+          {{- end }}
+          {{- if and .Values.auth.resolver .Values.auth.resolver.store }}
+          - name: nats-jwt-pvc
+            mountPath: {{ .Values.auth.resolver.store.dir }}
+          {{- end }}
           {{- end }}
 
           {{- if eq .Values.auth.resolver.type "URL" }}
@@ -260,7 +259,7 @@ spec:
           {{- end }}
 
           {{- if .Values.nats.jetstream.fileStorage.enabled }}
-          - name: jetstream-volume
+          - name: {{ template "nats.name" . }}-js-pvc
             mountPath: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
           {{- end }}
 
@@ -377,16 +376,34 @@ spec:
         - containerPort: 7777
           name: metrics
       {{ end }}
-  
+
+  volumeClaimTemplates:
+  {{- if eq .Values.auth.resolver.type "full" }}
+  {{- if and .Values.auth.resolver .Values.auth.resolver.store }}
+  #####################################
+  #                                   #
+  #  Account Server Embedded JWT      #
+  #                                   #
+  #####################################
+    - metadata:
+        name: nats-jwt-pvc
+      spec:
+        accessModes: 
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.auth.resolver.store.size }}
+  {{- end }}
+  {{- end }}
+
   {{- if and .Values.nats.jetstream.fileStorage.enabled (not .Values.nats.jetstream.fileStorage.existingClaim) }}
   #####################################
   #                                   #
   #  Jetstream New Persistent Volume  #
   #                                   #
   #####################################
-  volumeClaimTemplates:
     - metadata:
-        name: jetstream-volume
+        name: {{ template "nats.name" . }}-js-pvc
         {{- if .Values.nats.jetstream.fileStorage.annotations }}
         annotations:
         {{- range $key, $value := .Values.nats.jetstream.fileStorage.annotations }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -251,28 +251,62 @@ auth:
   # Public key of the System Account
   # systemAccount:
 
-  # resolver:
-  #   ############################
-  #   #                          #
-  #   # Memory resolver settings #
-  #   #                          #
-  #   ##############################
-  #   # type: memory
-  #   # 
-  #   # Use a configmap reference which will be mounted
-  #   # into the container.
-  #   # 
-  #   # configMap:
-  #   #   name: nats-accounts
-  #   #   key: resolver.conf
-  #  
-  #   ##########################
-  #   #                        #
-  #   #  URL resolver settings #
-  #   #                        #
-  #   ##########################
-  #   # type: URL
-  #   # url: "http://nats-account-server:9090/jwt/v1/accounts/"
+  resolver:
+    # Disables the resolver by default
+    type: none
+
+    ##########################################
+    #                                        #
+    # Embedded NATS Account Server Resolver  #
+    #                                        #
+    ##########################################
+    # type: full
+
+    # If the resolver type is 'full', delete when enabled will rename the jwt.
+    allowDelete: false
+
+    # Interval at which a nats-server with a nats based account resolver will compare
+    # it's state with one random nats based account resolver in the cluster and if needed, 
+    # exchange jwt and converge on the same set of jwt.
+    interval: 2m
+
+    # Operator JWT
+    operator: 
+
+    # System Account Public NKEY
+    systemAccount: 
+
+    # resolverPreload:
+    #   <ACCOUNT>: <JWT>
+
+    # Directory in which the account JWTs will be stored.
+    store:
+      dir: "/accounts/jwt"
+
+      # Size of the account JWT storage.
+      size: 1Gi
+
+    ##############################
+    #                            #
+    # Memory resolver settings   #
+    #                            #
+    ##############################
+    # type: memory
+    # 
+    # Use a configmap reference which will be mounted
+    # into the container.
+    # 
+    # configMap:
+    #   name: nats-accounts
+    #   key: resolver.conf
+   
+    ##########################
+    #                        #
+    #  URL resolver settings #
+    #                        #
+    ##########################
+    # type: URL
+    # url: "http://nats-account-server:9090/jwt/v1/accounts/"
 
 websocket:
   enabled: false


### PR DESCRIPTION
This adds support for persistence of JWTs via the embedded NATS Account Server option:

```yaml
nats:
  image: synadia/nats-server:nightly

auth:
  enabled: true

  resolver:
    type: full

    # Operator named KO
    operator: eyJ0eXAiOiJqd3QiLCJhbG...

    # System Account named SYS
    systemAccount: AC4AX46R...

    # Directory in which the account JWTs will be stored.
    store:
      dir: "/accounts/jwt"

      # Size of the account JWT storage.
      size: 1Gi

    resolverPreload:
      key: value

natsbox:
  enabled: false
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>