### PR TITLE
Add support for NATS and STAN ServiceMonitor namespace

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -449,6 +449,8 @@ exporter:
   enabled: true
   serviceMonitor:
     enabled: true
+    ## Specify the namespace where Prometheus Operator is running
+    # namespace: monitoring
     # ...
 ```
 

--- a/helm/charts/nats/templates/serviceMonitor.yaml
+++ b/helm/charts/nats/templates/serviceMonitor.yaml
@@ -3,6 +3,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "nats.name" . }}
+  {{- if .Values.exporter.serviceMonitor.namespace }}
+  namespace: {{ .Values.exporter.serviceMonitor.namespace }}
+  {{- else }}
   {{- if .Values.exporter.serviceMonitor.labels }}
   labels:
     {{ .Values.exporter.serviceMonitor.labels }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -222,6 +222,9 @@ exporter:
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false
+    ## Specify the namespace where Prometheus Operator is running
+    ##
+    # namespace: monitoring
     labels: {}
     annotations: {}
     path: /metrics

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -517,6 +517,8 @@ exporter:
   enabled: true
   serviceMonitor:
     enabled: true
+    ## Specify the namespace where Prometheus Operator is running
+    # namespace: monitoring
     # ...
 ```
 

--- a/helm/charts/stan/templates/serviceMonitor.yaml
+++ b/helm/charts/stan/templates/serviceMonitor.yaml
@@ -3,6 +3,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "stan.name" . }}
+  {{- if .Values.exporter.serviceMonitor.namespace }}
+  namespace: {{ .Values.exporter.serviceMonitor.namespace }}
+  {{- else }}
   {{- if .Values.exporter.serviceMonitor.labels }}
   labels:
     {{ .Values.exporter.serviceMonitor.labels }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -222,6 +222,9 @@ exporter:
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false
+    ## Specify the namespace where Prometheus Operator is running
+    ##
+    # namespace: monitoring
     labels: {}
     annotations: {}
     path: /metrics


### PR DESCRIPTION
Allow to pass custom namespace to ServiceMonitor, usually where Prometheus Operator is located

Addition for issue #79 and PR #141 