### PR TITLE
Add support for zero values in STAN limits

### DIFF
--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -89,28 +89,28 @@ data:
 
       {{- with .Values.store.limits }}
       store_limits: {
-        {{- if .max_channels }}
-        max_channels: {{ .max_channels }}
+        {{- if kindIs "float64" .max_channels }}
+        max_channels: {{ .max_channels | int }}
         {{- end }}
 
-        {{- if .max_msgs }}
-        max_msgs: {{ .max_msgs }}
+        {{- if kindIs "float64" .max_msgs }}
+        max_msgs: {{ .max_msgs | int }}
         {{- end }}
 
-        {{- if .max_bytes }}
-        max_bytes: {{ .max_bytes }}
+        {{- if kindIs "float64" .max_bytes }}
+        max_bytes: {{ .max_bytes | int }}
         {{- end }}
 
         {{- if .max_age }}
-        max_age: {{ .max_age }}
+        max_age: {{ .max_age | quote }}
         {{- end }}
 
-        {{- if .max_subs }}
-        max_subs: {{ .max_subs }}
+        {{- if kindIs "float64" .max_subs }}
+        max_subs: {{ .max_subs | int }}
         {{- end }}
 
         {{- if .max_inactivity }}
-        max_inactivity: {{ .max_inactivity }}
+        max_inactivity: {{ .max_inactivity | quote }}
         {{- end }}
 
         {{- if .channels }}
@@ -119,24 +119,25 @@ data:
         {{- range $channel, $limits := .channels }}
           {{ $channel }}: {
             {{- if $limits }}
-            {{- with $limits.max_subs }}
-            max_subs: {{ . }}
+
+            {{- if kindIs "float64" .max_subs }}
+            max_subs: {{ $limits.max_subs | int }}
             {{- end }}
 
-            {{- with $limits.max_msgs }}
-            max_msgs: {{ . }}
+            {{- if kindIs "float64" .max_msgs }}
+            max_msgs: {{ $limits.max_msgs | int }}
             {{- end }}
 
-            {{- with $limits.max_bytes }}
-            max_bytes: {{ . }}
+            {{- if kindIs "float64" .max_bytes }}
+            max_bytes: {{ $limits.max_bytes | int }}
             {{- end }}
 
-            {{- with $limits.max_age }}
-            max_age: {{ . }}
+            {{- if $limits.max_age }}
+            max_age: {{ $limits.max_age | quote }}
             {{- end }}
 
-            {{- with $limits.max_inactivity }}
-            max_inactivity: {{ . }}
+            {{- if $limits.max_inactivity }}
+            max_inactivity: {{ $limits.max_inactivity | quote }}
             {{- end }}
           {{- end }}
           }


### PR DESCRIPTION
Proper way to set unlimited values in STAN limits can be done now as follows: 

```yaml
store:
  type: file
  ft:
    group: ns
  limits: 
    max_channels: 0
    max_msgs: 0
    max_subs: 0
    max_bytes: 0
    max_age: "0"
    max_inactivity: "0"
    channels:
      foo:
        max_msgs: 0
        max_subs: 0
        max_bytes: 0
        max_age: "0"
        max_inactivity: "0"
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

Related: https://github.com/helm/helm/issues/3164