### PR TITLE
Fix labels and annotations on STAN's ServiceMonitor

### DIFF
--- a/helm/charts/stan/templates/serviceMonitor.yaml
+++ b/helm/charts/stan/templates/serviceMonitor.yaml
@@ -10,11 +10,15 @@ metadata:
   {{- end }}
   {{- if .Values.exporter.serviceMonitor.labels }}
   labels:
-    {{ .Values.exporter.serviceMonitor.labels }}
+    {{- range $key, $value := .Values.exporter.serviceMonitor.labels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
   {{- end }}
   {{- if .Values.exporter.serviceMonitor.annotations }}
   annotations:
-    {{ .Values.exporter.serviceMonitor.annotations }}
+    {{- range $key, $value := .Values.exporter.serviceMonitor.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
   {{- end }}
 spec:
   endpoints:


### PR DESCRIPTION
Following pattern from #158 
Fixing the same issue with STAN's ServiceMonitor