### PR TITLE
nats chart: Make terminationGracePeriodSeconds overridable

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -41,6 +41,9 @@ nats:
     maxPending: 
     maxPings: 
     lameDuckDuration: 
+
+  # Number of seconds to wait for client connections to end after the pod termination is requested
+  terminationGracePeriodSeconds: 60
 ```
 
 ### Logging

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
       #  NATS Server  #
       #               #
       #################
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.nats.terminationGracePeriodSeconds }}
       containers:
       - name: nats
         image: {{ .Values.nats.image }}
@@ -331,7 +331,10 @@ spec:
               # the same amount as the terminationGracePeriodSeconds to allow
               # the NATS Server to gracefully terminate the client connections.
               #
-              command: ["/bin/sh", "-c", "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"]
+              command:
+              - "/bin/sh"
+              - "-c"
+              - "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep {{ .Values.nats.terminationGracePeriodSeconds }}"
 
       #################################
       #                               #

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -40,6 +40,8 @@ nats:
     maxPings: 
     lameDuckDuration: 
 
+  terminationGracePeriodSeconds: 60
+
   logging:
     debug: 
     trace: 


### PR DESCRIPTION
The default 60 seconds makes it very hard to iterate when using nats for testing purposes.