### PR TITLE
NATS Streaming: Fix docs to reflect min number of replicas with clustering enabled

### DIFF
--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -117,9 +117,11 @@ stan:
   replicas: 2
 ```
 
-Note: in case of using clustering you will always get exactly 3 replicas.
+Note: in case of using clustering, you must set the number of replicas to 3 or more.
 
 ```yaml
+stan:
+  replicas: 3
 store:
   cluster:
     enabled: true


### PR DESCRIPTION
If I enable clustering without setting the replicas (or without setting them to 3 or more), I get the following error:

```
.Values.stan.replicas should be greater or equal to 3 in clustered mode
```