### PR TITLE
Stan chart: Allow "max_bytes" limit to have a suffix or be long

### DIFF
--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -97,8 +97,8 @@ data:
         max_msgs: {{ .max_msgs | int }}
         {{- end }}
 
-        {{- if kindIs "float64" .max_bytes }}
-        max_bytes: {{ .max_bytes | int }}
+        {{- if .max_bytes }}
+        max_bytes: {{ .max_bytes | quote }}
         {{- end }}
 
         {{- if .max_age }}

--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -98,7 +98,7 @@ data:
         {{- end }}
 
         {{- if .max_bytes }}
-        max_bytes: {{ .max_bytes | quote }}
+        max_bytes: {{ .max_bytes }}
         {{- end }}
 
         {{- if .max_age }}


### PR DESCRIPTION
The current code fails when trying to use 1MB or more, even if specified as the integer `1000000` because `| int` converts it to `1e+06`, which is invalid and the pod errors out with:

```
parameter "max_bytes" value is expected to be int64, got string
```

This change allows `max_bytes` to be something like `1MB` or `1000000`.