### PR TITLE
NATS chart: Fix setting of resources

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -512,6 +512,8 @@ nats:
       memory: 6Gi
 ```
 
+No resources are set by default.
+
 #### Annotations
 
 <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations>

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -176,19 +176,8 @@ spec:
       - name: nats
         image: {{ .Values.nats.image }}
         imagePullPolicy: {{ .Values.nats.pullPolicy }}
-        {{- if .Values.nats.resources  }}
         resources:
-          {{- if .Values.nats.requests }}
-          requests:
-            cpu: {{ .Values.nats.resources.requests.cpu }}
-            memory: {{ .Values.nats.resources.requests.memory }}
-          {{- end }}
-          {{- if .Values.nats.limits }}
-          limits:
-            cpu: {{ .Values.nats.resources.limits.cpu }}
-            memory: {{ .Values.nats.resources.limits.memory }}
-          {{- end }}
-        {{- end }}
+          {{- toYaml .Values.nats.resources | nindent 10 }}
         ports:
         - containerPort: 4222
           name: client

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -26,7 +26,9 @@ nats:
 
   # How many seconds should pass before sending a PING
   # to a client that has no activity.
-  pingInterval: 
+  pingInterval:
+
+  resources: {}
 
   # Server settings.
   limits:


### PR DESCRIPTION
The change in d13d5034b9dca5a564c5c4c90291441f39e088ee doesn't work: It has references to the non-existing value `.Values.nats.requests` and also `.Values.nats.limits` (which exists but has a totally different purpose).

I'm making this generic and taking any Kubernetes `resources` value, which is what you tend to see in Kubernetes charts.