### PR TITLE
NATS Chart working as subchart

### DIFF
--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -15,11 +15,11 @@ in the NATS documentation website:
 NATS Box has been deployed into your cluster, you can
 now use the NATS tools within the container as follows:
 
-  kubectl exec -n {{ .Release.Namespace }} -it {{ template "nats.name" . }}-box -- /bin/sh -l
+  kubectl exec -n {{ .Release.Namespace }} -it {{ template "nats.fullname" . }}-box -- /bin/sh -l
 
   nats-box:~# nats-sub test &
   nats-box:~# nats-pub test hi
-  nats-box:~# nc {{ template "nats.name" . }} 4222
+  nats-box:~# nc {{ template "nats.fullname" . }} 4222
 
 {{- end }}
 

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -19,6 +19,33 @@ Expand the name of the chart.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nats.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nats.labels" -}}
+helm.sh/chart: {{ include "nats.chart" . }}
+{{ include "nats.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nats.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nats.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
 
 {{/*
 Return the proper NATS image name

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -2,14 +2,29 @@
 Expand the name of the chart.
 */}}
 {{- define "nats.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{- define "nats.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Return the proper NATS image name
 */}}
 {{- define "nats.clusterAdvertise" -}}
-{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc" (include "nats.name" . ) }}
+{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc" (include "nats.fullname" . ) }}
 {{- end }}
 
 {{/*
@@ -20,4 +35,34 @@ Return the NATS cluster routes.
 {{- range $i, $e := until (.Values.cluster.replicas | int) -}}
 {{- printf "nats://%s-%d.%s.%s.svc:6222," $name $i $name $.Release.Namespace -}}
 {{- end -}}
+{{- end }}
+
+
+{{- define "nats.tlsConfig" -}}
+tls {
+{{- if .cert }}
+    cert_file: {{ .secretPath }}/{{ .secret.name }}/{{ .cert }}
+{{- end }}
+{{- if .key }}
+    key_file:  {{ .secretPath }}/{{ .secret.name }}/{{ .key }}
+{{- end }}
+{{- if .ca }}
+    ca_file: {{ .secretPath }}/{{ .secret.name }}/{{ .ca }}
+{{- end }}
+{{- if .insecure }}
+    insecure: {{ .insecure }}
+{{- end }}
+{{- if .verify }}
+    verify: {{ .verify }}
+{{- end }}
+{{- if .verifyAndMap }}
+    verify_and_map: {{ .verifyAndMap }}
+{{- end }}
+{{- if .curvePreferences }}
+    curve_preferences: {{ .curvePreferences }}
+{{- end }}
+{{- if .timeout }}
+    timeout: {{ .timeout }}
+{{- end }}
+}
 {{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -4,8 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "nats.fullname" . }}-config
   labels:
-    app: {{ include "nats.fullname" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- include "nats.labels" . | nindent 4 }}
 data:
   nats.conf: |
     # PID file shared with configuration reloader.
@@ -28,7 +27,7 @@ data:
     {{- with .Values.nats.tls }}
     {{- $nats_tls := merge (dict) . }}
     {{- $_ := set $nats_tls "secretPath" "/etc/nats-certs/clients" }}
-{{ include "nats.tlsConfig" $nats_tls | indent 4}}
+    {{- include "nats.tlsConfig" $nats_tls | nindent 4}}
     {{- end }}
     {{- end }}
 
@@ -73,7 +72,7 @@ data:
       {{- with .Values.cluster.tls }}
       {{-  $cluster_tls := merge (dict) . }}
       {{- $_ := set $cluster_tls "secretPath" "/etc/nats-certs/cluster" }}
-{{ include "nats.tlsConfig" $cluster_tls | indent 6}}
+      {{- include "nats.tlsConfig" $cluster_tls | nindent 6}}
       {{- end }}
 
       routes = [
@@ -115,7 +114,7 @@ data:
       {{- with .Values.leafnodes.tls }}
       {{-  $leafnode_tls := merge (dict) . }}
       {{- $_ := set $leafnode_tls "secretPath" "/etc/nats-certs/leafnodes" }}
-{{- include "nats.tlsConfig" $leafnode_tls | indent 6}}
+      {{- include "nats.tlsConfig" $leafnode_tls | nindent 6}}
       {{- end }}
 
       remotes: [
@@ -151,7 +150,7 @@ data:
       {{- with .Values.gateway.tls }}
       {{-  $gateway_tls := merge (dict) . }}
       {{- $_ := set $gateway_tls "secretPath" "/etc/nats-certs/gateway" }}
-{{- include "nats.tlsConfig" $gateway_tls | indent 6}}
+      {{- include "nats.tlsConfig" $gateway_tls | nindent 6}}
       {{- end }}
 
       # Gateways array here

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -221,7 +221,7 @@ data:
     {{- end }}
     {{- with .Values.nats.writeDeadline }}
     lame_duck_duration:  {{ . | quote }}
-        {{- end }}
+    {{- end }}
 
     {{- if .Values.websocket.enabled }}
     ##################

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "nats.name" . }}-config
+  name: {{ include "nats.fullname" . }}-config
   labels:
-    app: {{ template "nats.name" . }}
+    app: {{ include "nats.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
   nats.conf: |
@@ -26,40 +26,9 @@ data:
     #                   #
     #####################
     {{- with .Values.nats.tls }}
-    {{ $secretName := .secret.name }}
-    tls {
-       {{- with .cert }}
-       cert_file: /etc/nats-certs/clients/{{ $secretName }}/{{ . }}
-       {{- end }}
-
-       {{- with .key }}
-       key_file: /etc/nats-certs/clients/{{ $secretName }}/{{ . }}
-       {{- end }}
-
-       {{- with .ca }}
-       ca_file: /etc/nats-certs/clients/{{ $secretName }}/{{ . }}
-       {{- end }}
-
-       {{- with .insecure }}
-       insecure: {{ . }}
-       {{- end }}
-
-       {{- with .verify }}
-       verify: {{ . }}
-       {{- end }}
-
-       {{- with .verifyAndMap }}
-       verify_and_map: {{ . }}
-       {{- end }}
-
-       {{- with .curvePreferences }}
-       curve_preferences: {{ . }}
-       {{- end }}
-
-       {{- with .timeout }}
-       timeout: {{ . }}
-       {{- end }}
-    }
+    {{- $nats_tls := merge (dict) . }}
+    {{- $_ := set $nats_tls "secretPath" "/etc/nats-certs/clients" }}
+{{ include "nats.tlsConfig" $nats_tls | indent 4}}
     {{- end }}
     {{- end }}
 
@@ -71,7 +40,7 @@ data:
     ###################################
     jetstream {
       {{- if .Values.nats.jetstream.memStorage.enabled }}
-      max_mem: {{- .Values.nats.jetstream.memStorage.size }}
+      max_mem: {{ .Values.nats.jetstream.memStorage.size }}
       {{- end }}
 
       {{- if .Values.nats.jetstream.fileStorage.enabled }}
@@ -79,7 +48,7 @@ data:
      
       max_file: 
       {{- if .Values.nats.jetstream.fileStorage.existingClaim }}
-      {{- .Values.nats.jetstream.fileStorage.claimStorageSize }}
+      {{- .Values.nats.jetstream.fileStorage.claimStorageSize  }}
       {{- else }}
       {{- .Values.nats.jetstream.fileStorage.size }}
       {{- end }}
@@ -88,7 +57,7 @@ data:
     }
     {{- end }}
 
-    {{ if .Values.cluster.enabled }}
+    {{- if .Values.cluster.enabled }}
     ###################################
     #                                 #
     # NATS Full Mesh Clustering Setup #
@@ -102,44 +71,13 @@ data:
       {{- end }}
 
       {{- with .Values.cluster.tls }}
-      {{ $secretName := .secret.name }}
-      tls {
-         {{- with .cert }}
-         cert_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .key }}
-         key_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .ca }}
-         ca_file: /etc/nats-certs/cluster/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .insecure }}
-         insecure: {{ . }}
-         {{- end }}
-
-         {{- with .verify }}
-         verify: {{ . }}
-         {{- end }}
-
-         {{- with .verifyAndMap }}
-         verify_and_map: {{ . }}
-         {{- end }}
-
-         {{- with .curvePreferences }}
-         curve_preferences: {{ . }}
-         {{- end }}
-
-         {{- with .timeout }}
-         timeout: {{ . }}
-         {{- end }}
-      }
+      {{-  $cluster_tls := merge (dict) . }}
+      {{- $_ := set $cluster_tls "secretPath" "/etc/nats-certs/cluster" }}
+{{ include "nats.tlsConfig" $cluster_tls | indent 6}}
       {{- end }}
 
       routes = [
-        {{ template "nats.clusterRoutes" . }}
+        {{ include "nats.clusterRoutes" . }}
       ]
       cluster_advertise: $CLUSTER_ADVERTISE
 
@@ -175,40 +113,9 @@ data:
       {{- end }}
 
       {{- with .Values.leafnodes.tls }}
-      {{ $secretName := .secret.name }}
-      tls {
-         {{- with .cert }}
-         cert_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .key }}
-         key_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .ca }}
-         ca_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .insecure }}
-         insecure: {{ . }}
-         {{- end }}
-
-         {{- with .verify }}
-         verify: {{ . }}
-         {{- end }}
-
-         {{- with .verifyAndMap }}
-         verify_and_map: {{ . }}
-         {{- end }}
-
-         {{- with .curvePreferences }}
-         curve_preferences: {{ . }}
-         {{- end }}
-
-         {{- with .timeout }}
-         timeout: {{ . }}
-         {{- end }}
-      }
+      {{-  $leafnode_tls := merge (dict) . }}
+      {{- $_ := set $leafnode_tls "secretPath" "/etc/nats-certs/leafnodes" }}
+{{- include "nats.tlsConfig" $leafnode_tls | indent 6}}
       {{- end }}
 
       remotes: [
@@ -242,40 +149,9 @@ data:
       {{ end }}
 
       {{- with .Values.gateway.tls }}
-      {{ $secretName := .secret.name }}
-      tls {
-         {{- with .cert }}
-         cert_file: /etc/nats-certs/gateways/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .key }}
-         key_file: /etc/nats-certs/gateways/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .ca }}
-         ca_file: /etc/nats-certs/gateways/{{ $secretName }}/{{ . }}
-         {{- end }}
-
-         {{- with .insecure }}
-         insecure: {{ . }}
-         {{- end }}
-
-         {{- with .verify }}
-         verify: {{ . }}
-         {{- end }}
-
-         {{- with .verifyAndMap }}
-         verify_and_map: {{ . }}
-         {{- end }}
-
-         {{- with .curvePreferences }}
-         curve_preferences: {{ . }}
-         {{- end }}
-
-         {{- with .timeout }}
-         timeout: {{ . }}
-         {{- end }}
-      }
+      {{-  $gateway_tls := merge (dict) . }}
+      {{- $_ := set $gateway_tls "secretPath" "/etc/nats-certs/gateway" }}
+{{- include "nats.tlsConfig" $gateway_tls | indent 6}}
       {{- end }}
 
       # Gateways array here
@@ -345,7 +221,7 @@ data:
     {{- end }}
     {{- with .Values.nats.writeDeadline }}
     lame_duck_duration:  {{ . | quote }}
-    {{- end }}
+        {{- end }}
 
     {{- if .Values.websocket.enabled }}
     ##################

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ template "nats.name" . }}-box
+  name: {{ template "nats.fullname" . }}-box
   labels:
-    app: {{ template "nats.name" . }}-box
+    app: {{ template "nats.fullname" . }}-box
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   volumes:
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: {{ .Values.natsbox.pullPolicy }}
     env:
     - name: NATS_URL
-      value: {{ template "nats.name" . }}
+      value: {{ template "nats.fullname" . }}
     {{- if .Values.natsbox.credentials }}
     - name: USER_CREDS
       value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "nats.name" . }}
+  name: {{ include "nats.fullname" . }}
   labels:
-    app: {{ template "nats.name" . }}
+    app: {{ include "nats.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   selector:
-    app: {{ template "nats.name" . }}
+    app: {{ include "nats.fullname" . }}
   clusterIP: None
   {{- if .Values.topologyKeys }}
   topologyKeys:

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -4,11 +4,10 @@ kind: Service
 metadata:
   name: {{ include "nats.fullname" . }}
   labels:
-    app: {{ include "nats.fullname" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- include "nats.labels" . | nindent 4 }}
 spec:
   selector:
-    app: {{ include "nats.fullname" . }}
+    {{- include "nats.selectorLabels" . | nindent 4 }}
   clusterIP: None
   {{- if .Values.topologyKeys }}
   topologyKeys:

--- a/helm/charts/nats/templates/serviceMonitor.yaml
+++ b/helm/charts/nats/templates/serviceMonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "nats.name" . }}
+  name: {{ template "nats.fullname" . }}
   {{- if .Values.exporter.serviceMonitor.namespace }}
   namespace: {{ .Values.exporter.serviceMonitor.namespace }}
   {{- else }}
@@ -36,6 +36,6 @@ spec:
     any: true
   selector:
     matchLabels:
-      app: {{ template "nats.name" . }}
+      app: {{ template "nats.fullname" . }}
       chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end }}

--- a/helm/charts/nats/templates/serviceMonitor.yaml
+++ b/helm/charts/nats/templates/serviceMonitor.yaml
@@ -36,6 +36,5 @@ spec:
     any: true
   selector:
     matchLabels:
-      app: {{ template "nats.fullname" . }}
-      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      {{- include "nats.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -4,12 +4,11 @@ kind: StatefulSet
 metadata:
   name: {{ include "nats.fullname" . }}
   labels:
-    app: {{ include "nats.fullname" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- include "nats.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "nats.fullname" . }}
+      {{- include "nats.selectorLabels" . | nindent 6 }}
   {{- if .Values.cluster.enabled }}
   replicas: {{ .Values.cluster.replicas }}
   {{- else }}
@@ -30,8 +29,7 @@ spec:
       {{- end }}
       {{- end }}
       labels:
-        app: {{ include "nats.fullname" . }}
-        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        {{- include "nats.selectorLabels" . | nindent 8 }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -2,20 +2,20 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "nats.name" . }}
+  name: {{ include "nats.fullname" . }}
   labels:
-    app: {{ template "nats.name" . }}
+    app: {{ include "nats.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "nats.name" . }}
+      app: {{ include "nats.fullname" . }}
   {{- if .Values.cluster.enabled }}
   replicas: {{ .Values.cluster.replicas }}
   {{- else }}
   replicas: 1
   {{- end }}
-  serviceName: {{ template "nats.name" . }}
+  serviceName: {{ include "nats.fullname" . }}
   template:
     metadata:
       {{- if or .Values.podAnnotations .Values.exporter.enabled }}
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       {{- end }}
       labels:
-        app: {{ template "nats.name" . }}
+        app: {{ include "nats.fullname" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
 {{- with .Values.imagePullSecrets }}
@@ -49,7 +49,7 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: {{ template "nats.name" . }}-config
+          name: {{ include "nats.fullname" . }}-config
 
       # Local volume shared with the reloader.
       - name: pid
@@ -77,7 +77,7 @@ spec:
 
       {{- if and .Values.nats.jetstream.fileStorage.enabled .Values.nats.jetstream.fileStorage.existingClaim }}
       # Persistent volume for jetstream running with file storage option
-      - name: {{ template "nats.name" . }}-js-pvc
+      - name: {{ include "nats.fullname" . }}-js-pvc
         persistentVolumeClaim:
           claimName: {{ .Values.nats.jetstream.fileStorage.existingClaim | quote }}
       {{- end }}
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CLUSTER_ADVERTISE
-          value: {{ template "nats.clusterAdvertise" . }}
+          value: {{ include "nats.clusterAdvertise" . }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/nats-config
@@ -261,7 +261,7 @@ spec:
           {{- end }}
 
           {{- if .Values.nats.jetstream.fileStorage.enabled }}
-          - name: {{ template "nats.name" . }}-js-pvc
+          - name: {{ include "nats.fullname" . }}-js-pvc
             mountPath: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
           {{- end }}
 
@@ -408,7 +408,7 @@ spec:
   #                                   #
   #####################################
     - metadata:
-        name: {{ template "nats.name" . }}-js-pvc
+        name: {{ include "nats.fullname" . }}-js-pvc
         {{- if .Values.nats.jetstream.fileStorage.annotations }}
         annotations:
         {{- range $key, $value := .Values.nats.jetstream.fileStorage.annotations }}


### PR DESCRIPTION
* Use 'include' instead of template
* Use a fullname that will contain chartname if the current chart is a subchart.
* Extracted TLS config to _helpers.tpl.

ex:
helm install myrelease nats/nats will create ``myrelease``

If nats is a subchart of an umbrella chart called 'myrelease', then nats will be created: ``myrelease-nats``. The template for this change was the default template Helm creates when you run ``helm create <chart>`` 


Note: if using jetstream, I needed to use synadia/nats-server:nightly
image. Not sure if that should be called out somewhere in readme/notes.