### PR TITLE
Fix nats-box notes

### DIFF
--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -15,7 +15,7 @@ in the NATS documentation website:
 NATS Box has been deployed into your cluster, you can
 now use the NATS tools within the container as follows:
 
-  kubectl exec -n {{ .Release.Namespace }} -it {{ template "nats.name" . }}-box -- /bin/sh -l
+  kubectl exec -n {{ .Release.Namespace }} -it deployment/{{ template "nats.name" . }}-box -- /bin/sh -l
 
   nats-box:~# nats-sub test &
   nats-box:~# nats-pub test hi


### PR DESCRIPTION
Currently, the post install notes for nats-box are wrong. This adds the
correct command needed to exec into a nats-box container.