### PR TITLE
add nkey_seed_file option and others

### DIFF
--- a/helm/charts/stan/Chart.yaml
+++ b/helm/charts/stan/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - replay
   - statefulset
   - cncf
-version: 0.7.4
+version: 0.7.5
 maintainers:
   - name: Waldemar Quevedo
     github: https://github.com/wallyqs

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -591,8 +591,13 @@ store:
 
 stan:
   logging:
-   debug: true
-   trace: true
+    debug: true
+    trace: true
+   
+  auth:
+    enabled: true
+    username: stan
+    password: stan
 
 nats:
   logging:
@@ -604,8 +609,6 @@ auth:
   systemAccount: SYS
 
   basic:
-    noAuthUser: stan
-
     accounts: 
       STAN:
         imports: []

--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -36,21 +36,21 @@ data:
       {{- end }}
 
       {{- if .Values.stan.credentials }}
-        credentials: "/etc/stan-creds/{{ .Values.stan.credentials.secret.key }}"
+      credentials: "/etc/stan-creds/{{ .Values.stan.credentials.secret.key }}"
       {{- end }}
 
       {{- if .Values.stan.auth.enabled }}
       {{- if (and .Values.stan.auth.username .Values.stan.auth.password) }}
-        username: {{ .Values.stan.auth.username }}
-        password: {{ .Values.stan.auth.password }}
+      username: {{ .Values.stan.auth.username }}
+      password: {{ .Values.stan.auth.password }}
       {{- end }}
 
       {{- if .Values.stan.auth.token }}
-        token: {{ .Values.stan.auth.token }}
+      token: {{ .Values.stan.auth.token }}
       {{- end }}
 
       {{- if .Values.stan.auth.nkey_seed_file }}
-        nkey_seed_file: "/etc/nkey_seed_file/{{ .Values.stan.auth.nkey_seed_file.secret.key }}"
+      nkey_seed_file: "/etc/nkey_seed_file/{{ .Values.stan.auth.nkey_seed_file.secret.key }}"
       {{- end }}
       {{- end }}
 

--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -39,6 +39,21 @@ data:
         credentials: "/etc/stan-creds/{{ .Values.stan.credentials.secret.key }}"
       {{- end }}
 
+      {{- if .Values.stan.auth.enabled }}
+      {{- if and (.Values.stan.auth.username .Values.stan.auth.password) }}
+        username: {{ .Values.stan.auth.username }}
+        password: {{ .Values.stan.auth.password }}
+      {{- end }}
+
+      {{- if .Values.stan.auth.token }}
+        token: {{ .Values.stan.auth.token }}
+      {{- end }}
+
+      {{- if .Values.stan.auth.nkey_seed_file }}
+        nkey_seed_file: "/etc/nkey_seed_file/{{ .Values.stan.auth.nkey_seed_file.secret.key }}"
+      {{- end }}
+      {{- end }}
+
       {{- if and .Values.stan.tls.enabled .Values.stan.tls.secretName }}
       tls: {{ mustToJson .Values.stan.tls.settings }}
       {{- end }}

--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
       {{- end }}
 
       {{- if .Values.stan.auth.enabled }}
-      {{- if and (.Values.stan.auth.username .Values.stan.auth.password) }}
+      {{- if (and .Values.stan.auth.username .Values.stan.auth.password) }}
         username: {{ .Values.stan.auth.username }}
         password: {{ .Values.stan.auth.password }}
       {{- end }}

--- a/helm/charts/stan/templates/configmap.yaml
+++ b/helm/charts/stan/templates/configmap.yaml
@@ -49,8 +49,8 @@ data:
       token: {{ .Values.stan.auth.token }}
       {{- end }}
 
-      {{- if .Values.stan.auth.nkey_seed_file }}
-      nkey_seed_file: "/etc/nkey_seed_file/{{ .Values.stan.auth.nkey_seed_file.secret.key }}"
+      {{- if .Values.stan.auth.nkeySeedFile }}
+      nkey_seed_file: "/etc/nkey-seed-file"
       {{- end }}
       {{- end }}
 

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -68,6 +68,11 @@ spec:
         secret:
           secretName: {{ .Values.stan.credentials.secret.name }}
       {{- end }}
+      {{- if .Values.stan.auth.nkey_seed_file }}
+      - name: stan-sys-nkey-seed-file
+        secret:
+          secretName: {{ .Values.stan.auth.nkey_seed_file.secret.name }}
+      {{- end }}
 
       # Local volume shared with the reloader.
       - name: pid
@@ -170,6 +175,10 @@ spec:
           {{- if .Values.stan.credentials }}
           - name: stan-sys-creds
             mountPath: /etc/stan-creds
+          {{- end }}
+          {{- if .Values.stan.auth.nkey_seed_file }}
+          - name: stan-sys-nkey-seed-file
+            mountPath: /etc/nkey_seed_file
           {{- end }}
           - name: pid
             mountPath: /var/run/stan

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -68,10 +68,10 @@ spec:
         secret:
           secretName: {{ .Values.stan.credentials.secret.name }}
       {{- end }}
-      {{- if .Values.stan.auth.nkey_seed_file }}
+      {{- if .Values.stan.auth.nkeySeedFile }}
       - name: stan-sys-nkey-seed-file
         secret:
-          secretName: {{ .Values.stan.auth.nkey_seed_file.secret.name }}
+          secretName: {{ .Values.stan.auth.nkeySeedFile.secret.name }}
       {{- end }}
 
       # Local volume shared with the reloader.
@@ -176,9 +176,10 @@ spec:
           - name: stan-sys-creds
             mountPath: /etc/stan-creds
           {{- end }}
-          {{- if .Values.stan.auth.nkey_seed_file }}
+          {{- if .Values.stan.auth.nkeySeedFile }}
           - name: stan-sys-nkey-seed-file
-            mountPath: /etc/nkey_seed_file
+            mountPath: /etc/nkey-seed-file
+            subPath: {{ .Values.stan.auth.nkeySeedFile.secret.key }}
           {{- end }}
           - name: pid
             mountPath: /var/run/stan

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -44,7 +44,7 @@ stan:
   #    key: sys.creds
 
   auth:
-    enabled: false
+    enabled: true
 
     # Username/password is used to connect to a NATS Server when authentication with multiple users is enabled
     # username:

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -44,7 +44,7 @@ stan:
   #    key: sys.creds
 
   auth:
-    enabled: true
+    enabled: false
 
     # Username/password is used to connect to a NATS Server when authentication with multiple users is enabled
     # username:

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -43,6 +43,22 @@ stan:
   #    name: nats-sys-creds
   #    key: sys.creds
 
+  auth:
+    enabled: false
+
+    # Username/password is used to connect to a NATS Server when authentication with multiple users is enabled
+    # username:
+    # password:
+
+    # Authentication token if the NATS Server requires a token
+    # token:
+
+    # Secret to an NKey seed file if NKey authentication is used
+    # nkey_seed_file:
+    #   secret:
+    #     name:
+    #     key:
+
 nameOverride: ""
 imagePullSecrets: []
 serviceAccountName: ""

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -54,7 +54,13 @@ stan:
     # token:
 
     # Secret to an NKey seed file if NKey authentication is used
-    # nkey_seed_file:
+
+    # Format:
+    # -----BEGIN USER NKEY SEED-----
+    # SU<rest of the seed>
+    # ------END USER NKEY SEED------
+
+    # nkeySeedFile:
     #   secret:
     #     name:
     #     key:

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -4,7 +4,7 @@
 #                                #
 ##################################
 stan:
-  image: nats-streaming:0.19.0
+  image: nats-streaming:0.20.0
   pullPolicy: IfNotPresent
   replicas: 1
 
@@ -262,7 +262,7 @@ exporter:
 #                                                                               #
 #################################################################################
 nats:
-  image: nats:2.1.7-alpine3.11
+  image: nats:2.1.9-alpine3.12
   pullPolicy: IfNotPresent
 
   # Toggle whether to enable external access.


### PR DESCRIPTION
I think some options missing in the `helm` chart make it difficult to properly configure NATS/STAN.