### PR TITLE
Fix nats-box deployment yaml

### DIFF
--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -8,19 +8,6 @@ metadata:
     app: {{ include "nats.fullname" . }}-box
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
-  volumes:
-  {{- if .Values.natsbox.credentials }}
-  - name: nats-sys-creds
-    secret:
-      secretName: {{ .Values.natsbox.credentials.secret.name }}
-  {{- end }}
-  {{- with .Values.nats.tls }}
-  {{ $secretName := .secret.name }}
-  - name: {{ $secretName }}-clients-volume
-    secret:
-      secretName: {{ $secretName }}
-  {{- end }}
-
   replicas: 1
   selector:
     matchLabels:
@@ -30,6 +17,19 @@ spec:
       labels:
         app: {{ include "nats.fullname" . }}-box
     spec:
+      volumes:
+      {{- if .Values.natsbox.credentials }}
+      - name: nats-sys-creds
+        secret:
+          secretName: {{ .Values.natsbox.credentials.secret.name }}
+      {{- end }}
+      {{- with .Values.nats.tls }}
+      {{ $secretName := .secret.name }}
+      - name: {{ $secretName }}-clients-volume
+        secret:
+          secretName: {{ $secretName }}
+      {{- end }}
+
       containers:
       - name: nats-box
         image: {{ .Values.natsbox.image }}


### PR DESCRIPTION
 Volumes section in not at the correct position, so when credential or tls is enabled, helm deployment fails with 

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec): unknown field "volumes" in io.k8s.api.apps.v1.DeploymentSpec
```

To reproduce, enable tls of nats in values.yaml