### PR TITLE
feat: nats and stan container securityContext.

### DIFF
--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -29,11 +29,18 @@ spec:
         secret:
           secretName: {{ $secretName }}
       {{- end }}
-
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
       - name: nats-box
         image: {{ .Values.natsbox.image }}
         imagePullPolicy: {{ .Values.natsbox.pullPolicy }}
+        {{- if .Values.natsbox.securityContext }}
+        securityContext:
+        {{- .Values.natsbox.securityContext | toYaml | nindent 10 }}
+        {{- end }}
         env:
         - name: NATS_URL
           value: {{ template "nats.fullname" . }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -164,6 +164,10 @@ spec:
               fieldPath: spec.nodeName
         image: {{ .Values.bootconfig.image }}
         imagePullPolicy: {{ .Values.bootconfig.pullPolicy }}
+        {{- if .Values.bootconfig.securityContext }}
+        securityContext:
+        {{- .Values.bootconfig.securityContext | toYaml | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /etc/nats-config/advertise
           name: advertiseconfig
@@ -180,6 +184,10 @@ spec:
       - name: nats
         image: {{ .Values.nats.image }}
         imagePullPolicy: {{ .Values.nats.pullPolicy }}
+        {{- if .Values.nats.securityContext }}
+        securityContext:
+        {{- .Values.nats.securityContext | toYaml | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.nats.resources | nindent 10 }}
         ports:
@@ -351,6 +359,10 @@ spec:
       - name: reloader
         image: {{ .Values.reloader.image }}
         imagePullPolicy: {{ .Values.reloader.pullPolicy }}
+        {{- if .Values.reloader.securityContext }}
+        securityContext:
+        {{- .Values.reloader.securityContext | toYaml | nindent 10 }}
+        {{- end }}
         command:
          - "nats-server-config-reloader"
          - "-pid"
@@ -373,6 +385,10 @@ spec:
       - name: metrics
         image: {{ .Values.exporter.image }}
         imagePullPolicy: {{ .Values.exporter.pullPolicy }}
+        {{- if .Values.exporter.securityContext }}
+        securityContext:
+        {{- .Values.exporter.securityContext | toYaml | nindent 10 }}
+        {{- end }}
         args:
         - -connz
         - -routez

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -7,6 +7,9 @@ nats:
   image: nats:2.1.9-alpine3.12
   pullPolicy: IfNotPresent
 
+  # securityContext for the nats container
+  securityContext: {}
+
   # Toggle whether to enable external access.
   # This binds a host port for clients, gateways and leafnodes.
   externalAccess: false
@@ -207,6 +210,7 @@ gateway:
 bootconfig:
   image: connecteverything/nats-boot-config:0.5.2
   pullPolicy: IfNotPresent
+  securityContext: {}
 
 # NATS Box
 #
@@ -216,6 +220,7 @@ natsbox:
   enabled: true
   image: synadia/nats-box:0.4.0
   pullPolicy: IfNotPresent
+  securityContext: {}
 
   # credentials:
   #   secret:
@@ -227,12 +232,14 @@ reloader:
   enabled: true
   image: connecteverything/nats-server-config-reloader:0.6.0
   pullPolicy: IfNotPresent
+  securityContext: {}
 
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
   image: synadia/prometheus-nats-exporter:0.5.0
   pullPolicy: IfNotPresent
+  securityContext: {}
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -104,6 +104,10 @@ spec:
         ####################
         - name: stan
           image: {{ .Values.stan.image }}
+          {{- if .Values.stan.securityContext }}
+          securityContext:
+          {{- .Values.stan.securityContext | toYaml | nindent 12 }}
+          {{- end }}
           args:
           - -sc
           - /etc/stan-config/stan.conf
@@ -207,6 +211,10 @@ spec:
         ######################
         - name: backup
           image: amazon/aws-cli
+          {{- if .Values.store.backup.securityContext }}
+          securityContext:
+          {{- .Values.store.backup.securityContext | toYaml | nindent 12 }}
+          {{- end }}
           command: ["/bin/sh", "-c"]
           args:
           - {{ toYaml .Values.store.backup.backupContainerScript | indent 12 }}
@@ -260,6 +268,10 @@ spec:
         #################################
         - name: metrics
           image: {{ .Values.exporter.image }}
+          {{- if .Values.exporter.securityContext }}
+          securityContext:
+          {{- .Values.exporter.securityContext | toYaml | nindent 12 }}
+          {{- end }}
           args:
           - -connz
           - -routez

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -8,6 +8,10 @@ stan:
   pullPolicy: IfNotPresent
   replicas: 1
 
+  # securityContext for the stan container
+  securityContext: {}
+
+
   # Cluster name, generated into a name from the
   # release name by default.
   clusterID:
@@ -202,6 +206,7 @@ store:
 
   backup:
     enabled: false
+    securityContext: {}
     sleepTime: 3600
     s3Path: ""
     # To use backup functionality, you are required to either create a secret with the name you define here, or provide an instance profile.
@@ -241,6 +246,7 @@ exporter:
   enabled: true
   image: synadia/prometheus-nats-exporter:0.6.2
   pullPolicy: IfNotPresent
+  securityContext: {}
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false
@@ -407,6 +413,7 @@ reloader:
   enabled: false
   image: connecteverything/nats-server-config-reloader:0.6.0
   pullPolicy: IfNotPresent
+  securityContext: {}
 
 # Authentication setup
 auth:


### PR DESCRIPTION
Add the ability to set the securityContext for the containers in the nats and stan helm chart.
This is in addition to the Pod securityContext which is already available to be set.