### PR TITLE
Expose websocket port in NATS service

### DIFF
--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -20,6 +20,10 @@ spec:
      {{- .Values.topologyKeys | toYaml | nindent 4 }}
   {{- end }}
   ports:
+  {{- if .Values.websocket.enabled }}
+  - name: websocket
+    port: {{ .Values.websocket.port }}
+  {{- end }}
   - name: client
     port: 4222
   - name: cluster


### PR DESCRIPTION
The nats service object in the NATS helm chart was not exposing the websocket port when websocket is enabled.  This adds the port.