### PR TITLE
Add topology spread constraints and PDB for NATS helm chart (#217)

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.8.2
+version: 0.8.3
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/pdb.yaml
+++ b/helm/charts/nats/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podDisruptionBudget }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+  name: {{ include "nats.fullname" . }}
+  labels:
+    {{- include "nats.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+          {{- include "nats.selectorLabels" . | nindent 6 }}
+{{- end }}
+

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -47,7 +47,22 @@ spec:
 {{- end }}
 {{- with .Values.affinity }}
       affinity:
-{{- toYaml  . | nindent 8 }}
+{{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range .Values.topologySpreadConstraints }}
+      {{- if and .maxSkew .topologyKey }}
+      - maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        {{- if .whenUnsatisfiable }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        {{- end }}
+        labelSelector:
+          matchLabels:
+            {{- include "nats.selectorLabels" $ | nindent 12 }}
+      {{- end}}
+      {{- end }}
 {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -126,10 +126,23 @@ priorityClassName: null
 # ref: https://kubernetes.io/docs/concepts/services-networking/service-topology/
 topologyKeys: []
 
+# Pod Topology Spread Constraints
+# ref https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: zone
+#   whenUnsatisfiable: DoNotSchedule
+
 # Annotations to add to the NATS pods
 # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}
 # key: "value"
+
+## Define a Pod Disruption Budget for the stateful set
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget: null
+  # minAvailable: 1
+  # maxUnavailable: 1
 
 # Annotations to add to the NATS StatefulSet
 statefulSetAnnotations: {}


### PR DESCRIPTION
This adds topology spread constraints and pod disruption budgets. We have been using these for critical deployments.
(Also made the affinity value templated)