### PR TITLE
Adds Statefulset LivenessProbe (disabled by default)

### DIFF
--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -164,6 +164,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          {{- with .Values.livenessProbe.probe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
 
           volumeMounts:
           {{- with .Values.nats.tls }}

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -97,6 +97,16 @@ readinessProbe:
     port: monitor
   timeoutSeconds: 2
 
+# Liveness probe to determine when nats-streaming is ready
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  enabled: false
+  probe:
+    httpGet:
+      path: /
+      port: monitor
+    timeoutSeconds: 2
+
 # Readiness probe to determine when nats-streaming cluster is ready.
 # Overrides the readinessProbe in case present.
 # NOTE: Only works with the nats-streaming alpine image.

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -97,16 +97,6 @@ readinessProbe:
     port: monitor
   timeoutSeconds: 2
 
-# Liveness probe to determine when nats-streaming is ready
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  enabled: false
-  probe:
-    httpGet:
-      path: /
-      port: monitor
-    timeoutSeconds: 2
-
 # Readiness probe to determine when nats-streaming cluster is ready.
 # Overrides the readinessProbe in case present.
 # NOTE: Only works with the nats-streaming alpine image.
@@ -118,6 +108,16 @@ clusterReadinessProbe:
       command: ["/bin/sh", "-c", "n=$(($STAN_REPLICAS-1)); for i in `seq 0 $n`; do wget -qO- $STAN_SERVICE_NAME-$i.$STAN_SERVICE_NAME:8222/streaming/serverz 2> /dev/null > /dev/null; done; if [[ $? -ne 0 ]]; then wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Candidate\\|Follower\\|Leader\\)'; else wget -qO- 127.0.0.1:8222/streaming/serverz | grep role | awk '{print $2}' | grep '\\(Follower\\|Leader\\)'; fi;"]
     initialDelaySeconds:
     periodSeconds: 10
+
+# Liveness probe to determine when nats-streaming is alive
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  enabled: false
+  probe:
+    httpGet:
+      path: /
+      port: monitor
+    timeoutSeconds: 2
 
 ###########################
 #                         #


### PR DESCRIPTION
Some teams (mine included) require things like resource limits and liveness/readiness probes to be set. Instead of requiring teams to fork the helm charts and customize them, this MR adds a liveness probe to the statefulset. It is disabled by default to not cause issues with existing implementations.

Validated with `helm template --debug -f values.yaml .` along with ensuring `readinessProbe` and `clusterReadinessProbe` remained unaffected.