### PR TITLE
Support setting the securityContext

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -108,8 +108,8 @@ imagePullSecrets: []
 
 # Toggle whether to use setup a Pod Security Context
 # ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-securityContext: null
-# securityContext: null
+securityContext: {}
+# securityContext: 
 #   fsGroup: 1000
 #   runAsUser: 1000
 #   runAsNonRoot: true


### PR DESCRIPTION
The Helm chart does not allow to set the securityContext because its default value is null. 
You get the following warning by Helm `coalesce.go:160: warning: skipped value for securityContext: Not a table.`

Fix: Use an empty object.