### PR TITLE
Remove uneeded else statement from configmap

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -256,8 +256,6 @@ data:
       {{- else }}
       no_tls: {{ .Values.websocket.noTLS }}
       {{- end }}
-      {{- else }}
-      no_tls: {{ .Values.websocket.noTLS }}
     }
     {{- end }}
 


### PR DESCRIPTION
This fixes an misconfigured configmap. Running helm template with the default values file produces:

```
data:
  nats.conf: |
    # PID file shared with configuration reloader.
    pid_file: "/var/run/nats/nats.pid"

    ###############
    #             #
    # Monitoring  #
    #             #
    ###############
    http: 8222
    server_name: $POD_NAME
      no_tls: 
    }
```

Note the `no_tls` and closing curly brace. This PR removes that so that the configmap is generated correctly. 