### PR TITLE
Support setting resources for metrics exporter

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -391,6 +391,8 @@ spec:
       - name: metrics
         image: {{ .Values.exporter.image }}
         imagePullPolicy: {{ .Values.exporter.pullPolicy }}
+        resources:
+          {{- toYaml .Values.exporter.resources | nindent 10 }}
         args:
         - -connz
         - -routez

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -250,6 +250,7 @@ exporter:
   enabled: true
   image: natsio/prometheus-nats-exporter:0.7.0
   pullPolicy: IfNotPresent
+  resources: {}
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
I find some platforms (GKE Autopilot) will force setting resources. It will inject platform default settings if user don't specify resources. This at least let people customize resources themselves.