### PR TITLE
Nats-operator helm chart to output podAnnotations and podLabels as yaml

### DIFF
--- a/helm/charts/nats-operator/templates/deployment.yaml
+++ b/helm/charts/nats-operator/templates/deployment.yaml
@@ -30,11 +30,11 @@ spec:
         app: {{ template "nats.name" . }}
         release: {{ .Release.Name }}
       {{- if .Values.podLabels }}
-        {{ .Values.podLabels}}
+{{ toYaml .Values.podLabels | indent 8 }}
       {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
-        {{ .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
       {{- if .Values.rbacEnabled }}


### PR DESCRIPTION
There is currently an issue when you try to use `podAnnotations` and `podLabels` in the values file to add extra pod `labels` and `annotations`.

```
podAnnotations:
  my.annotation: "My Annotation"

podLabels:
  mylabel: "My Label"
```

Currently, helm will render annotations as a map object in the template.
```
annotations:
  map[my.annotation:My Annotation]
```

Whereas it will fail to render the template with a `podLabel` set with...
```
Error: YAML parse error on nats-operator/templates/deployment.yaml: error converting YAML to JSON: yaml: line 28: could not find expected ':'
```

I believe this needs to be updated to ensure the value is output in the template as yaml using the `toYaml` and `indent` functions to ensure that the template renders these correctly.
```
annotations:
  my.annotation: My Annotation

labels:
  mylabel: My Label
```

Referencing this related issue https://github.com/nats-io/k8s/issues/216