### PR TITLE
Added recommended kubernetes labels to nats-operator Helm Chart

### DIFF
--- a/helm/charts/nats-operator/templates/_helpers.tpl
+++ b/helm/charts/nats-operator/templates/_helpers.tpl
@@ -19,3 +19,26 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "nats.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nats.labels" -}}
+app.kubernetes.io/name: {{ template "nats.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "operator"
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+helm.sh/chart: {{ include "nats.chart" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nats.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nats.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "operator"
+{{- end -}}

--- a/helm/charts/nats-operator/templates/deployment.yaml
+++ b/helm/charts/nats-operator/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
 {{- end }}
 
   labels:
+    {{- include "nats.labels" . | nindent 4 }}
     app: {{ template "nats.name" . }}
     chart: {{ template "nats.chart" . }}
     release: {{ .Release.Name }}
@@ -27,14 +28,15 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "nats.selectorLabels" . | nindent 8 }}
         app: {{ template "nats.name" . }}
         release: {{ .Release.Name }}
       {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
       {{- if .Values.rbacEnabled }}


### PR DESCRIPTION
I have added some recommended kubernetes labels to the `nats-operator` Helm Chart based on the following doc.
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

This is to make it easier if trying to target pods based on labels such as `app.kubernetes.io/name`

The labels have been added to the `_helpers.tpl` and included in the `deployment.yaml`