### PR TITLE
Fix for clusterRoutes template generation

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -58,7 +58,7 @@ Return the proper NATS image name
 Return the NATS cluster routes.
 */}}
 {{- define "nats.clusterRoutes" -}}
-{{- $name := default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- $name := = (include "nats.fullname" . ) -}}
 {{- range $i, $e := until (.Values.cluster.replicas | int) -}}
 {{- printf "nats://%s-%d.%s.%s.svc:6222," $name $i $name $.Release.Namespace -}}
 {{- end -}}


### PR DESCRIPTION
Hostname used to generate the various routes to the cluster nodes where not using a conistent naming with regards to the one used for the statefulset

fixes #240 