### PR TITLE
Add leafnode remote TLS section to nats helm charts configmap.

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -109,6 +109,16 @@ leafnodes:
   enabled: true
   remotes:
     - url: "tls://connect.ngs.global:7422"
+      # credentials:
+      #   secret:
+      #     name: leafnode-creds
+      #     key: TA.creds
+      # tls:
+      #   secret:
+      #     name: nats-leafnode-tls
+      #   ca: "ca.crt"
+      #   cert: "tls.crt"
+      #   key: "tls.key"
 
   #######################
   #                     #

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -135,6 +135,23 @@ data:
         {{- with .credentials }}
         credentials: "/etc/nats-creds/{{ .secret.name }}/{{ .secret.key }}"
         {{- end }}
+
+        {{- with .tls }}
+        {{ $secretName := .secret.name }}
+        tls: {
+          {{- with .cert }}
+          cert_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
+          {{- end }}
+
+          {{- with .key }}
+          key_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
+          {{- end }}
+
+          {{- with .ca }}
+          ca_file: /etc/nats-certs/leafnodes/{{ $secretName }}/{{ . }}
+          {{- end }}
+        }
+        {{- end }}
       }
       {{- end }}
       ]


### PR DESCRIPTION
Added leafnode remotes tls section in the configmap. Also, added some guidance in readme for connecting.

*Note: There appears to be a bunch of other authorization mechanisms missing from the helm charts for leafnodes, i.e. user/pass, etc..*

