### PR TITLE
Allow to specify appProtocol

### DIFF
--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: {{ include "nats.fullname" . }}-box
     spec:
+      {{- with .Values.affinity }}
+      affinity:
+      {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if .Values.natsbox.credentials }}
       - name: nats-sys-creds

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -23,16 +23,37 @@ spec:
   {{- if .Values.websocket.enabled }}
   - name: websocket
     port: {{ .Values.websocket.port }}
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: tcp
+    {{- end }}
   {{- end }}
   - name: client
     port: 4222
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: tcp
+    {{- end }}
   - name: cluster
     port: 6222
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: tcp
+    {{- end }}
   - name: monitor
     port: 8222
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: http
+    {{- end }}
   - name: metrics
     port: 7777
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: http
+    {{- end }}
   - name: leafnodes
     port: 7422
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: tcp
+    {{- end }}
   - name: gateways
     port: 7522
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: tcp
+    {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -346,3 +346,6 @@ auth:
 websocket:
   enabled: false
   port: 443
+
+appProtocol: 
+  enabled: false


### PR DESCRIPTION
This is needed if Nats will be used next to Istio sidecars.
https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/