### PR TITLE
Fix indentation of StatefulSet annotations for nats helm chart

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "nats.labels" . | nindent 4 }}
     {{- if .Values.statefulSetAnnotations}}
-    annotations:
-    {{- range $key, $value := .Values.statefulSetAnnotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
-    {{- end }}
+  annotations:
+  {{- range $key, $value := .Values.statefulSetAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This is currently trying to apply the annotations as a sub-field on labels (currently breaks if you try to apply annotations in your values.yaml).

I've verified in my fork that fixing the indentation applies the annotations correctly.