### PR TITLE
Add nats cluster authorization block to helm charts

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -83,6 +83,20 @@ data:
       {{- include "nats.tlsConfig" $cluster_tls | nindent 6}}
       {{- end }}
 
+      {{- if .Values.cluster.authorization }}
+      authorization {
+        {{- with .Values.cluster.authorization.user }}
+        user: {{ . }}
+        {{- end }}
+        {{- with .Values.cluster.authorization.password }}
+        password: {{ . }}
+        {{- end }}
+        {{- with .Values.cluster.authorization.timeout }}
+        timeout: {{ . }}
+        {{- end }}
+      }
+      {{- end }}
+
       routes = [
         {{ include "nats.clusterRoutes" . }}
       ]

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -154,6 +154,10 @@ cluster:
   enabled: false
   replicas: 3
   noAdvertise: false
+  # authorization:
+  #   user: foo
+  #   password: pwd
+  #   timeout: 0.5
 
 # Leafnode connections to extend a cluster:
 #


### PR DESCRIPTION
This PR adds the ability for a user to configure authorization between NATS cluster nodes via the helm charts.

cc @wallyqs 