### PR TITLE
Updating binding name to follow the naming standard

### DIFF
--- a/helm/charts/nats-operator/templates/rbac.yaml
+++ b/helm/charts/nats-operator/templates/rbac.yaml
@@ -26,7 +26,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nats-io:nats-operator-crd-binding
+  name: nats-io-nats-operator-crd-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
It looks like there was a previous change to replace these `:` characters but this one was missed. thanks!