### PR TITLE
fix: nats box referenced the wrong pod annotations

### DIFF
--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ include "nats.fullname" . }}-box
       {{- if .Values.natsbox.podAnnotations }}
       annotations:
-        {{- range $key, $value := .Values.podAnnotations }}
+        {{- range $key, $value := .Values.natsbox.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}


### PR DESCRIPTION
Tested with `helm template . --set natsbox.podAnnotations.a=b`

```yml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-nats-box
  labels:
    app: RELEASE-NAME-nats-box
    chart: nats-0.8.1-sn.1
spec:
  replicas: 1
  selector:
    matchLabels:
      app: RELEASE-NAME-nats-box
  template:
    metadata:
      labels:
        app: RELEASE-NAME-nats-box
      annotations:
        a: "b"
    spec:
	# ...
```