### PR TITLE
Common Labels

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -31,6 +31,9 @@ Common labels
 */}}
 {{- define "nats.labels" -}}
 helm.sh/chart: {{ include "nats.chart" . }}
+{{- range $name, $value := .Values.commonLabels }}
+{{ $name }}: {{ $value }}
+{{- end }}
 {{ include "nats.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -1,3 +1,6 @@
+# Add labels to all the deployed resources
+commonLabels: {}
+
 ###############################
 #                             #
 #  NATS Server Configuration  #


### PR DESCRIPTION
There are some cases in which users want to have their custom labels beside the official ones on their resource, for example, app label, region label and etc. by the common label they can add them into the resources.