### PR TITLE
Support for jetstream metrics in  nats Prometheus exporter 

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -422,6 +422,9 @@ spec:
         - -varz
         - -prefix=nats
         - -use_internal_server_id
+        {{- if .Values.nats.jetstream.enabled }}
+        - -jsz=all
+        {{- end }}
         - http://localhost:8222/
         ports:
         - containerPort: 7777

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -291,7 +291,7 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: natsio/prometheus-nats-exporter:0.7.0
+  image: natsio/prometheus-nats-exporter:0.8.0
   pullPolicy: IfNotPresent
   resources: {}
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled


### PR DESCRIPTION
Upgrades the nats Prometheus exporter to 0.8.0, adds "-jsz=all" args if jetstream is enabled

Note when I enabled this, the exported metrics were in the form "nats..." not "jetstream..." 

for example: 

nats_consumer_num_ack_pending rather than jetstream_consumer_num_ack_pending as per the 0.8.0 change log of the nats Prometheus exporter.

