### PR TITLE
helm/nats: fully qualify advertised routes with the k8s cluster-domain

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the proper NATS image name
 */}}
 {{- define "nats.clusterAdvertise" -}}
-{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc" (include "nats.fullname" . ) }}
+{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc.%s." (include "nats.fullname" . ) $.Values.k8sClusterDomain }}
 {{- end }}
 
 {{/*
@@ -63,7 +63,7 @@ Return the NATS cluster routes.
 {{- define "nats.clusterRoutes" -}}
 {{- $name := (include "nats.fullname" . ) -}}
 {{- range $i, $e := until (.Values.cluster.replicas | int) -}}
-{{- printf "nats://%s-%d.%s.%s.svc:6222," $name $i $name $.Release.Namespace -}}
+{{- printf "nats://%s-%d.%s.%s.svc.%s.:6222," $name $i $name $.Release.Namespace $.Values.k8sClusterDomain -}}
 {{- end -}}
 {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -392,3 +392,7 @@ websocket:
 
 appProtocol:
   enabled: false
+
+# Cluster Domain configured on the kubelets
+# https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+k8sClusterDomain: cluster.local


### PR DESCRIPTION
This change reduces the number of DNS queries being made. At scale we
have had surprises/issues even with the CoreDNS `autopath` plugin enabled.