### PR TITLE
helm/nats: also leverage the securityContext values for nats-box deployment

### DIFF
--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -87,4 +87,8 @@ spec:
         - name: {{ $secretName }}-clients-volume
           mountPath: /etc/nats-certs/clients/{{ $secretName }}
         {{- end }}
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Currently, there is no built-in way to make it work when restricted pod security policies are in place.