### PR TITLE
Separate nats and natsbox affinity

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.8.2
+version: 0.8.3
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -23,7 +23,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      {{- with .Values.affinity }}
+      {{- with .Values.natsbox.affinity }}
       affinity:
       {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -279,6 +279,10 @@ natsbox:
   podAnnotations: {}
   #  key: "value"
 
+  # Affinity for nats box pod assignment
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
 # The NATS config reloader image to use.
 reloader:
   enabled: true


### PR DESCRIPTION
Natsbox should have it's own affinity to not to have race conditions on 3 node clusters

![Screenshot_1](https://user-images.githubusercontent.com/46970457/125174692-eae09a00-e1cf-11eb-9659-a29199ebe2f4.png)

