### PR TITLE
Update label used for load balancers

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -240,7 +240,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    app: nats
+    app.kubernetes.io/name: nats
   ports:
     - protocol: TCP
       port: 4222


### PR DESCRIPTION
In latest versions of the Helm Chart different label selectors are used now:

https://github.com/nats-io/k8s/blob/f006a95746ac213b6fd766cbaa49652e8646e0c9/helm/charts/nats/templates/_helpers.tpl#L44-L47