### PR TITLE
Allow using token authentication with nats

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -383,6 +383,12 @@ data:
     }
     {{- end }}
 
+    {{- if .token }}
+    authorization {
+      token: "{{ .token }}"
+    }
+    {{- end }}
+
     {{- with .accounts }}
     accounts: {{- toRawJson . }}
     {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -327,6 +327,9 @@ auth:
   #     name: operator-jwt
   #     key: KO.jwt
 
+  # Token authentication
+  # token:
+
   # Public key of the System Account
   # systemAccount:
 


### PR DESCRIPTION
One of the supported modes of authentication in nats is a global
token. This makes that possible to configure with the helm chart.

Closes: #271