### PR TITLE
Add initial nats-kafka helm chart

### DIFF
--- a/helm/charts/nats-kafka/Chart.yaml
+++ b/helm/charts/nats-kafka/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+version: "0.8.4"
+appVersion: "0.2.1"
+type: application
+
+name: nats-kafka
+description: A multi-connector bridge between NATS and Kafka.

--- a/helm/charts/nats-kafka/README.md
+++ b/helm/charts/nats-kafka/README.md
@@ -1,0 +1,32 @@
+# nats-kafka
+
+## TL;DR;
+
+```
+helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+helm install -f my-values.yaml my-nats-kafka nats/nats-kafka
+```
+
+## Basic Configuration
+
+This is an example configuration file you can pass to `-f`.
+
+```yaml
+natskafka:
+  nats:
+    servers:
+      - "nats://1.2.3.4:4222"
+  connect:
+    - type: "NATSToKafka"
+      brokers:
+        - 1.2.3.4:9092
+      id: whizz
+      topic: bar
+      subject: bang
+    - type: "KafkaToNATS"
+      brokers:
+        - 1.2.3.4:9092
+      id: foo
+      topic: bar
+      subject: baz
+```

--- a/helm/charts/nats-kafka/templates/_helpers.tpl
+++ b/helm/charts/nats-kafka/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nats-kafka.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nats-kafka.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nats-kafka.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nats-kafka.labels" -}}
+helm.sh/chart: {{ include "nats-kafka.chart" . }}
+{{ include "nats-kafka.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nats-kafka.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nats-kafka.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nats-kafka.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nats-kafka.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/charts/nats-kafka/templates/configmap.yaml
+++ b/helm/charts/nats-kafka/templates/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nats-kafka.fullname" . }}-config
+  labels:
+    {{- include "nats-kafka.labels" . | nindent 4 }}
+data:
+  nats-kafka.conf: |
+    reconnectinterval: {{ .Values.natskafka.reconnectInterval }}
+    connecttimeout: {{ .Values.natskafka.connectTimeout }}
+
+    logging: {
+      time: {{ .Values.natskafka.logging.time }},
+      debug: {{ .Values.natskafka.logging.debug }},
+      trace: {{ .Values.natskafka.logging.trace }},
+      colors: {{ .Values.natskafka.logging.colors }},
+      pid: {{ .Values.natskafka.logging.pid }},
+    }
+
+    nats: {
+      Servers: [
+        {{- range .Values.natskafka.nats.servers }}
+        "{{ . }}",
+        {{- end }}
+      ],
+      ConnectTimeout: {{ .Values.natskafka.nats.connectTimeout }},
+      MaxReconnects: {{ .Values.natskafka.nats.maxReconnects }},
+      ReconnectWait: {{ .Values.natskafka.nats.reconnectWait }},
+    }
+
+    connect: {{ toPrettyJson .Values.natskafka.connect | indent 4 }}

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nats-kafka.fullname" . }}
+  labels:
+    {{- include "nats-kafka.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nats-kafka.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nats-kafka.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tagOverride | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/nats-kafka
+          command:
+            - "nats-kafka"
+            - "-c"
+            - "/etc/nats-kafka/nats-kafka.conf"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "nats-kafka.fullname" . }}-config

--- a/helm/charts/nats-kafka/values.yaml
+++ b/helm/charts/nats-kafka/values.yaml
@@ -1,0 +1,27 @@
+# nameOverride overrides nats-kafka.name
+nameOverride: ""
+# fullnameOverride overrides nats-kafka.fullname
+fullnameOverride: ""
+replicaCount: 1
+
+image:
+  repository: natsio/nats-kafka
+  pullPolicy: IfNotPresent
+  # tagOverride overrides .Chart.AppVersion
+  tagOverride: ""
+
+natskafka:
+  reconnectInterval: 5000
+  connectTimeout: 5000
+  logging:
+    time: true
+    debug: false
+    trace: false
+    colors: true
+    pid: true
+  nats:
+    servers: []
+    connectTimeout: 5000
+    maxReconnects: 120
+    reconnectWait: 5000
+  connect: []


### PR DESCRIPTION
This adds a basic Helm chart for nats-kafka.

Closes https://github.com/nats-io/nats-kafka/issues/9