### PR TITLE
Add nats-kafka monitoring support

### DIFF
--- a/helm/charts/nats-kafka/README.md
+++ b/helm/charts/nats-kafka/README.md
@@ -7,9 +7,11 @@ helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm install -f my-values.yaml my-nats-kafka nats/nats-kafka
 ```
 
-## Basic Configuration
+## Configuration
 
-This is an example configuration file you can pass to `-f`.
+The following example configurations can be set with `-f`.
+
+**Basic**
 
 ```yaml
 natskafka:
@@ -26,6 +28,70 @@ natskafka:
     - type: "KafkaToNATS"
       brokers:
         - 1.2.3.4:9092
+      id: foo
+      topic: bar
+      subject: baz
+```
+
+**Monitoring**
+
+```yaml
+natskafka:
+  monitoring:
+    httpPort: 8222
+  nats:
+    servers:
+      - "nats://1.2.3.4:4222"
+  connect:
+    - type: "NATSToKafka"
+      brokers:
+        - "1.2.3.4:9092"
+      id: whizz
+      topic: bar
+      subject: bang
+    - type: "KafkaToNATS"
+      brokers:
+        - "1.2.3.4:9092"
+      id: foo
+      topic: bar
+      subject: baz
+```
+
+**Monitoring with TLS**
+
+First, create a secret in Kubernetes with certs and keys.
+
+```
+kubectl create secret generic monitor-tls \
+	--from-file=ca-cert.pem \
+	--from-file=user-key.pem \
+	--from-file=user-cert.pem
+```
+
+Then use the data in the secret in the configuration.
+
+```yaml
+natskafka:
+  monitoring:
+    httpsPort: 8222
+    tls:
+      secret: monitor-tls
+      root: ca-cert.pem
+      cert: user-cert.pem
+      key: user-key.pem
+  nats:
+    servers:
+      - "nats://1.2.3.4:4222"
+  connect:
+    - type: "NATSToKafka"
+      brokers:
+        - "1.2.3.4:9092"
+      id: whizz
+      topic: bar
+      subject: bang
+    - type: "KafkaToNATS"
+      brokers:
+        - "1.2.3.4:9092"
       id: foo
       topic: bar
       subject: baz

--- a/helm/charts/nats-kafka/templates/configmap.yaml
+++ b/helm/charts/nats-kafka/templates/configmap.yaml
@@ -28,4 +28,19 @@ data:
       ReconnectWait: {{ .Values.natskafka.nats.reconnectWait }},
     }
 
+    {{ if or .Values.natskafka.monitoring.httpPort .Values.natskafka.monitoring.httpsPort }}
+    monitoring: {
+      {{ with .Values.natskafka.monitoring.httpHost }}httpHost: {{ . }}{{ end -}}
+      {{ with .Values.natskafka.monitoring.httpPort }}httpPort: {{ . }}{{ end -}}
+      {{ with .Values.natskafka.monitoring.httpsPort }}httpsPort: {{ . }}{{ end -}}
+      {{ if and .Values.natskafka.monitoring.tls.cert .Values.natskafka.monitoring.tls.key }}
+      tls: {
+        {{ with .Values.natskafka.monitoring.tls.root }}root: /etc/nats-kafka/tls/{{ . }}{{ end }}
+        {{ with .Values.natskafka.monitoring.tls.cert }}cert: /etc/nats-kafka/tls/{{ . }}{{ end }}
+        {{ with .Values.natskafka.monitoring.tls.key }}key: /etc/nats-kafka/tls/{{ . }}{{ end }}
+      }
+      {{- end }}
+    }
+    {{- end }}
+
     connect: {{ toPrettyJson .Values.natskafka.connect | indent 4 }}

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -21,11 +21,35 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/nats-kafka
+            {{ if .Values.natskafka.monitoring.tls.secret }}
+            - name: tls-volume
+              mountPath: /etc/nats-kafka/tls
+              readOnly: true
+            {{ end }}
           command:
             - "nats-kafka"
             - "-c"
             - "/etc/nats-kafka/nats-kafka.conf"
+          {{ if .Values.natskafka.monitoring.httpPort }}
+          livenessProbe:
+            httpGet:
+              path: "/healthz"
+              port: {{ .Values.natskafka.monitoring.httpPort }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: "/healthz"
+              port: {{ .Values.natskafka.monitoring.httpPort }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          {{ end }}
       volumes:
         - name: config-volume
           configMap:
             name: {{ include "nats-kafka.fullname" . }}-config
+        {{ if .Values.natskafka.monitoring.tls.secret }}
+        - name: tls-volume
+          secret:
+            secretName: {{ .Values.natskafka.monitoring.tls.secret }}
+        {{ end }}

--- a/helm/charts/nats-kafka/templates/service.yaml
+++ b/helm/charts/nats-kafka/templates/service.yaml
@@ -1,0 +1,16 @@
+{{ if or .Values.natskafka.monitoring.httpPort .Values.natskafka.monitoring.httpsPort }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nats-kafka.fullname" . }}
+  labels:
+    {{- include "nats-kafka.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "nats-kafka.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http-monitoring
+      protocol: TCP
+      {{ with .Values.natskafka.monitoring.httpPort }}port: {{ . }}{{end}}
+      {{ with .Values.natskafka.monitoring.httpsPort }}port: {{ . }}{{end}}
+{{ end }}

--- a/helm/charts/nats-kafka/values.yaml
+++ b/helm/charts/nats-kafka/values.yaml
@@ -19,6 +19,16 @@ natskafka:
     trace: false
     colors: true
     pid: true
+  monitoring:
+    httpHost: ""
+    # 0 means no monitoring, -1 means some available port
+    httpPort: 0
+    httpsPort: 0
+    tls:
+      secret: ""
+      root: ""
+      cert: ""
+      key: ""
   nats:
     servers: []
     connectTimeout: 5000


### PR DESCRIPTION
This adds monitoring support for nats-kafka. It supports HTTP and HTTPS monitoring.