### PR TITLE
Fix WebSocket TLS ConfigMap template

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -293,7 +293,7 @@ data:
     ##################
     websocket {
       port: {{ .Values.websocket.port }}
-      {{- if .Values.websocket.tls }}
+      {{- with .Values.websocket.tls }}
         {{ $secretName := .secret.name }}
         tls {
         {{- with .cert }}


### PR DESCRIPTION
The context for following TLS settings seems to break.