### PR TITLE
feat(helm/nats): optional nats.jetstream.fileStorage.storageClassName

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -473,5 +473,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.nats.jetstream.fileStorage.size }}
+        {{- if .Values.nats.jetstream.fileStorage.storageClassName }}
         storageClassName: {{ .Values.nats.jetstream.fileStorage.storageClassName | quote }}
+        {{- end }}
   {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -79,7 +79,7 @@ nats:
       # Use below block to create new persistent volume
       # only used if existingClaim is not specified
       size: 1Gi
-      storageClassName: default
+      # storageClassName: ""
       accessModes:
         - ReadWriteOnce
       annotations:


### PR DESCRIPTION
This PR adds support for [DefaultStorageClass](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#defaultstorageclass) ([doc](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1)). This allows chart consumers to optionally specify a storage class name, leaving the default to be provided by the cluster environment.

This mirrors Traefik's method of passing `storageClassName` [here](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/templates/pvc.yaml#L23) and [here](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L375).