### PR TITLE
Add URLs and Account into Leafnodes Remote

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -194,6 +194,14 @@ data:
         url: {{ . }}
         {{- end }}
 
+        {{- with .urls }}
+        urls: {{ toRawJson . }}
+        {{- end }}
+
+        {{- with .account }}
+        account: {{ . }}
+        {{- end }}
+
         {{- with .credentials }}
         credentials: "/etc/nats-creds/{{ .secret.name }}/{{ .secret.key }}"
         {{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -166,7 +166,7 @@ data:
         password: {{ . }}
         {{- end }}
         {{- with .account }}
-        account: {{ . }}
+        account: {{ . | quote }}
         {{- end }}
         {{- with .timeout }}
         timeout: {{ . }}
@@ -191,7 +191,7 @@ data:
       {{- range .Values.leafnodes.remotes }}
       {
         {{- with .url }}
-        url: {{ . }}
+        url: {{ . | quote }}
         {{- end }}
 
         {{- with .urls }}
@@ -199,7 +199,7 @@ data:
         {{- end }}
 
         {{- with .account }}
-        account: {{ . }}
+        account: {{ . | quote }}
         {{- end }}
 
         {{- with .credentials }}


### PR DESCRIPTION
These configurations have been added based on [documentation](https://docs.nats.io/nats-server/configuration/leafnodes/leafnode_conf) for leaf node remotes. Also, I think this will close #256.

Also, I have added a quote pipe for URL and account values.