### PR TITLE
Add Tests for NATS Chart

### DIFF
--- a/helm/charts/nats/templates/tests/test-request-reply.yaml
+++ b/helm/charts/nats/templates/tests/test-request-reply.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nats.fullname" . }}-test-request-reply"
+  labels:
+    {{- include "nats.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: nats-box
+      image: synadia/nats-box
+      env:
+        - name: NATS_HOST
+          value: {{ template "nats.fullname" . }}
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          nats reply -s nats://$NATS_HOST:4222 'name.>' --command "echo {{1}}" &
+        - |
+          "&&"
+        - |
+          name=$(nats request -s nats://$NATS_HOST:4222 name.test '' 2>/dev/null)
+        - |
+          "&&"
+        - |
+          [ $name = test ]
+
+  restartPolicy: Never


### PR DESCRIPTION
I have added a very simple request/response test to make sure we have an up and running nats cluster. Also if you agree I can also add a Github pipeline like [this](https://github.com/helm/chart-testing-action) to run the chart and its test for making sure about the PRs.