### PR TITLE
re-pluralize gateway cert path in configmap

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -244,7 +244,7 @@ data:
 
       {{- with .Values.gateway.tls }}
       {{-  $gateway_tls := merge (dict) . }}
-      {{- $_ := set $gateway_tls "secretPath" "/etc/nats-certs/gateway" }}
+      {{- $_ := set $gateway_tls "secretPath" "/etc/nats-certs/gateways" }}
       {{- include "nats.tlsConfig" $gateway_tls | nindent 6}}
       {{- end }}
 


### PR DESCRIPTION
Just fixing a typo that looks to have been introduced in b29643fb. The cert path in the configmap and the volumeMount need to agree.

Currently, using chart version `0.8.6`, if you have gateway tls configured, the `nats-server` container cannot find the mounted secret and errors out.