### PR TITLE
[helm/nats] Expose nats-server profiling option

### DIFF
--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -28,6 +28,13 @@ spec:
     appProtocol: tcp
     {{- end }}
   {{- end }}
+  {{- if .Values.nats.profiling.enabled }}
+  - name: profiling
+    port: {{ .Values.nats.profiling.port }}
+    {{- if .Values.appProtocol.enabled }}
+    appProtocol: http
+    {{- end }}
+  {{- end }}
   - name: client
     port: 4222
     {{- if .Values.appProtocol.enabled }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -245,10 +245,18 @@ spec:
           hostPort: {{ .Values.websocket.port }}
           {{- end }}
         {{- end }}
+        {{- if .Values.nats.profiling.enabled }}
+        - containerPort: {{ .Values.nats.profiling.port }}
+          name: profiling
+        {{- end }}
+
         command:
          - "nats-server"
          - "--config"
          - "/etc/nats-config/nats.conf"
+        {{- if .Values.nats.profiling.enabled }}
+         - "--profile={{ .Values.nats.profiling.port }}"
+        {{- end }}
 
         # Required to be able to define an environment variable
         # that refers to other environment variables.  This env var

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -7,6 +7,12 @@ nats:
   image: nats:2.3.1-alpine
   pullPolicy: IfNotPresent
 
+  # Toggle profiling.
+  # This enables nats-server pprof (profiling) port, so you can see goroutines stacks, memory heap sizes, etc.
+  profiling:
+    enabled: false
+    port: 6000
+
   # Toggle whether to enable external access.
   # This binds a host port for clients, gateways and leafnodes.
   externalAccess: false


### PR DESCRIPTION
Allows users to enable profiling on the `value.yaml` file.