### PR TITLE
fix: Correct and Short Circuiting Issue

### DIFF
--- a/helm/charts/stan/templates/pvc.yaml
+++ b/helm/charts/stan/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.store.volume.persistentVolumeClaim (not .Values.store.volume.persistentVolumeClaim.existingClaim) -}}
+{{- if .Values.store.volume.persistentVolumeClaim -}}{{- if not .Values.store.volume.persistentVolumeClaim.existingClaim -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -17,4 +17,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.store.volume.storageSize }}
-{{- end -}}
+{{- end -}}{{- end -}}


### PR DESCRIPTION
Helm templates don't use short-circuiting so for an and expression they check both conditions and this causes issues. This resolves what is discussed [here](https://github.com/nats-io/k8s/commit/6d010c8a8abbaa76c402a0f2db081acfa3f058da)