### PR TITLE
remove trailing whitespace from nats.conf in ConfigMap

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -138,7 +138,7 @@ data:
 
       connect_retries: {{ .Values.nats.connectRetries }}
     }
-    {{ end }}
+    {{- end }}
 
     {{- if and .Values.nats.advertise .Values.nats.externalAccess }}
     include "advertise/client_advertise.conf"
@@ -155,9 +155,9 @@ data:
       listen: "0.0.0.0:7422"
       {{- end }}
 
-      {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
+      {{- if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
-      {{ end }}
+      {{- end }}
 
       {{- with .Values.leafnodes.noAdvertise }}
       no_advertise: {{ . }}
@@ -232,7 +232,7 @@ data:
       {{- end }}
       ]
     }
-    {{ end }}
+    {{- end }}
 
     {{- if .Values.gateway.enabled }}
     #################
@@ -244,9 +244,9 @@ data:
       name: {{ .Values.gateway.name }}
       port: 7522
 
-      {{ if and .Values.nats.advertise .Values.nats.externalAccess }}
+      {{- if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
-      {{ end }}
+      {{- end }}
 
       {{- with .Values.gateway.tls }}
       {{-  $gateway_tls := merge (dict) . }}
@@ -273,7 +273,7 @@ data:
         {{- end }}
       ]
     }
-    {{ end }}
+    {{- end }}
 
     {{- with .Values.nats.logging.debug }}
     debug: {{ . }}


### PR DESCRIPTION
Depending on your configuration, the configmap can be rendered with
lines having trailing whitespace. This causes k8s to display the
configmap as just a big string containing literal "\n" strings, rather
than actual linebreaks.

This is most notably a problem when using `kubectl edit`, as it is
somewhat more difficult to edit the config when it's all on one line.

https://github.com/kubernetes/kubernetes/issues/36222 has a whole bunch
of discussion on the issue, in case you wanted to read about a bunch of
people yelling past each other.

Regardless of whether it's a bug or not, seems best to just avoid it in
the first place.