### PR TITLE
Add support for secrets as config source

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.8.8
+version: 0.8.9
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -71,8 +71,13 @@ spec:
       # Common volumes for the containers.
       volumes:
       - name: config-volume
+        {{ if .Values.nats.configMap.enabled }}
         configMap:
           name: {{ include "nats.fullname" . }}-config
+        {{ else }}
+        secret:
+          secretName: {{ .Values.nats.secret.name }} 
+        {{ end }}
 
       # Local volume shared with the reloader.
       - name: pid

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -40,6 +40,14 @@ nats:
 
   resources: {}
 
+  # This flag can be use to either use the ConfigMap the helm chart generates or pass a secret with the custom config you desire
+  # E.g use case - You want to define users with password and have ExternalSecrets(https://github.com/external-secrets/external-secrets) creating a secret containing the config 
+  configMap:
+    enabled: true
+
+  secret:
+    name:
+
   # Server settings.
   limits:
     maxConnections:


### PR DESCRIPTION
This PR seeks to introduce the ability to pass a custom secret as the config source for NATS

I encountered an issue when I wanted to pass custom config (like creating users with passwords) which isn't supported by the helm configmap template presently

With this PR, users can pass the name of a secret which contains their custom config (along any extra configuration which isn't natively supported by the helm chart)