### PR TITLE
Add origin option for nats websocket

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -356,7 +356,7 @@ data:
       {{- end }}
       same_origin: {{ .Values.websocket.sameOrigin }}
       {{- with .Values.websocket.allowedOrigins }}
-      allowed_origins: ["{{ first . }}" {{- range (rest .) }}, "{{ . }}" {{- end }}]
+      allowed_origins: {{ toRawJson . }}
       {{- end }}
     }
     {{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -354,6 +354,10 @@ data:
       {{- else }}
       no_tls: {{ .Values.websocket.noTLS }}
       {{- end }}
+      same_origin: {{ .Values.websocket.sameOrigin }}
+      {{- with .Values.websocket.allowedOrigins }}
+      allowed_origins: ["{{ first . }}" {{- range (rest .) }}, "{{ . }}" {{- end }}]
+      {{- end }}
     }
     {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -428,6 +428,10 @@ auth:
 websocket:
   enabled: false
   port: 443
+  noTLS: true
+
+  sameOrigin: false
+  allowedOrigins: []
 
 appProtocol:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Masudur Rahman <masudjuly02@gmail.com>

`allowed_origins` is an important part for websocket.
To have the options available for user, I added the `same_origin` and `allowed_origins` field.

And also if `TLS` isn't enabled, `no_tls` field must be set `true`. That's why I added this.