### PR TITLE
fix: add support to define nats selector labels.

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -45,8 +45,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "nats.selectorLabels" -}}
+{{- if .Values.nats.selectorLabels }}
+{{ .Values.nats.selectorLabels | toYaml }}
+{{- else }}
 app.kubernetes.io/name: {{ include "nats.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -38,6 +38,11 @@ nats:
   # to a client that has no activity.
   pingInterval:
 
+  # selector matchLabels for the server and service.
+  # If left empty defaults are used.
+  # This is helpful if you are updating from Chart version <=7.4
+  selectorLabels: {}
+
   resources: {}
 
   # Server settings.


### PR DESCRIPTION
Allowing users to set custom selector labels will allow upgrades from chart <= 7.4 to 8.0 =>.


Helm Chart <=7.4 has the selector labels set to 
```
app: {{ template "nats.name" . }}
```

This has changed in Chart 8.0+ and makes it very difficult to upgrade from lower version. Without the ability to set the selector to what is already defined you will get an error similar to the following.

```
Error: UPGRADE FAILED: cannot patch "nats" with kind StatefulSet: StatefulSet.apps "nats" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```



