### PR TITLE
Update NATS to 2.5.0-alpine image

### DIFF
--- a/helm/charts/index.yaml
+++ b/helm/charts/index.yaml
@@ -132,7 +132,7 @@ entries:
         url: https://github.com/variadico
     name: nats
     urls:
-      - https://nats-io.github.io/k8s/helm/charts/nats-0.8.9.tgz
+    - https://github.com/nats-io/k8s/releases/download/v0.8.9/nats-0.8.9.tgz
     version: 0.8.9
   - apiVersion: v2
     appVersion: 2.3.4

--- a/helm/charts/index.yaml
+++ b/helm/charts/index.yaml
@@ -109,6 +109,32 @@ entries:
     version: 0.7.4
   nats:
   - apiVersion: v2
+    appVersion: 2.5.0
+    created: "2021-09-14T17:53:30.869646746+01:00"
+    description: A Helm chart for the NATS.io High Speed Cloud Native Distributed
+      Communications Technology.
+    digest: d35f5c2414d113d232003106f88e9dc1dc15e784628bf4f12bd8161d1df6c798
+    home: http://github.com/nats-io/k8s
+    icon: https://nats.io/img/nats-icon-color.png
+    keywords:
+      - nats
+      - messaging
+      - cncf
+    maintainers:
+      - email: wally@nats.io
+        name: Waldemar Quevedo
+        url: https://github.com/wallyqs
+      - email: colin@nats.io
+        name: Colin Sullivan
+        url: https://github.com/ColinSullivan1
+      - email: jaime@nats.io
+        name: Jaime Piña
+        url: https://github.com/variadico
+    name: nats
+    urls:
+      - https://nats-io.github.io/k8s/helm/charts/nats-0.8.9.tgz
+    version: 0.8.9
+  - apiVersion: v2
     appVersion: 2.3.4
     created: "2021-08-19T14:27:36.356311-07:00"
     description: A Helm chart for the NATS.io High Speed Cloud Native Distributed

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: "2.3.4"
+appVersion: "2.5.0"
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications Technology.
 name: nats
 keywords:
   - nats
   - messaging
   - cncf
-version: 0.8.8
+version: 0.8.9
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -4,7 +4,7 @@
 #                             #
 ###############################
 nats:
-  image: nats:2.3.4-alpine
+  image: nats:2.5.0-alpine
   pullPolicy: IfNotPresent
 
   # Toggle profiling.


### PR DESCRIPTION
This updates the helm chart to use NATS 2.5.0