### PR TITLE
[Gateway Configuration] Implicit Advertise Configuration

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -249,6 +249,10 @@ data:
       name: {{ .Values.gateway.name }}
       port: 7522
 
+      {{- if .Values.gateway.advertise }}
+      advertise: {{ .Values.gateway.advertise }} 
+      {{- end }}
+
       {{- if and .Values.nats.advertise .Values.nats.externalAccess }}
       include "advertise/gateway_advertise.conf"
       {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -254,6 +254,10 @@ gateway:
   enabled: false
   name: 'default'
 
+  # You can add an implicit advertise address instead of using from Node's IP
+  # could also be a fqdn address
+  #advertise: "nats.example.com"
+
   #############################
   #                           #
   #  List of remote gateways  #
@@ -287,7 +291,7 @@ bootconfig:
   image: natsio/nats-boot-config:0.5.4
   pullPolicy: IfNotPresent
   securityContext: {}
-
+  
 # NATS Box
 #
 # https://github.com/nats-io/nats-box


### PR DESCRIPTION
Hello Guys, 
We're starting to use NATS and the Super Cluster feature, but we had a problem regarding the bootconfig , because bootconfig tries to check an ExternalIP from nodes and unfortunately our nodes do not have ExternalIps. To solve that we used an implicit advertise option passing a value to ConfigMap. 
Could you check if this is something that other persons also needed? 

Thanks! 