### PR TITLE
add additionalArguments to nats-kafka chart

### DIFF
--- a/helm/charts/nats-kafka/Chart.yaml
+++ b/helm/charts/nats-kafka/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: "0.8.4"
+version: "0.8.5"
 appVersion: "0.2.1"
 type: application
 

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -30,6 +30,14 @@ spec:
             - "nats-kafka"
             - "-c"
             - "/etc/nats-kafka/nats-kafka.conf"
+          {{- if .Values.additionalArguments }}
+          args:
+            {{- with .Values.additionalArguments }}
+            {{- range . }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end}}
           {{ if .Values.natskafka.monitoring.httpPort }}
           livenessProbe:
             httpGet:

--- a/helm/charts/nats-kafka/values.yaml
+++ b/helm/charts/nats-kafka/values.yaml
@@ -29,6 +29,7 @@ natskafka:
       root: ""
       cert: ""
       key: ""
+  additionalArguments: []
   nats:
     servers: []
     connectTimeout: 5000


### PR DESCRIPTION
add `.Values.additionalArguments`

Currently this does not replace any `CMD` of the docker image, judging by https://hub.docker.com/layers/natsio/nats-kafka/latest/images/sha256-97ba2cc388536dd968053ad60eaca26f8f6efc3cd9426924ef6a9a481f02bb42?context=explore