### PR TITLE
Bump lame duck duration, add auth timeout, fix some limits...

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -386,21 +386,31 @@ data:
     #                #
     ##################
     {{- if .Values.auth.resolver }}
+
     {{- if eq .Values.auth.resolver.type "memory" }}
     resolver: MEMORY
     include "accounts/{{ .Values.auth.resolver.configMap.key }}"
     {{- end }}
 
     {{- if eq .Values.auth.resolver.type "full" }}
-
     {{- if .Values.auth.resolver.configMap }}
     include "accounts/{{ .Values.auth.resolver.configMap.key }}"
     {{- else }}
 
     {{- with .Values.auth.resolver }}
-    operator: {{ .operator }}
+    {{- if $.Values.auth.timeout }}
+    authorization {
+      timeout: {{ $.Values.auth.timeout }}
+    }
+    {{- end }}
 
+    {{- if .operator }}
+    operator: {{ .operator }}
+    {{- end }}
+
+    {{- if .systemAccount }}
     system_account: {{ .systemAccount }}
+    {{- end }}
     {{- end }}
 
     resolver: {
@@ -435,12 +445,20 @@ data:
     {{- with .Values.auth.token }}
     authorization {
       token: "{{ . }}"
+
+      {{- if $.Values.auth.timeout }}
+      timeout: {{ $.Values.auth.timeout }}
+      {{- end }}
     }
     {{- end }}
 
     {{- with .Values.auth.nkeys }}
     {{- with .users }}
     authorization {
+      {{- if $.Values.auth.timeout }}
+      timeout: {{ $.Values.auth.timeout }}
+      {{- end }}
+
       users: [
       {{- range . }}
       {{- toRawJson . | nindent 4 }},
@@ -458,6 +476,10 @@ data:
 
     {{- with .users }}
     authorization {
+      {{- if $.Values.auth.timeout }}
+      timeout: {{ $.Values.auth.timeout }}
+      {{- end }}
+
       users: [
       {{- range . }}
       {{- toRawJson . | nindent 4 }},
@@ -467,6 +489,12 @@ data:
     {{- end }}
 
     {{- with .accounts }}
+    authorization {
+      {{- if $.Values.auth.timeout }}
+      timeout: {{ $.Values.auth.timeout }}
+      {{- end }}
+    }
+
     accounts: {{- toRawJson . }}
     {{- end }}
 

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -321,29 +321,37 @@ data:
     {{- with .Values.nats.limits.maxConnections }}
     max_connections: {{ . }}
     {{- end }}
+
     {{- with .Values.nats.limits.maxSubscriptions }}
     max_subscriptions: {{ . }}
     {{- end }}
+
     {{- with .Values.nats.limits.maxPending }}
     max_pending: {{ . }}
     {{- end }}
+
     {{- with .Values.nats.limits.maxControlLine }}
     max_control_line: {{ . }}
     {{- end }}
+
     {{- with .Values.nats.limits.maxPayload }}
     max_payload: {{ . }}
     {{- end }}
-    {{- with .Values.nats.pingInterval }}
+
+    {{- with .Values.nats.limits.pingInterval }}
     ping_interval: {{ . }}
     {{- end }}
-    {{- with .Values.nats.maxPings }}
+
+    {{- with .Values.nats.limits.maxPings }}
     ping_max: {{ . }}
     {{- end }}
-    {{- with .Values.nats.writeDeadline }}
-    write_deadline: {{ . | quote }}
+
+    {{- with .Values.nats.limits.writeDeadline }}
+    write_deadline: {{ . }}
     {{- end }}
-    {{- with .Values.nats.writeDeadline }}
-    lame_duck_duration:  {{ . | quote }}
+
+    {{- with .Values.nats.limits.lameDuckDuration }}
+    lame_duck_duration: {{ . }}
     {{- end }}
 
     {{- if .Values.websocket.enabled }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -55,9 +55,12 @@ nats:
     writeDeadline:
     maxPending:
     maxPings:
-    lameDuckDuration:
 
-  terminationGracePeriodSeconds: 60
+    # NOTE: this should be at least the same as 'terminationGracePeriodSeconds'
+    lameDuckDuration: "120s"
+
+  # Default lame duck duration in the server is 2 minutes.
+  terminationGracePeriodSeconds: 120
 
   logging:
     debug:


### PR DESCRIPTION
- Limits were not being applied in some cases since were under the wrong block.
- Made it possible to bump the auth timeout
- Termination grace period (time the pod pre-stop sleeps before shutting down) is now 120 as in the default lame duck duration from the server.  This may help with memory based streams and snapshots when using JetStream.

Sample YAML:

```yaml

nats:
  image: synadia/nats-server:nightly-20210923

  limits:
    writeDeadline: 30s
    lameDuckDuration: 122s

  logging:
    debug: true
    trace: false

  jetstream:
    enabled: false

    memStorage:
      enabled: true
      size: "2Gi"

    fileStorage:
      enabled: true
      size: "8Gi"
      storageDirectory: /data/
      storageClassName: gp2

cluster:
  enabled: true
  # Can set a custom cluster name
  name: "nats"
  replicas: 3

auth:
  enabled: true

  timeout: "5s"

  systemAccount: sys

  # token: foo

  # nkeys:
  #   users:
  #    - user: asdf
  #      pass: asdf

  # resolver:
  #   type: full
  #   operator: foo
  #   systemAccount: asdf

  basic:
    accounts:
      sys:
        users:
        - user: sys
          pass: sys
      js:
        jetstream: true
        users:
        - user: foo
```