### PR TITLE
Update CRDs for multiple servers

### DIFF
--- a/helm/charts/nack/crds/jetstream.yml
+++ b/helm/charts/nack/crds/jetstream.yml
@@ -23,6 +23,20 @@ spec:
           spec:
             type: object
             properties:
+              servers:
+                description: A list of servers for creating stream
+                type: array
+                items:
+                  type: string
+                default: []
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
               name:
                 description: A unique name for the Stream.
                 type: string
@@ -146,6 +160,21 @@ spec:
                       type: string
                     externalDeliverPrefix:
                       type: string
+              tls:
+                description: A client's TLS certs and keys.
+                type: object
+                properties:
+                  clientCert:
+                    description: A client's cert filepath. Should be mounted.
+                    type: string
+                  clientKey:
+                    description: A client's key filepath. Should be mounted.
+                    type: string
+                  rootCas:
+                    description: A list of filepaths to CAs. Should be mounted.
+                    type: array
+                    items:
+                      type: string
           status:
             type: object
             properties:
@@ -204,6 +233,20 @@ spec:
           spec:
             type: object
             properties:
+              servers:
+                description: A list of servers for creating consumer
+                type: array
+                items:
+                  type: string
+                default: []
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
               streamName:
                 description: The name of the Stream to create the Consumer in.
                 type: string
@@ -279,6 +322,21 @@ spec:
               heartbeatInterval:
                 description: The interval used to deliver idle heartbeats for push-based consumers, in Go's time.Duration format.
                 type: string
+              tls:
+                description: A client's TLS certs and keys.
+                type: object
+                properties:
+                  clientCert:
+                    description: A client's cert filepath. Should be mounted.
+                    type: string
+                  clientKey:
+                    description: A client's key filepath. Should be mounted.
+                    type: string
+                  rootCas:
+                    description: A list of filepaths to CAs. Should be mounted.
+                    type: array
+                    items:
+                      type: string
           status:
             type: object
             properties:
@@ -341,6 +399,20 @@ spec:
           spec:
             type: object
             properties:
+              servers:
+                description: A list of servers for creating stream
+                type: array
+                items:
+                  type: string
+                default: []
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
               name:
                 description: A unique name for the Stream Template.
                 type: string

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -100,6 +100,7 @@ spec:
           command:
           - /jetstream-controller
           - -s={{ .Values.jetstream.nats.url }}
+          - -crd-connect={{ .Values.jetstream.crdConnect }}
           {{- with .Values.jetstream.nats.credentials }}
           - --creds=/etc/jsc-creds/{{ .secret.key }}
           {{- end }}

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -49,6 +49,35 @@ spec:
           secretName: {{ .Values.jetstream.nats.credentials.secret.name }}
       {{- end }}
 
+      {{- if .Values.jetstream.accounts }}
+      {{- range $key, $value := .Values.jetstream.accounts }}
+        {{- with $value.creds }}
+      - name: {{ $key }}-creds-volume
+        secret:
+          secretName: {{ .secret.name }}
+        {{- end }}
+
+        {{- with $value.nkey }}
+      - name: {{ $key }}-nkey-volume
+        secret:
+          secretName: {{ .secret.name }}
+        {{- end }}
+
+        {{- if $value.certs }}
+        {{- with $value.certs.ca }}
+      - name: {{ $key }}-ca-volume
+        secret:
+          secretName: {{ .secret.name }}
+        {{- end }}
+        {{- with $value.certs.client }}
+      - name: {{ $key }}-client-tls-volume
+        secret:
+          secretName: {{ .secret.name }}
+        {{- end }}
+        {{- end}}
+      {{- end }}
+      {{- end }}
+
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -110,4 +139,26 @@ spec:
           - name: jsc-sys-creds
             mountPath: /etc/jsc-creds
           {{- end }}
+
+          {{- if .Values.jetstream.accounts }}
+          {{- range $key, $value := .Values.jetstream.accounts }}
+            {{- with $value.creds }}
+          - name: {{ $key }}-creds-volume
+            mountPath: /etc/creds/{{ $key }}
+            {{- end}}
+
+            {{- if $value.certs }}
+            {{- with $value.certs.ca }}
+          - name: {{ $key }}-ca-volume
+            mountPath: /etc/certs/ca/{{ $key }}
+            {{- end }}
+            {{- with $value.certs.client }}
+          - name: {{ $key }}-client-tls-volume
+            mountPath: /etc/certs/client/{{ $key }}
+            {{- end }}
+            {{- end}}
+
+          {{- end }}
+          {{- end }}
+
 {{- end }}

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -8,6 +8,7 @@ jetstream:
   image: natsio/jetstream-controller:0.5.0
   pullPolicy: IfNotPresent
   replicas: 1
+  crdConnect: false
 
   # NATS URL
   nats:


### PR DESCRIPTION
This updates the CRDs to allow specifying multiple NATS servers. The jetstream-controller changes are here: https://github.com/nats-io/nack/pull/41