### PR TITLE
Support different k8s clusters on nats helm chart

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -71,6 +71,11 @@ Return the NATS cluster routes.
 {{- end -}}
 {{- end }}
 
+{{- define "nats.extraRoutes" -}}
+{{- range $i, $url := .Values.nats.extraRoutes -}}
+{{- printf "%s," $url -}}
+{{- end -}}
+{{- end }}
 
 {{- define "nats.tlsConfig" -}}
 tls {

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -72,7 +72,7 @@ Return the NATS cluster routes.
 {{- end }}
 
 {{- define "nats.extraRoutes" -}}
-{{- range $i, $url := .Values.nats.extraRoutes -}}
+{{- range $i, $url := .Values.cluster.extraRoutes -}}
 {{- printf "%s," $url -}}
 {{- end -}}
 {{- end }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
     #             #
     ###############
     http: 8222
-    server_name: $POD_NAME
+    server_name: {{- if .Values.nats.serverName  }}{{ .Values.nats.serverName }}{{- else }}$POD_NAME {{- end }}
 
     {{- if .Values.nats.tls }}
     #####################
@@ -134,6 +134,7 @@ data:
 
       routes = [
         {{ include "nats.clusterRoutes" . }}
+        {{ include "nats.extraRoutes" . }}
       ]
       cluster_advertise: $CLUSTER_ADVERTISE
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -48,10 +48,6 @@ nats:
 
   resources: {}
 
-  # Explicitly set routes for clustering.
-  # When JetStream is enabled, the serverName must be unique in the cluster.
-  extraRoutes: []
-
   # Server settings.
   limits:
     maxConnections:
@@ -249,6 +245,11 @@ cluster:
   enabled: false
   replicas: 3
   noAdvertise: false
+
+  # Explicitly set routes for clustering.
+  # When JetStream is enabled, the serverName must be unique in the cluster.
+  extraRoutes: []
+
   # authorization:
   #   user: foo
   #   password: pwd

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -7,6 +7,9 @@ nats:
   image: nats:2.6.1-alpine
   pullPolicy: IfNotPresent
 
+  # The servers name, shows up in logging.
+  serverName: ""
+
   # Toggle profiling.
   # This enables nats-server pprof (profiling) port, so you can see goroutines
   # stacks, memory heap sizes, etc.
@@ -44,6 +47,10 @@ nats:
   selectorLabels: {}
 
   resources: {}
+
+  # Explicitly set routes for clustering.
+  # When JetStream is enabled, the serverName must be unique in the cluster.
+  extraRoutes: []
 
   # Server settings.
   limits:


### PR DESCRIPTION
It's not possible to create a nats cluster which includes nats nodes
on different kubernetes clusters.
Using the helm chart, I cannot explicitly set the cluster routes expected
in the configMap since it generates it based on the current k8s cluster.
This commit makes it possible with a new value nats.extraRoutes and
nats.serverName.

Relates to #355 