### PR TITLE
[nats][helm] bump chart to 0.9.1

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - nats
   - messaging
   - cncf
-version: 0.9.0
+version: 0.9.1
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo


### PR DESCRIPTION
@wallyqs would you release nats helm chart 0.9.1 with new fixes? 

`0.9.0` is broken in some places.