### PR TITLE
Use serverNamePrefix instead of serverName

### DIFF
--- a/helm/charts/index.yaml
+++ b/helm/charts/index.yaml
@@ -151,32 +151,6 @@ entries:
     version: 0.7.4
   nats:
   - apiVersion: v2
-    appVersion: 2.6.2
-    created: "2021-09-29T10:54:50.225792-07:00"
-    description: A Helm chart for the NATS.io High Speed Cloud Native Distributed
-      Communications Technology.
-    digest: 23a70e10ab513af51488f763100b223284d44971261177e0f7a722758c662add
-    home: http://github.com/filhodanuvem/k8s
-    icon: https://nats.io/img/nats-icon-color.png
-    keywords:
-    - nats
-    - messaging
-    - cncf
-    maintainers:
-    - email: wally@nats.io
-      name: Waldemar Quevedo
-      url: https://github.com/wallyqs
-    - email: colin@nats.io
-      name: Colin Sullivan
-      url: https://github.com/ColinSullivan1
-    - email: jaime@nats.io
-      name: Jaime Piña
-      url: https://github.com/variadico
-    name: nats
-    urls:
-    - https://github.com/filhodanuvem/k8s/releases/download/v0.10.0/nats-0.10.0.tgz
-    version: 0.10.0
-  - apiVersion: v2
     appVersion: 2.6.1
     created: "2021-09-29T10:54:50.225792-07:00"
     description: A Helm chart for the NATS.io High Speed Cloud Native Distributed

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: "2.6.2"
+appVersion: "2.6.1"
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications Technology.
 name: nats
 keywords:
   - nats
   - messaging
   - cncf
-version: 0.10.0
+version: 0.9.0
 home: http://github.com/nats-io/k8s
 maintainers:
   - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
     #             #
     ###############
     http: 8222
-    server_name:  {{- if .Values.nats.serverNamePrefix  }}$SERVER_NAME{{- else }}$POD_NAME{{- end }}
+    server_name: {{- if .Values.nats.serverNamePrefix  }}$SERVER_NAME{{- else }}$POD_NAME{{- end }}
 
     {{- if .Values.nats.tls }}
     #####################

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -7,7 +7,8 @@ nats:
   image: nats:2.6.1-alpine
   pullPolicy: IfNotPresent
 
-  # The servers name prefix, shows up in logging.
+  # The servers name prefix, must be used for example when we want a NATS cluster
+  # spanning multiple Kubernetes clusters.
   serverNamePrefix: ""
 
   # Toggle profiling.


### PR DESCRIPTION
Relates to #356 
The serverName value allows us to create a nats cluster
containing only one node per k8s cluster becuase
each node in a nats cluster must have an unique serverName.
So changing serverName to serverNamePrefix improve it in a way
where we can achieve multiple nods per k8s cluster.
Ex:
```yaml
serverNamePrefix: cluster1-
cluster:
  replicas: 2
```

will generate pods with the following serverNames:
- cluster1-nats-0
- cluster2-nats-1

```yaml
serverNamePrefix: cluster2-
cluster:
  replicas: 3
```

will genreate the following serverNames:
- cluster2-nats-0
- cluster2-nats-1
- cluster2-nats-2