### PR TITLE
[chart, patch] add appProtocol to client port

### DIFF
--- a/helm/charts/stan/templates/service.yaml
+++ b/helm/charts/stan/templates/service.yaml
@@ -18,4 +18,5 @@ spec:
   {{- if not .Values.stan.nats.url }}
   - name: client
     port: 4222
+    appProtocol: tcp
   {{- end }}


### PR DESCRIPTION
Istio does not correctly automatically protocol sniff the `client` port, as such, adding `appProtocol: tcp` explicitly resolves this with istio.

Alternatively, you could rename the port to `tcp-client`, which also fixes this. I don't see this port name referenced elsewhere, but I don't want to create a possible issue by renaming it if it is.