### PR TITLE
Add mounts to leafnodes remote tls secrets

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -170,6 +170,11 @@ spec:
         secret:
           secretName: {{ .secret.name }}
       {{- end }}
+      {{- with .tls }}
+      - name: {{ .secret.name }}-volume
+        secret:
+          secretName: {{ .secret.name }}
+      {{- end }}
       {{- end }}
       {{- end }}
 
@@ -392,6 +397,10 @@ spec:
           {{- with .credentials }}
           - name: {{ .secret.name }}-volume
             mountPath: /etc/nats-creds/{{ .secret.name }}
+          {{- end }}
+          {{- with .tls }}
+          - name: {{ .secret.name }}-volume
+            mountPath: /etc/nats-certs/leafnodes/{{ .secret.name }}
           {{- end }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
This PR fixes the issue where the leafnodes remote tls secrets are not mounted into the NATS containers. This makes mTLS connections to be impossible to establish.

Co-authored-by: David Peinado-sempere <david.peinado-sempere@form3.tech>