### PR TITLE
Add Timeout and ExpectedServers flags

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -4,6 +4,6 @@ description: NATS Monitoring, Simplified.
 
 type: application
 
-version: 0.1.0
+version: 0.2.0
 
 appVersion: latest

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -43,6 +43,14 @@ spec:
            {{- with .servers }}
             - -s={{ . }}
            {{- end }}
+
+           {{- with .timeout }}
+            - -timeout={{ . }}
+           {{- end}}
+
+           {{- with .expectedServers }}
+            - -c={{ . }}
+           {{- end}}
            {{- end }}
           ports:
             - name: http

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -72,6 +72,12 @@ config:
   # Required.
   servers: "nats://nats:4222"
 
+  # Polling timeout
+  timeout: 3s
+
+  # Expected number of servers
+  expectedServers: 1
+
   # Required if auth is enabled.
   credentials:
     secret:


### PR DESCRIPTION
Co-authored-by: David Peinado-sempere <david.peinado-sempere@form3.tech>

This PR adds the possibility of defining timeouts and the number of expected servers.
Those flags were available on the binary but not the the Chart.

cc: @ripienaar