### PR TITLE
Add TLS Support

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -4,6 +4,6 @@ description: NATS Monitoring, Simplified.
 
 type: application
 
-version: 0.2.0
+version: 0.3.0
 
 appVersion: latest

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -46,11 +46,17 @@ spec:
 
            {{- with .timeout }}
             - -timeout={{ . }}
-           {{- end}}
+           {{- end }}
 
            {{- with .expectedServers }}
             - -c={{ . }}
-           {{- end}}
+           {{- end }}
+           
+           {{- with .tls }}
+            - -tlscacert=/etc/nats-certs/clients/{{ .ca }}
+            - -tlskey=/etc/nats-certs/clients/{{ .key }}
+            - -tlscert=/etc/nats-certs/clients/{{ .cert }}
+           {{- end }}
            {{- end }}
           ports:
             - name: http
@@ -65,14 +71,26 @@ spec:
               path: /metrics
               port: http
           volumeMounts:
+            {{- with .Values.config.credentials }}
             - name: creds
-              mountPath: "/creds/"
+              mountPath: /creds/
               readOnly: true
+            {{- end }}
+            {{- with .Values.config.tls }}
+            - name: {{ .secret.name }}-volume
+              mountPath: /etc/nats-certs/clients/
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         {{- with .Values.config.credentials }}
         - name: creds
+          secret:
+            secretName: {{ .secret.name }}
+        {{- end }}
+        {{- with .Values.config.tls }}
+        - name: {{ .secret.name }}-volume
           secret:
             secretName: {{ .secret.name }}
         {{- end }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -79,7 +79,15 @@ config:
   expectedServers: 1
 
   # Required if auth is enabled.
-  credentials:
-    secret:
-      name: nats-sys-creds
-      key: sys.creds
+  # credentials:
+  #   secret:
+  #     name: nats-sys-creds
+  #     key: sys.creds
+
+  # Required if tls is enabled.
+  # tls:
+  #    secret:
+  #      name: nats-client-tls
+  #    ca: "ca.crt"
+  #    cert: "tls.crt"
+  #    key: "tls.key"


### PR DESCRIPTION
Adds TLS Support so Surveyor can use authenticate using mTLS.
Sets credentials as optional. 

Co-authored-by: David Peinado-sempere <david.peinado-sempere@form3.tech>

cc: @ripienaar