### PR TITLE
Add support for JetStream account mTLS authentication in surveyor chart

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -4,6 +4,6 @@ description: NATS Monitoring, Simplified.
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 appVersion: latest

--- a/helm/charts/surveyor/templates/configmap.yaml
+++ b/helm/charts/surveyor/templates/configmap.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.config.jetstream.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-surveyor-accounts
+  labels:
+    {{- include "surveyor.labels" . | nindent 4 }}
+data:
+  {{- range .Values.config.jetstream.accounts }}
+  {{ .name }}.json: |
+    {
+      "name": "{{ .name }}",
+      {{- if .tls }}
+      "tls_ca": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.ca }}",
+      "tls_cert": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.cert }}",
+      "tls_key": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.key }}"
+      {{- end }}
+    }
+  {{- end }}
+{{- end }}

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -51,12 +51,16 @@ spec:
            {{- with .expectedServers }}
             - -c={{ . }}
            {{- end }}
-           
+
            {{- with .tls }}
             - -tlscacert=/etc/nats-certs/clients/{{ .ca }}
             - -tlskey=/etc/nats-certs/clients/{{ .key }}
             - -tlscert=/etc/nats-certs/clients/{{ .cert }}
            {{- end }}
+           {{- end }}
+
+           {{- if .Values.config.jetstream.enabled }}
+            - -jetstream=/jetstream
            {{- end }}
           ports:
             - name: http
@@ -64,11 +68,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /metrics
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /metrics
+              path: /healthz
               port: http
           volumeMounts:
             {{- with .Values.config.credentials }}
@@ -80,6 +80,23 @@ spec:
             - name: {{ .secret.name }}-volume
               mountPath: /etc/nats-certs/clients/
               readOnly: true
+            {{- end }}
+
+            {{- if .Values.config.jetstream.enabled }}
+            {{- with .Values.config.jetstream.accounts }}
+
+            {{- range . }}
+            # Mount every account tls certificate
+            {{- if .tls }}
+            - name: {{ .tls.secret.name }}-volume
+              mountPath: /etc/nats-certs/accounts/{{ .name }}
+            {{- end }}
+            {{- end }}
+
+            # Mount accounts configmap
+            - name: accounts-config-map
+              mountPath: /jetstream
+            {{- end }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -94,6 +111,26 @@ spec:
           secret:
             secretName: {{ .secret.name }}
         {{- end }}
+
+        {{- if .Values.config.jetstream.enabled }}
+        {{- with .Values.config.jetstream.accounts }}
+
+        {{- range . }}
+        # Mount every account tls certificate
+        {{- with .tls }}
+        - name: {{ .secret.name }}-volume
+          secret:
+            secretName: {{ .secret.name }}
+        {{- end }}
+        {{- end }}
+
+        # Mount accounts configmap
+        - name: accounts-config-map
+          configMap:
+            name: nats-surveyor-accounts
+        {{- end }}
+        {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -91,3 +91,14 @@ config:
   #    ca: "ca.crt"
   #    cert: "tls.crt"
   #    key: "tls.key"
+
+  jetstream:
+    enabled: false
+    # accounts:
+    # - name: test
+    #   tls:
+    #     secret:
+    #       name: test-user-tls
+    #     ca: "ca.crt"
+    #     cert: "tls.crt"
+    #     key: "tls.key"


### PR DESCRIPTION
NATS Surveyor chart does not currently support JetStream metrics.

We're adding support for the JetStream metrics and mTLS authentication.

Changes:

- Add new `jetstream` section to the chart values allowing configuration for the JetStream metrics and authentication.
- Fix `livenessProbe` to point to the `health` endpoint instead of the `metrics` one. The reason for this change is we were experiencing failures because both, prometheus and kubernetes were calling the `/metrics` endpoint and it doesn't support concurrent requests.
- Remove `readinessProbe` as NATS surveyor does not provide a readiness endpoint.

Co-authored-by: Samuel Torres <samuel.torres@form3.tech>