### PR TITLE
Add support for leafnode metrics on prometheus exporter

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -487,6 +487,9 @@ spec:
         {{- if .Values.nats.jetstream.enabled }}
         - -jsz=all
         {{- end }}
+        {{- if .Values.leafnodes.enabled }}
+        - -leafz
+        {{- end }}
         - http://localhost:8222/
         ports:
         - containerPort: 7777

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -396,7 +396,7 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: natsio/prometheus-nats-exporter:0.8.0
+  image: natsio/prometheus-nats-exporter:0.9.0
   pullPolicy: IfNotPresent
   securityContext: {}
   resources: {}


### PR DESCRIPTION
- Bump nats-exporter-version to 0.9.0
- Add leaf node metrics flag on prometheus exporter when leafnodes are enabled.

Co-authored-by: David Peinado-sempere <david.peinado-sempere@form3.tech>