### PR TITLE
Fix pingInterval in nats values

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -38,10 +38,6 @@ nats:
   # The number of connect attempts against discovered routes.
   connectRetries: 120
 
-  # How many seconds should pass before sending a PING
-  # to a client that has no activity.
-  pingInterval:
-
   # selector matchLabels for the server and service.
   # If left empty defaults are used.
   # This is helpful if you are updating from Chart version <=7.4
@@ -59,6 +55,10 @@ nats:
     writeDeadline:
     maxPending:
     maxPings:
+    
+    # How many seconds should pass before sending a PING
+    # to a client that has no activity.
+    pingInterval:
 
     # NOTE: this should be at least the same as 'terminationGracePeriodSeconds'
     lameDuckDuration: "120s"


### PR DESCRIPTION
I've noticed that to define pingInterval was not well documented in values.yaml. It should be on `.Values.nats.limits.pingInterval`

https://github.com/nats-io/k8s/blob/876f5e75d6b9aa3c661816ea1b25742ac8dcc0a6/helm/charts/nats/templates/configmap.yaml#L342-L344