### PR TITLE
Remove duplicated block securityContext in nats-box template

### DIFF
--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -108,8 +108,4 @@ spec:
         - name: {{ $secretName }}-clients-volume
           mountPath: /etc/nats-certs/clients/{{ $secretName }}
         {{- end }}
-{{- with .Values.securityContext }}
-      securityContext:
-{{ toYaml . | indent 8 }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
Remove duplicated block for security context in Nats helm chart.

without this update we always get the following error :
```
error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 40: mapping key "securityContext" already defined at line 23
```
  
This Error can be reproduced with following values.yaml:
```
cluster:
  enabled: true
  replicas: 3
natsbox:
  enabled: true
securityContext:
  fsGroup: 1000
  runAsUser: 1000
  runAsNonRoot: true
```