### PR TITLE
Feature/385 extend config via helm

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -10,21 +10,16 @@ data:
   nats.conf: |
     # PID file shared with configuration reloader.
     pid_file: "/var/run/nats/nats.pid"
-
-
-    {{- if .Values.nats.conf }}
+    
+    {{- if .Values.nats.config }}
     ###########
     #         #
     # Imports #
     #         #
     ###########
-    {{- with .Values.nats.conf }}
-    {{- range . }}
-    import ./{{ . }}.conf
+    {{- range .Values.nats.config }}
+    include ./{{ .name }}/{{ .name }}.conf
     {{- end}}
-    {{- end }}
-
-
     {{- end }}
 
     ###############

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -11,6 +11,22 @@ data:
     # PID file shared with configuration reloader.
     pid_file: "/var/run/nats/nats.pid"
 
+
+    {{- if .Values.nats.conf }}
+    ###########
+    #         #
+    # Imports #
+    #         #
+    ###########
+    {{- with .Values.nats.conf }}
+    {{- range . }}
+    import ./{{ . }}.conf
+    {{- end}}
+    {{- end }}
+
+
+    {{- end }}
+
     ###############
     #             #
     # Monitoring  #

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -88,6 +88,14 @@ spec:
           name: {{ include "nats.fullname" . }}-config
         {{ end }}
 
+      {{/* User extended config volumes*/}}
+      {{- if .Values.nats.config }}
+      # User extended config volumes
+      {{- with .Values.nats.config }}
+        {{- . | toYaml | nindent 6 }}
+      {{- end }}
+      {{- end }}
+  
       # Local volume shared with the reloader.
       - name: pid
         emptyDir: {}
@@ -323,6 +331,14 @@ spec:
             name: advertiseconfig
             subPath: advertise
           {{- end }}
+
+          {{/* User extended config volumes*/}}
+          {{- range .Values.nats.config }}
+          # User extended config volumes
+          - name: {{ .name }}
+            mountPath: /etc/nats-config/{{ .name }}
+          {{- end }}
+
 
           {{- if and .Values.auth.enabled .Values.auth.resolver }}
           {{- if eq .Values.auth.resolver.type "memory" }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -94,14 +94,13 @@ nats:
   #
   # e.g:
   #
-  # config:
-  #   auth:
-  #     configMap:
-  #       name: "nats-auth-configmap"
-  config:
-   - auth:
-     configMap:
-       mountPath: /p
+  #  config:
+  #    - name: ssh-key
+  #      secret:
+  #        secretName: ssh-key
+  #    - name: config-vol
+  #      configMap:
+  #        name: log-config
 
 
   jetstream:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -82,6 +82,27 @@ nats:
   # 
   # customConfigSecret:
   #  name:
+  #
+  # Alternately, the generated config can be extended with extra imports using the below syntax.
+  # The benefit of this is that cluster settings can be built up via helm values, but external
+  # secrets can be referenced and imported alongside it.
+  #
+  # config:
+  #   <name-of-config-item>:
+  #     <configMap|secret>
+  #       name: "<configMap|secret name>"
+  #
+  # e.g:
+  #
+  # config:
+  #   auth:
+  #     configMap:
+  #       name: "nats-auth-configmap"
+  config:
+   - auth:
+     configMap:
+       mountPath: /p
+
 
   jetstream:
     enabled: false


### PR DESCRIPTION
Allows for users to leverage the `import` directive of the NATS server conf by providing their own ConfigMap or Secret. 
Relates to Issue #385 

Can be demo'd in the following way

1. Create the following file (`auth.conf`):
```
authorization {
  default_permissions = {
    publish = "SANDBOX.*"
    subscribe = ["PUBLIC.>", "_INBOX.>"]
  }
  ADMIN = {
    publish = ">"
    subscribe = ">"
  }
  REQUESTOR = {
    publish = ["req.a", "req.b"]
    subscribe = "_INBOX.>"
  }
  RESPONDER = {
    subscribe = ["req.a", "req.b"]
    publish = "_INBOX.>"
  }
  users = [
    {user: admin,   password: "abc", permissions: $ADMIN}
    {user: client,  password: "123", permissions: $REQUESTOR}
    {user: service,  password: "easypeezy", permissions: $RESPONDER}
    {user: other, password: "lemonsqueezy"}
  ]
}
```
2. Create a secret based off the file
```
kubectl create secret generic nats-auth-conf --from-file=./auth.conf
```
3. Add a reference to the secret into the `values.yaml`
```
nats:
  config:
    - name: auth
      secret:
        secretName: nats-auth-conf
```
4. Deploy the chart: `helm install helm-mount . -f values.yaml`
5. Verify

```
$ kubectl exec -c nats -it pod/helm-mount-nats-0 -- ls -R /etc/nats-config
/etc/nats-config:
auth       nats.conf

/etc/nats-config/auth:
auth.conf
```

```
$ kubectl exec -c nats -it pod/helm-mount-nats-0 -- cat /etc/nats-config/nats.conf | grep include
include ./auth/auth.conf
```