### PR TITLE
Add support for installation to non-default namespace

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -1,7 +1,7 @@
 # NATS Setup
 
 The `setup.sh` script found at the root of the repository will run a
-`nats-setup` container image which will deploy a secure NATS cluster 
+`nats-setup` container image which will deploy a secure NATS cluster
 of three with allowed external access.
 
 ### Running the script locally
@@ -18,11 +18,12 @@ source .env
 
 Usage: ./setup/nats-setup.sh [options]
 
-    --without-tls             Setup the cluster without TLS enabled
-    --without-auth            Setup the cluster without Auth enabled
-    --without-surveyor        Skips installing NATS surveyor
-    --without-cert-manager    Skips installing the cert manager component
-    --without-nats-streaming  Setup the cluster without NATS Streaming
+    -n, --namespace <namespace>  Setup the cluster in the specified namespace
+    --without-tls                Setup the cluster without TLS enabled
+    --without-auth               Setup the cluster without Auth enabled
+    --without-surveyor           Skips installing NATS surveyor
+    --without-cert-manager       Skips installing the cert manager component
+    --without-nats-streaming     Setup the cluster without NATS Streaming
 ```
 
 ### Building nats-setup container image


### PR DESCRIPTION
Just a small backwards-compatible feature add to allow namespacing of resources created by `nats-setup.sh`.

Should pass all tests, but I'll be honest - I'm not sure if this PR's new feature will function as intended for all combinations of installed components.  It's entirely possible that adding a namespace in this manner might break I did a quick scan through the various yaml manifests and nothing stood out as especially problematic (like certain components expecting to be in the default namespace).

The only component I'm actually concerned for is prometheus, since it's the only component (that I saw) that is installed via a direct call to kubectl instead of using the kctl() helper function in `nats-setup.sh`.  Looking at `tools/prometheus-operator.yml` you're creating ClusterRoles rather than namespaced Roles, so that _should_ be totally fine.