### PR TITLE
updating the docker images in the example manifests

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -15,7 +15,7 @@ helm install my-nats nats/nats
 
 ```yaml
 nats:
-  image: nats:2.1.7-alpine3.11
+  image: nats:2.6.5-alpine
   pullPolicy: IfNotPresent
 ```
 

--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -131,7 +131,7 @@ store:
 
 ```yaml
 stan:
-  image: nats-streaming:0.18.0
+  image: nats-streaming:0.23.0
   pullPolicy: IfNotPresent
 ```
 
@@ -358,7 +358,7 @@ Example that will back up the file store when operating in clustered mode:
 
 ```yaml
 stan:
-  image: nats-streaming:0.18.0-alpine
+  image: nats-streaming:0.23.0-alpine
 store:
   limits:
     max_msgs: 5

--- a/nats-server/leafnodes/nats-cluster.yaml
+++ b/nats-server/leafnodes/nats-cluster.yaml
@@ -95,7 +95,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.9-alpine
+        image: nats:2.6.5-alpine
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/leafnodes/stan-server.yaml
+++ b/nats-server/leafnodes/stan-server.yaml
@@ -70,7 +70,7 @@ spec:
       # STAN Server
       containers:
       - name: stan
-        image: nats-streaming:0.19.0-alpine
+        image: nats-streaming:0.23.0-alpine
         ports:
         - containerPort: 8222
           name: monitor

--- a/nats-server/nats-server-plain.yml
+++ b/nats-server/nats-server-plain.yml
@@ -157,7 +157,7 @@ spec:
       #                               #
       #################################
       - name: reloader
-        image: connecteverything/nats-server-config-reloader:0.6.0
+        image: natsio/nats-server-config-reloader:0.6.2
         command:
          - "nats-server-config-reloader"
          - "-pid"
@@ -176,7 +176,7 @@ spec:
       #                            #
       ##############################
       - name: metrics
-        image: synadia/prometheus-nats-exporter:0.5.0
+        image: natsio/prometheus-nats-exporter:0.9.0
         args:
         - -connz
         - -routez

--- a/nats-server/nats-server-plain.yml
+++ b/nats-server/nats-server-plain.yml
@@ -86,7 +86,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.7-alpine3.11
+        image: nats:2.6.5-alpine
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/nats-server-with-auth-and-tls.yml
+++ b/nats-server/nats-server-with-auth-and-tls.yml
@@ -160,7 +160,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.7-alpine3.11
+        image: nats:2.6.5-alpine
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/nats-server-with-auth-and-tls.yml
+++ b/nats-server/nats-server-with-auth-and-tls.yml
@@ -145,7 +145,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: connecteverything/nats-boot-config:0.5.2
+        image: natsio/nats-boot-config:0.5.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /etc/nats-config/advertise
@@ -247,7 +247,7 @@ spec:
       #                               #
       #################################
       - name: reloader
-        image: connecteverything/nats-server-config-reloader:0.6.0
+        image: natsio/nats-server-config-reloader:0.6.2
         command:
          - "nats-server-config-reloader"
          - "-pid"
@@ -270,7 +270,7 @@ spec:
       #                            #
       ##############################
       - name: metrics
-        image: synadia/prometheus-nats-exporter:0.5.0
+        image: natsio/prometheus-nats-exporter:0.9.0
         args:
         - -connz
         - -routez

--- a/nats-server/nats-server-with-auth.yml
+++ b/nats-server/nats-server-with-auth.yml
@@ -133,7 +133,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.7-alpine3.11
+        image: nats:2.6.5-alpine
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/nats-server-with-auth.yml
+++ b/nats-server/nats-server-with-auth.yml
@@ -118,7 +118,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: connecteverything/nats-boot-config:0.5.2
+        image: natsio/nats-boot-config:0.5.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /etc/nats-config/advertise
@@ -212,7 +212,7 @@ spec:
       #                               #
       #################################
       - name: reloader
-        image: connecteverything/nats-server-config-reloader:0.6.0
+        image: natsio/nats-server-config-reloader:0.6.2
         command:
          - "nats-server-config-reloader"
          - "-pid"
@@ -235,7 +235,7 @@ spec:
       #                            #
       ##############################
       - name: metrics
-        image: synadia/prometheus-nats-exporter:0.5.0
+        image: natsio/prometheus-nats-exporter:0.9.0
         args:
         - -connz
         - -routez

--- a/nats-server/nats-server-without-auth.yml
+++ b/nats-server/nats-server-without-auth.yml
@@ -133,7 +133,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.7-alpine3.11
+        image: nats:2.6.5-alpine
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/nats-server-without-auth.yml
+++ b/nats-server/nats-server-without-auth.yml
@@ -118,7 +118,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: connecteverything/nats-boot-config:0.5.2
+        image: natsio/nats-boot-config:0.5.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /etc/nats-config/advertise
@@ -215,7 +215,7 @@ spec:
       #                               #
       #################################
       - name: reloader
-        image: connecteverything/nats-server-config-reloader:0.6.0
+        image: natsio/nats-server-config-reloader:0.6.2
         command:
          - "nats-server-config-reloader"
          - "-pid"
@@ -238,7 +238,7 @@ spec:
       #                            #
       ##############################
       - name: metrics
-        image: synadia/prometheus-nats-exporter:0.5.0
+        image: natsio/prometheus-nats-exporter:0.9.0
         args:
         - -connz
         - -routez

--- a/nats-server/simple-nats.yml
+++ b/nats-server/simple-nats.yml
@@ -85,7 +85,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.7-alpine3.11
+        image: nats:2.6.5-alpine
         ports:
         - containerPort: 4222
           name: client

--- a/nats-server/single-server-nats.yml
+++ b/nats-server/single-server-nats.yml
@@ -69,7 +69,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
-        image: nats:2.1.7-alpine3.11
+        image: nats:2.6.5-alpine
         ports:
         - containerPort: 4222
           name: client

--- a/nats-streaming-server/nats-streaming-auth-and-tls.yml
+++ b/nats-streaming-server/nats-streaming-auth-and-tls.yml
@@ -149,7 +149,7 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
       - name: metrics
-        image: synadia/prometheus-nats-exporter:0.6.0
+        image: natsio/prometheus-nats-exporter:0.9.0
         args:
         - -connz
         - -routez

--- a/nats-streaming-server/nats-streaming-auth-and-tls.yml
+++ b/nats-streaming-server/nats-streaming-auth-and-tls.yml
@@ -105,7 +105,7 @@ spec:
       # STAN Server
       containers:
       - name: stan
-        image: nats-streaming:0.16.2
+        image: nats-streaming:0.23.0
         ports:
         - containerPort: 8222
           name: monitor

--- a/nats-streaming-server/nats-streaming-auth.yml
+++ b/nats-streaming-server/nats-streaming-auth.yml
@@ -88,7 +88,7 @@ spec:
       # STAN Server
       containers:
       - name: stan
-        image: nats-streaming:0.16.2
+        image: nats-streaming:0.23.0
         ports:
         - containerPort: 8222
           name: monitor

--- a/nats-streaming-server/nats-streaming-auth.yml
+++ b/nats-streaming-server/nats-streaming-auth.yml
@@ -130,7 +130,7 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
       - name: metrics
-        image: synadia/prometheus-nats-exporter:0.6.0
+        image: natsio/prometheus-nats-exporter:0.9.0
         args:
         - -connz
         - -routez

--- a/nats-streaming-server/simple-stan.yml
+++ b/nats-streaming-server/simple-stan.yml
@@ -77,7 +77,7 @@ spec:
       # STAN Server
       containers:
       - name: stan
-        image: nats-streaming:0.16.2
+        image: nats-streaming:0.23.0
         ports:
         - containerPort: 8222
           name: monitor

--- a/nats-streaming-server/single-server-stan.yml
+++ b/nats-streaming-server/single-server-stan.yml
@@ -70,7 +70,7 @@ spec:
       # STAN Server
       containers:
       - name: stan
-        image: nats-streaming:0.16.2
+        image: nats-streaming:0.23.0
         ports:
         - containerPort: 8222
           name: monitor


### PR DESCRIPTION
  updating the docker images in the example manifests ([nats-server](https://github.com/nats-io/k8s/tree/main/nats-server) and [nats-streaming-server](https://github.com/nats-io/k8s/tree/main/nats-streaming-server)) with the values from https://github.com/nats-io/k8s/blob/main/helm/charts/nats/values.yaml

closes https://github.com/nats-io/k8s/issues/195