### PR TITLE
Added `namespaceOverride` for helm charts

### DIFF
--- a/helm/charts/nack/templates/_helpers.tpl
+++ b/helm/charts/nack/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Define the namespace where the content of the chart will be deployed.
+*/}}
+{{- define "jsc.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Define the serviceaccountname
 */}}
 {{- define "jsc.serviceAccountName" -}}

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -79,7 +79,7 @@ spec:
           - --creds=/etc/jsc-creds/{{ .secret.key }}
           {{- end }}
           {{- if .Values.namespaced }}
-          - --namespace={{ .Release.Namespace }}
+          - --namespace={{ template "jsc.namespace" }}
           {{- end }}
           {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.settings.client_cert }}
           - --tlscert={{ .Values.jetstream.tls.settings.client_cert }}

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -79,7 +79,7 @@ spec:
           - --creds=/etc/jsc-creds/{{ .secret.key }}
           {{- end }}
           {{- if .Values.namespaced }}
-          - --namespace={{ template "jsc.namespace" }}
+          - --namespace={{ template "jsc.namespace" . }}
           {{- end }}
           {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.settings.client_cert }}
           - --tlscert={{ .Values.jetstream.tls.settings.client_cert }}

--- a/helm/charts/nack/templates/rbac-jetstream-controller.yml
+++ b/helm/charts/nack/templates/rbac-jetstream-controller.yml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jsc.namespace" }}
 {{- if .Values.namespaced }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-role
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jsc.namespace" }}
 rules:
 - apiGroups:
   - ''
@@ -51,11 +51,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-role-binding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jsc.namespace" }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "jsc.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jsc.namespace" }}
 roleRef:
   kind: Role
   name: {{ template "jsc.serviceAccountName" . }}-role
@@ -66,7 +66,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-cluster-role
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jsc.namespace" }}
 rules:
 - apiGroups:
   - ''
@@ -107,11 +107,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-cluster-role-binding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jsc.namespace" }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "jsc.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jsc.namespace" }}
 roleRef:
   kind: ClusterRole
   name: {{ template "jsc.serviceAccountName" . }}-cluster-role

--- a/helm/charts/nack/templates/rbac-jetstream-controller.yml
+++ b/helm/charts/nack/templates/rbac-jetstream-controller.yml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}
-  namespace: {{ include "jsc.namespace" }}
+  namespace: {{ include "jsc.namespace" . }}
 {{- if .Values.namespaced }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-role
-  namespace: {{ include "jsc.namespace" }}
+  namespace: {{ include "jsc.namespace" . }}
 rules:
 - apiGroups:
   - ''
@@ -51,11 +51,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-role-binding
-  namespace: {{ include "jsc.namespace" }}
+  namespace: {{ include "jsc.namespace" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "jsc.serviceAccountName" . }}
-  namespace: {{ include "jsc.namespace" }}
+  namespace: {{ include "jsc.namespace" . }}
 roleRef:
   kind: Role
   name: {{ template "jsc.serviceAccountName" . }}-role
@@ -66,7 +66,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-cluster-role
-  namespace: {{ include "jsc.namespace" }}
+  namespace: {{ include "jsc.namespace" . }}
 rules:
 - apiGroups:
   - ''
@@ -107,11 +107,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-cluster-role-binding
-  namespace: {{ include "jsc.namespace" }}
+  namespace: {{ include "jsc.namespace" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "jsc.serviceAccountName" . }}
-  namespace: {{ include "jsc.namespace" }}
+  namespace: {{ include "jsc.namespace" . }}
 roleRef:
   kind: ClusterRole
   name: {{ template "jsc.serviceAccountName" . }}-cluster-role

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -40,6 +40,7 @@ jetstream:
 namespaced: false
 
 nameOverride: ""
+namespaceOverride: ""
 imagePullSecrets: []
 serviceAccountName: ""
 

--- a/helm/charts/nats-kafka/templates/_helpers.tpl
+++ b/helm/charts/nats-kafka/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Expand the namespace of the chart.
+*/}}
+{{- define "nats-kafka.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/helm/charts/nats-kafka/templates/configmap.yaml
+++ b/helm/charts/nats-kafka/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "nats-kafka.fullname" . }}-config
+  namespace: {{ include "nats-kafka.namespace" . }}
   labels:
     {{- include "nats-kafka.labels" . | nindent 4 }}
 data:

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "nats-kafka.fullname" . }}
+  namespace: {{ include "nats-kafka.namespace" . }}
   labels:
     {{- include "nats-kafka.labels" . | nindent 4 }}
     {{- if .Values.natskafka.deploymentLabels }}

--- a/helm/charts/nats-kafka/templates/service.yaml
+++ b/helm/charts/nats-kafka/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "nats-kafka.fullname" . }}
+  namespace: {{ include "nats-kafka.namespace" . }}
   labels:
     {{- include "nats-kafka.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/nats-kafka/values.yaml
+++ b/helm/charts/nats-kafka/values.yaml
@@ -2,6 +2,8 @@
 nameOverride: ""
 # fullnameOverride overrides nats-kafka.fullname
 fullnameOverride: ""
+# namespaceOverride overrides nats-kafka.namespace
+namespaceOverride: ""
 replicaCount: 1
 
 image:

--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -15,7 +15,7 @@ in the NATS documentation website:
 NATS Box has been deployed into your cluster, you can
 now use the NATS tools within the container as follows:
 
-  kubectl exec -n {{ template "nats.namespace" }} -it deployment/{{ template "nats.fullname" . }}-box -- /bin/sh -l
+  kubectl exec -n {{ template "nats.namespace" . }} -it deployment/{{ template "nats.fullname" . }}-box -- /bin/sh -l
 
   nats-box:~# nats-sub test &
   nats-box:~# nats-pub test hi

--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -15,7 +15,7 @@ in the NATS documentation website:
 NATS Box has been deployed into your cluster, you can
 now use the NATS tools within the container as follows:
 
-  kubectl exec -n {{ .Release.Namespace }} -it deployment/{{ template "nats.fullname" . }}-box -- /bin/sh -l
+  kubectl exec -n {{ template "nats.namespace" }} -it deployment/{{ template "nats.fullname" . }}-box -- /bin/sh -l
 
   nats-box:~# nats-sub test &
   nats-box:~# nats-pub test hi

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "nats.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 
 {{- define "nats.fullname" -}}
 {{- if .Values.fullnameOverride -}}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "nats.fullname" . }}-config
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "nats.namespace" . }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
 data:
   nats.conf: |
     # PID file shared with configuration reloader.
     pid_file: "/var/run/nats/nats.pid"
-    
+
     {{- if .Values.nats.config }}
     ###########
     #         #

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "nats.fullname" . }}-box
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "nats.namespace" . }}
   labels:
     app: {{ include "nats.fullname" . }}-box
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/helm/charts/nats/templates/networkpolicy.yaml
+++ b/helm/charts/nats/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ kind: NetworkPolicy
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 metadata:
   name: {{ include "nats.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "nats.namespace" . }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/nats/templates/pdb.yaml
+++ b/helm/charts/nats/templates/pdb.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "nats.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "nats.namespace" . }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/nats/templates/rbac.yaml
+++ b/helm/charts/nats/templates/rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.nats.serviceAccount }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "nats.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -27,5 +27,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.nats.serviceAccount }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "nats.namespace" . }}
 {{ end }}

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "nats.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "nats.namespace" . }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
   {{- if .Values.serviceAnnotations}}

--- a/helm/charts/nats/templates/serviceMonitor.yaml
+++ b/helm/charts/nats/templates/serviceMonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.exporter.serviceMonitor.namespace }}
   namespace: {{ .Values.exporter.serviceMonitor.namespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "nats.namespace" . }}
   {{- end }}
   {{- if .Values.exporter.serviceMonitor.labels }}
   labels:

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "nats.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "nats.namespace" . }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
     {{- if .Values.statefulSetAnnotations}}
@@ -95,7 +95,7 @@ spec:
         {{- . | toYaml | nindent 6 }}
       {{- end }}
       {{- end }}
-  
+
       # Local volume shared with the reloader.
       - name: pid
         emptyDir: {}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -55,7 +55,7 @@ nats:
     writeDeadline:
     maxPending:
     maxPings:
-    
+
     # How many seconds should pass before sending a PING
     # to a client that has no activity.
     pingInterval:
@@ -77,9 +77,9 @@ nats:
   # of the NATS Server.
   # NOTE: For this to work the name of the configuration has to be
   # called `nats.conf`.
-  # 
+  #
   # e.g. kubectl create secret generic custom-nats-conf --from-file nats.conf
-  # 
+  #
   # customConfigSecret:
   #  name:
   #
@@ -101,7 +101,6 @@ nats:
   #    - name: config-vol
   #      configMap:
   #        name: log-config
-
 
   jetstream:
     enabled: false
@@ -197,6 +196,7 @@ mqtt:
   #   key: "tls.key"
 
 nameOverride: ""
+namespaceOverride: ""
 
 # An array of imagePullSecrets, and they have to be created manually in the same namespace
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -320,7 +320,7 @@ leafnodes:
 #
 gateway:
   enabled: false
-  name: 'default'
+  name: "default"
   # authorization:
   #   user: foo
   #   password: pwd
@@ -363,7 +363,7 @@ bootconfig:
   image: natsio/nats-boot-config:0.5.4
   pullPolicy: IfNotPresent
   securityContext: {}
-  
+
 # NATS Box
 #
 # https://github.com/nats-io/nats-box


### PR DESCRIPTION
As proposed in #397 adding a `namespaceOverride` property enables users to select the namespace to deploy the resources to.

I implemented this to nack, nats and nats-kafka.

Is there anything else that needs to be done for this PR to be merged?