### PR TITLE
Expose log verbosity setting for JetStream Controller

### DIFF
--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -70,6 +70,9 @@ spec:
           imagePullPolicy: {{ .Values.jetstream.pullPolicy }}
           command:
           - /jetstream-controller
+          {{- if .Values.jetstream.klogLevel }}
+          - -v={{ .Values.jetstream.klogLevel }}
+          {{- end }}
           {{- if .Values.jetstream.nats.url }}
           - -s={{ .Values.jetstream.nats.url }}
           {{- else }}


### PR DESCRIPTION
This allows users to change the [klog](https://pkg.go.dev/k8s.io/klog) verbosity level for JetStream Controller. The value should be a positive integer.
```yaml
jetstream:
  enabled: true
  klogLevel: 10
  nats:
    url: nats://nats:4222
```