### PR TITLE
Allow client port name update so nats can be used with istio

### DIFF
--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
     appProtocol: http
     {{- end }}
   {{- end }}
-  - name: {{ .Values.nats.clientPortName | default client }}
+  - name: {{ .Values.nats.client.portName }}
     port: 4222
     {{- if .Values.appProtocol.enabled }}
     appProtocol: tcp

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
     appProtocol: http
     {{- end }}
   {{- end }}
-  - name: {{ .Values.nats.clientPortName }}
+  - name: {{ .Values.nats.clientPortName | default client }}
     port: 4222
     {{- if .Values.appProtocol.enabled }}
     appProtocol: tcp

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
     appProtocol: http
     {{- end }}
   {{- end }}
-  - name: client
+  - name: {{ .Values.nats.clientPortName }}
     port: 4222
     {{- if .Values.appProtocol.enabled }}
     appProtocol: tcp

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -252,7 +252,7 @@ spec:
           {{- toYaml .Values.nats.resources | nindent 10 }}
         ports:
         - containerPort: 4222
-          name: {{ .Values.nats.clientPortName }}
+          name: {{ .Values.nats.clientPortName | default client }}
           {{- if .Values.nats.externalAccess }}
           hostPort: 4222
           {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -252,7 +252,7 @@ spec:
           {{- toYaml .Values.nats.resources | nindent 10 }}
         ports:
         - containerPort: 4222
-          name: {{ .Values.nats.clientPortName | default client }}
+          name: {{ .Values.nats.client.portName }}
           {{- if .Values.nats.externalAccess }}
           hostPort: 4222
           {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -252,7 +252,7 @@ spec:
           {{- toYaml .Values.nats.resources | nindent 10 }}
         ports:
         - containerPort: 4222
-          name: client
+          name: {{ .Values.nats.clientPortName }}
           {{- if .Values.nats.externalAccess }}
           hostPort: 4222
           {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -45,8 +45,6 @@ nats:
 
   resources: {}
 
-  clientPortName: client
-
   # Server settings.
   limits:
     maxConnections:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -45,6 +45,9 @@ nats:
 
   resources: {}
 
+  client:
+    portName: "client"
+
   # Server settings.
   limits:
     maxConnections:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -45,6 +45,8 @@ nats:
 
   resources: {}
 
+  clientPortName: client
+
   # Server settings.
   limits:
     maxConnections:


### PR DESCRIPTION
### What
This PR allows for the update of the client container port name. Need to be able to name the 4222 port (client port) to tcp for nats to work with istio. see here: istio/istio#28623. Reason for this is because nats is a server first protocol. 

### Test
Where I work we have copied the nats chart and made this update, we needed to do this since we are using nats with istio.