### PR TITLE
Add healthz

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.11.2
+version: 0.11.3
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 2.7.0
+appVersion: 2.7.1
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications
   Technology.
 name: nats
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.11.3
+version: 0.12.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -22,6 +22,9 @@ spec:
   replicas: 1
   {{- end }}
   serviceName: {{ include "nats.fullname" . }}
+
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+
   template:
     metadata:
       {{- if or .Values.podAnnotations .Values.exporter.enabled }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -435,20 +435,56 @@ spec:
           {{- toYaml .Values.additionalVolumeMounts | nindent 10 }}
           {{- end }}
 
-        # Liveness/Readiness probes against the monitoring.
-        #
+        ################################
+        #                              #
+        # Liveness/Readiness probes.   #
+        #                              #
+        ################################
+        {{- if .Values.nats.healthcheck }}
+
+        {{- with .Values.nats.healthcheck.liveness }}
+        {{- if .enabled }}
         livenessProbe:
           httpGet:
             path: /
             port: 8222
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          successThreshold: {{ .successThreshold }}
+          failureThreshold: {{ .failureThreshold }}
+        {{- end }}
+        {{- end }}
+
+        {{- with .Values.nats.healthcheck.readiness }}
+        {{- if .enabled }}
         readinessProbe:
           httpGet:
             path: /
             port: 8222
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          successThreshold: {{ .successThreshold }}
+          failureThreshold: {{ .failureThreshold }}
+        {{- end }}
+        {{- end }}
+
+        {{- with .Values.nats.healthcheck.startup }}
+        {{- if .enabled }}
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8222
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          successThreshold: {{ .successThreshold }}
+          failureThreshold: {{ .failureThreshold }}
+        {{- end }}
+        {{- end }}
+
+        {{- end }}
 
         # Gracefully stop NATS Server on pod deletion or image upgrade.
         #

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -438,11 +438,11 @@ spec:
           {{- toYaml .Values.additionalVolumeMounts | nindent 10 }}
           {{- end }}
 
-        ################################
-        #                              #
-        # Liveness/Readiness probes.   #
-        #                              #
-        ################################
+        #######################
+        #                     #
+        # Healthcheck Probes  #
+        #                     #
+        #######################
         {{- if .Values.nats.healthcheck }}
 
         {{- with .Values.nats.healthcheck.liveness }}
@@ -456,6 +456,9 @@ spec:
           periodSeconds: {{ .periodSeconds }}
           successThreshold: {{ .successThreshold }}
           failureThreshold: {{ .failureThreshold }}
+          {{- if .terminationGracePeriodSeconds }}
+          terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+          {{- end }}
         {{- end }}
         {{- end }}
 
@@ -473,12 +476,18 @@ spec:
         {{- end }}
         {{- end }}
 
-        {{- with .Values.nats.healthcheck.startup }}
-        {{- if .enabled }}
+        {{- if .Values.nats.healthcheck.startup.enabled }}
         startupProbe:
           httpGet:
+            {{- if and .Values.nats.healthcheck.useHealthz .Release.IsUpgrade }}
+            # During upgrades, healthz will be enabled instead to allow for a grace period
+            # in case of JetStream enabled deployments to form quorum and streams to catch up.
             path: /healthz
+            {{- else }}
+            path: /
+            {{- end }}
             port: 8222
+        {{- with .Values.nats.healthcheck.startup }}
           initialDelaySeconds: {{ .initialDelaySeconds }}
           timeoutSeconds: {{ .timeoutSeconds }}
           periodSeconds: {{ .periodSeconds }}
@@ -501,7 +510,7 @@ spec:
               command:
               - "/bin/sh"
               - "-c"
-              - "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep {{ .Values.nats.terminationGracePeriodSeconds }}"
+              - "nats-server -sl=ldm=/var/run/nats/nats.pid"
 
       #################################
       #                               #

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -479,7 +479,11 @@ spec:
         {{- if .Values.nats.healthcheck.startup.enabled }}
         startupProbe:
           httpGet:
-            {{- if and .Values.nats.healthcheck.useHealthz .Release.IsUpgrade }}
+            {{- $parts := split ":" .Values.nats.image }}
+            {{- $tag := $parts._1 }}
+            {{- $version := semver $tag }}
+            {{- $simpleVersion := printf "%d.%d.%d" $version.Major $version.Minor $version.Patch }}
+            {{- if and (and .Release.IsUpgrade (semverCompare "~2.7.1" $simpleVersion) .Values.nats.healthcheck.enableHealthz ) }}
             # During upgrades, healthz will be enabled instead to allow for a grace period
             # in case of JetStream enabled deployments to form quorum and streams to catch up.
             path: /healthz

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -18,6 +18,40 @@ nats:
     enabled: false
     port: 6000
 
+  # Toggle using health check probes to better detect failures.
+  healthcheck:
+    # Enable liveness checks.  If this fails, then the NATS Server will restarted.
+    liveness:
+      enabled: true
+
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+
+    # Check for the server to be ready for connections during startup.
+    readiness:
+      enabled: true
+
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+
+    # Enable startup checks.
+    # NOTE: Only works on NATS Server +2.7.1.
+    # This is recommended for NATS JetStream deployments.
+    startup:
+      enabled: false
+
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
   # securityContext for the nats container
   securityContext: {}
 
@@ -332,7 +366,7 @@ gateway:
 
   # You can add an implicit advertise address instead of using from Node's IP
   # could also be a fqdn address
-  #advertise: "nats.example.com"
+  # advertise: "nats.example.com"
 
   #############################
   #                           #
@@ -374,7 +408,7 @@ bootconfig:
 #
 natsbox:
   enabled: true
-  image: natsio/nats-box:0.7.0
+  image: natsio/nats-box:0.8.0
   pullPolicy: IfNotPresent
   securityContext: {}
 
@@ -595,3 +629,4 @@ k8sClusterDomain: cluster.local
 
 # Add labels to all the deployed resources
 commonLabels: {}
+

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -630,3 +630,6 @@ k8sClusterDomain: cluster.local
 # Add labels to all the deployed resources
 commonLabels: {}
 
+# podManagementPolicy controls how pods are created during initial scale up,
+# when replacing pods on nodes, or when scaling down.
+podManagementPolicy: Parallel

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -20,6 +20,10 @@ nats:
 
   # Toggle using health check probes to better detect failures.
   healthcheck:
+    # NOTE: Only works on NATS Server +2.7.1.
+    # This is recommended to be enabled for NATS JetStream deployments upgrades.
+    useHealthz: false
+
     # Enable liveness checks.  If this fails, then the NATS Server will restarted.
     liveness:
       enabled: true
@@ -29,10 +33,15 @@ nats:
       periodSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+      # Only for Kubernetes +1.22 that have pod level probes enabled.
+      terminationGracePeriodSeconds:
 
-    # Check for the server to be ready for connections during startup.
+    # Periodically check for the server to be ready for connections while
+    # the NATS container is running.
+    # Disabled by default since covered by startup probe and it is the same
+    # as the liveness check.
     readiness:
-      enabled: true
+      enabled: false
 
       initialDelaySeconds: 10
       timeoutSeconds: 5
@@ -40,11 +49,11 @@ nats:
       successThreshold: 1
       failureThreshold: 3
 
-    # Enable startup checks.
-    # NOTE: Only works on NATS Server +2.7.1.
-    # This is recommended for NATS JetStream deployments.
+    # Enable startup checks to confirm server is ready for traffic.
+    # This is recommended for JetStream deployments since in cluster mode
+    # it will try to ensure that the server is ready to serve streams.
     startup:
-      enabled: false
+      enabled: true
 
       initialDelaySeconds: 10
       timeoutSeconds: 5
@@ -101,7 +110,8 @@ nats:
     # NOTE: this should be at least the same as 'terminationGracePeriodSeconds'
     lameDuckDuration: "120s"
 
-  # Default lame duck duration in the server is 2 minutes.
+  # terminationGracePeriodSeconds determines how long to allow for a pod
+  # to be restarted.
   terminationGracePeriodSeconds: 120
 
   logging:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -4,7 +4,7 @@
 #                             #
 ###############################
 nats:
-  image: nats:2.7.0-alpine
+  image: nats:2.7.1-alpine
   pullPolicy: IfNotPresent
 
   # The servers name prefix, must be used for example when we want a NATS cluster
@@ -22,7 +22,7 @@ nats:
   healthcheck:
     # NOTE: Only works on NATS Server +2.7.1.
     # This is recommended to be enabled for NATS JetStream deployments upgrades.
-    useHealthz: false
+    enableHealthz: true
 
     # Enable liveness checks.  If this fails, then the NATS Server will restarted.
     liveness:


### PR DESCRIPTION
This is to enable the startup probe healthz to ensure JS is ready at the beginning. _**This the default**_ when using  NATS Server +2.7.1 and assumes running on a Kubernetes version above 1.16.  The `/healthz` endpoint only becomes enabled during upgrades and it is disabled during a first install of NATS.

In order to disable in case of not using a K8S version above 1.16:

```yaml
nats:
  image: nats:2.7.1
  pullPolicy: Always

  healthcheck:
    startup:
      enabled: false
```

Other major changes:

- The preStop command no longer waits for `terminationGracePeriodSeconds` since this blocks pod termination, this workaround used to exist for when nats-server did not handle TERM but since v2.2 it does now so lame duck should work correctly without being stopped prematurely.
- podManagementPolicy is now set to `Parallel` by default .
- readiness probe is disabled now by default since it is the same as livenessProbe and the startupProbe covers the same check during startup.