### PR TITLE
Bump default liveness period seconds

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.12.0
+version: 0.12.1
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -30,7 +30,20 @@ nats:
 
       initialDelaySeconds: 10
       timeoutSeconds: 5
-      periodSeconds: 10
+      # NOTE: liveness check + terminationGracePeriodSeconds can introduce unecessarily long outages
+      # due to the coupling between liveness probe and terminationGracePeriodSeconds.
+      # To avoid this, we make the periodSeconds of the liveness check to be about half the default
+      # time that it takes for lame duck graceful stop.
+      #
+      # In case of using Kubernetes +1.22 with probe-level terminationGracePeriodSeconds
+      # we could revise this but for now keep a minimal liveness check.
+      #
+      # More info:
+      #
+      #  https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#probe-level-terminationgraceperiodseconds
+      #  https://github.com/kubernetes/kubernetes/issues/64715
+      #
+      periodSeconds: 60
       successThreshold: 1
       failureThreshold: 3
       # Only for Kubernetes +1.22 that have pod level probes enabled.


### PR DESCRIPTION
Noticed that sometimes during lame duck the liveness check can conflict with the graceful stop, since a liveness check failing will unexpectedly cause a pod to take terminationGracePeriodSeconds long to exit causing unecessary outages (120 seconds) (k8s issue: https://github.com/kubernetes/kubernetes/issues/64715)

This got eventually fixed in k8s by adding liveness probe but for now the liveness check does more harm than it helps considering that the liveness check is just a request to check that the monitoring endpoint is alive, so for now bump to about half the time it would take lame duck to complete and once k8s v1.22 has pod liveness probe out of beta switch to use those instead.

Signed-off-by: Waldemar Quevedo <wally@nats.io>