### PR TITLE
Add option to use short names instead of FQDN

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -62,7 +62,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the proper NATS image name
 */}}
 {{- define "nats.clusterAdvertise" -}}
+{{- if $.Values.useFQDN }}
 {{- printf "$(POD_NAME).%s.$(POD_NAMESPACE).svc.%s" (include "nats.fullname" . ) $.Values.k8sClusterDomain }}
+{{- else }}
+{{- printf "$(POD_NAME).%s.$(POD_NAMESPACE)" (include "nats.fullname" . ) }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -72,7 +76,11 @@ Return the NATS cluster routes.
 {{- $name := (include "nats.fullname" . ) -}}
 {{- $namespace := (include "nats.namespace" . ) -}}
 {{- range $i, $e := until (.Values.cluster.replicas | int) -}}
+{{- if $.Values.useFQDN }}
 {{- printf "nats://%s-%d.%s.%s.svc.%s:6222," $name $i $name $namespace $.Values.k8sClusterDomain -}}
+{{- else }}
+{{- printf "nats://%s-%d.%s.%s:6222," $name $i $name $namespace -}}
+{{- end }}
 {{- end -}}
 {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -651,6 +651,9 @@ networkPolicy:
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 k8sClusterDomain: cluster.local
 
+# Define if NATS is using FQDN name for clustering (i.e. nats-0.nats.default.svc.cluster.local) or short name (i.e. nats-0.nats.default).
+useFQDN: true
+
 # Add labels to all the deployed resources
 commonLabels: {}
 


### PR DESCRIPTION
Currently if cluster has custom domain name, users have to override `k8sClusterDomain: cluster.local`.
This is not very portable if you want to reuse the same config for different clusters.

Added optional (disabled by default) FQDN usage.
If 
```
useFQDN: false
```
is set, NATS will use short DNS names (i.e. `nats-0.nats.default`)

EDIT: we could consider to use this option by default, though I didn't want to introduce such a change without knowing context.