### PR TITLE
adding allow_non_tls to tls config

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -44,6 +44,9 @@ data:
     {{- $_ := set $nats_tls "secretPath" "/etc/nats-certs/clients" }}
     {{- tpl (include "nats.tlsConfig" $nats_tls) $ | nindent 4}}
     {{- end }}
+
+    allow_non_tls: {{ .Values.nats.tls.allow_non_tls }}
+    
     {{- end }}
 
     {{- if .Values.nats.jetstream.enabled }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -226,6 +226,7 @@ nats:
   #
 
   # tls:
+  #   allow_non_tls: false
   #   secret:
   #     name: nats-client-tls
   #   ca: "ca.crt"


### PR DESCRIPTION
This will give the possibility to enable the feature flag _allow_non_tls_. 