### PR TITLE
Fixed stan helm readme for clarity

### DIFF
--- a/helm/charts/stan/README.md
+++ b/helm/charts/stan/README.md
@@ -68,6 +68,7 @@ This will cause STAN  to connect to NATS using TLS, given a
 secret containing the ca.crt, tls.crt, and tls.key.
 
 ```yaml
+stan:
   tls:
     enabled: true
     # the secret containing the client ca.crt, tls.crt, and tls.key for STAN


### PR DESCRIPTION
When configuring TLS myself I didn't notice this section was indented or that it belonged to the `stan` section of the values file until I looked through the values file and noticed it. I'm proposing this change to prevent the confusion I had