### PR TITLE
Fixes parameters overwrite problems when used with kustomize

### DIFF
--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -48,7 +48,7 @@ podAnnotations: {}
 
 # Toggle whether to use setup a Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-securityContext: null
+securityContext: {}
 # securityContext:
 #   fsGroup: 1000
 #   runAsUser: 1000
@@ -56,7 +56,7 @@ securityContext: null
 
 # Configure a container security context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-containerSecurityContext: null
+containerSecurityContext: {}
 # containerSecurityContext:
 #   allowPrivilegeEscalation: false
 #   readOnlyRootFilesystem: true


### PR DESCRIPTION
I tried to overwrite the SecurityContext of the helm chart using `kustomize build . --enable-helm` and appended `kustomization.yaml`. Unfortunately, the securityContext wasn't set as expected. Changing the `values.yaml` resolved the problem for me.

kustomization.yaml
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

helmCharts:
  - name: nack
    includeCRDs: false
    valuesInline:
      jetstream:
        enabled: true
        nats:
          url: nats://nats:4222
      securityContext:
        fsGroup: 1000
        runAsUser: 1000
        runAsNonRoot: true
    releaseName: nack
    version: 0.13.0
    repo: https://raw.githubusercontent.com/nats-io/k8s/master/helm/charts
    namespace: nats
```
