### PR TITLE
Remove storage class name from examples

### DIFF
--- a/helm/charts/nack/README.md
+++ b/helm/charts/nack/README.md
@@ -36,7 +36,6 @@ nats:
       enabled: true
       storageDirectory: /data/jetstream
       size: 10Gi
-      storageClassName: default
 
 natsbox:
   enabled: false

--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -372,7 +372,6 @@ nats:
       enabled: true
       size: 1Gi
       storageDirectory: /data/
-      storageClassName: default
 ```
 
 ### Using with an existing PersistentVolumeClaim
@@ -429,7 +428,6 @@ nats:
       enabled: true
       size: "1Gi"
       storageDirectory: /data/
-      storageClassName: default
 
 cluster:
   enabled: true


### PR DESCRIPTION
Passing `default` as a name for storage class in example can lead to pretty hard to undersand errors with PVCs, despite them being extremely simple.

That's because error will say that `"default" storage class is not found` despite having `default` storage class set. The error says that it cannot find storage class named `default`, not the actual k8s default storage class...

That happens for example in GKE, where default storage class is named `standard`