### PR TITLE
Add support for specifying websocket advertise host:port

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -418,6 +418,9 @@ data:
       {{- with .Values.websocket.allowedOrigins }}
       allowed_origins: {{ toRawJson . }}
       {{- end }}
+      {{- with .Values.websocket.advertise }}
+      advertise: {{ . }}
+      {{- end }}
     }
     {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -606,6 +606,10 @@ websocket:
   sameOrigin: false
   allowedOrigins: []
 
+  # This will optionally specify what host:port for websocket
+  # connections to be advertised in the cluster.
+  # advertise: "host:port"
+
 appProtocol:
   enabled: false
 


### PR DESCRIPTION
Add the ability to specify the websocket advertise property, which is particularly useful when wanting to expose via a load balancer.