### PR TITLE
[nats helm] improve healthz detection

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -480,11 +480,9 @@ spec:
         startupProbe:
           httpGet:
             {{- $parts := split ":" .Values.nats.image }}
-            {{- $tag := $parts._1 }}
-            {{- $version := semver $tag }}
-            {{- $simpleVersion := printf "%d.%d.%d" $version.Major $version.Minor $version.Patch }}
-            {{- if and (and (or .Release.IsUpgrade .Values.upgrade) (semverCompare "~2.7.1" $simpleVersion) .Values.nats.healthcheck.enableHealthz ) }}
-            # During upgrades, healthz will be enabled instead to allow for a grace period
+            {{- $simpleVersion := $parts._1 | default "latest" | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.7.1" }}
+            {{- if and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $simpleVersion)) }}
+            # for NATS server versions >=2.7.1, healthz will be enabled to allow for a grace period
             # in case of JetStream enabled deployments to form quorum and streams to catch up.
             path: /healthz
             {{- else }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -20,8 +20,10 @@ nats:
 
   # Toggle using health check probes to better detect failures.
   healthcheck:
-    # NOTE: Only works on NATS Server +2.7.1.
-    # This is recommended to be enabled for NATS JetStream deployments upgrades.
+    # /healthz health check endpoint was introduced in NATS Server 2.7.1
+    # Attempt to detect /healthz support by inspecting if tag is >=2.7.1
+    detectHealthz: true
+    # Enable /healthz startupProbe for controlled upgrades of NATS JetStream
     enableHealthz: true
 
     # Enable liveness checks.  If this fails, then the NATS Server will restarted.
@@ -671,7 +673,3 @@ commonLabels: {}
 # podManagementPolicy controls how pods are created during initial scale up,
 # when replacing pods on nodes, or when scaling down.
 podManagementPolicy: Parallel
-
-# Toggle that this is an upgrade to enable healthz, in case not
-# using `helm upgrade` command to apply upgrades.
-upgrade: false


### PR DESCRIPTION
- switch version detection to use `regexFind`, since `semver` raises an error if no valid semver is found, and image tags are not required to be semvers
- default version to support healthz if a semver cannot be detected
- add `nats.healthcheck.detectHealthz` bool to optionally disable version detection
- remove helm upgrade checking for health check - this didn't work in some tools such as ArgoCD and should no longer be needed since #442 was merged