### PR TITLE
[nats helm] release 0.13.2

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 2.7.2
+appVersion: 2.7.3
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications
   Technology.
 name: nats
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.13.1
+version: 0.13.2
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -4,7 +4,7 @@
 #                             #
 ###############################
 nats:
-  image: nats:2.7.2-alpine
+  image: nats:2.7.3-alpine
   pullPolicy: IfNotPresent
 
   # The servers name prefix, must be used for example when we want a NATS cluster


### PR DESCRIPTION
# nats-helm release 0.13.2

## Improvements

- Improve healthcheck /healthz endpoint detection ([#445](https://github.com/nats-io/k8s/pull/445))
- Add publishNotReadyAddresses: true to headless service ([#442](https://github.com/nats-io/k8s/pull/442))
