### PR TITLE
Further YAML formatting consistency fixes for nats chart

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -48,7 +48,7 @@ data:
     {{- if .Values.nats.tls.allowNonTLS }}
     allow_non_tls: {{ .Values.nats.tls.allowNonTLS }}
     {{- end }}
-   
+
     {{- end }}
 
     {{- if .Values.nats.jetstream.enabled }}

--- a/helm/charts/nats/templates/networkpolicy.yaml
+++ b/helm/charts/nats/templates/networkpolicy.yaml
@@ -8,69 +8,72 @@ metadata:
     {{- include "nats.labels" . | nindent 4 }}
 spec:
   podSelector:
-    matchLabels: {{- include "nats.selectorLabels" . | nindent 6 }}
+    matchLabels:
+      {{- include "nats.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Ingress
   - Egress
   egress:
-    # Allow dns resolution
-    - ports:
-      - port: 53
-        protocol: UDP
-    # Allow outbound connections to other cluster pods
-    - ports:
-      - port: 4222
-        protocol: TCP
-      - port: 6222
-        protocol: TCP
-      - port: 8222
-        protocol: TCP
-      - port: 7777
-        protocol: TCP
-      - port: 7422
-        protocol: TCP
-      - port: 7522
-        protocol: TCP
-      to:
-      - podSelector:
-          matchLabels: {{- include "nats.selectorLabels" . | nindent 14 }}
-    {{- if .Values.networkPolicy.extraEgress }}
-    {{- include "tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
-    {{- end }}
+  # Allow dns resolution
+  - ports:
+    - port: 53
+      protocol: UDP
+  # Allow outbound connections to other cluster pods
+  - ports:
+    - port: 4222
+      protocol: TCP
+    - port: 6222
+      protocol: TCP
+    - port: 8222
+      protocol: TCP
+    - port: 7777
+      protocol: TCP
+    - port: 7422
+      protocol: TCP
+    - port: 7522
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          {{- include "nats.selectorLabels" . | nindent 10 }}
+  {{- if .Values.networkPolicy.extraEgress }}
+  {{- include "tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 2 }}
+  {{- end }}
   ingress:
-    # Allow inbound connections
-    - ports:
-      - port: 4222
-        protocol: TCP
-      - port: 6222
-        protocol: TCP
-      - port: 8222
-        protocol: TCP
-      - port: 7777
-        protocol: TCP
-      - port: 7422
-        protocol: TCP
-      - port: 7522
-        protocol: TCP
-      {{- if not .Values.networkPolicy.allowExternal }}
-      from:
-        - podSelector:
-            matchLabels:
-              {{ include "nats.fullname" . }}-client: "true"
-        - podSelector:
-            matchLabels: {{- include "nats.selectorLabels" . | nindent 14 }}
-        {{- if .Values.networkPolicy.ingressNSMatchLabels }}
-        - namespaceSelector:
-            matchLabels:
-              {{- toYaml .Values.networkPolicy.ingressNSMatchLabels | nindent 14 }}
-          {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
-          podSelector:
-            matchLabels:
-              {{- toYaml .Values.networkPolicy.ingressNSPodMatchLabels | nindent 14 }}
-          {{- end }}
-        {{- end }}
+  # Allow inbound connections
+  - ports:
+    - port: 4222
+      protocol: TCP
+    - port: 6222
+      protocol: TCP
+    - port: 8222
+      protocol: TCP
+    - port: 7777
+      protocol: TCP
+    - port: 7422
+      protocol: TCP
+    - port: 7522
+      protocol: TCP
+    {{- if not .Values.networkPolicy.allowExternal }}
+    from:
+    - podSelector:
+        matchLabels:
+          {{ include "nats.fullname" . }}-client: "true"
+    - podSelector:
+        matchLabels:
+          {{- include "nats.selectorLabels" . | nindent 10 }}
+    {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+    - namespaceSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.ingressNSMatchLabels | nindent 10 }}
+      {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+      podSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.ingressNSPodMatchLabels | nindent 10 }}
       {{- end }}
-    {{- if .Values.networkPolicy.extraIngress }}
-    {{- include "tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- end }}
+  {{- if .Values.networkPolicy.extraIngress }}
+  {{- include "tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 2 }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Following on from https://github.com/nats-io/k8s/pull/437 I have subsequently discovered a few more YAML formatting inconsistencies in the templates of the `nats` chart. This PR should update those to make them consistent with the rest of the chart and pass `yamllint` checks.