### PR TITLE
enable skip-existing flag on helm releaser

### DIFF
--- a/helm/cr.yaml
+++ b/helm/cr.yaml
@@ -1,3 +1,4 @@
 # https://github.com/helm/chart-releaser#config-file
 pages-branch: main
 pages-index-path: helm/charts/index.yaml
+skip-existing: true


### PR DESCRIPTION
prevents helm releaser from trying to push over existing tags