### PR TITLE
[nats helm] faster rollouts for graceful shutdowns

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -384,6 +384,10 @@ data:
     write_deadline: {{ . }}
     {{- end }}
 
+    {{- with .Values.nats.limits.lameDuckGracePeriod }}
+    lame_duck_grace_period: {{ . }}
+    {{- end }}
+
     {{- with .Values.nats.limits.lameDuckDuration }}
     lame_duck_duration: {{ . }}
     {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -503,14 +503,12 @@ spec:
         lifecycle:
           preStop:
             exec:
-              # Using the alpine based NATS image, we add an extra sleep that is
-              # the same amount as the terminationGracePeriodSeconds to allow
-              # the NATS Server to gracefully terminate the client connections.
+              # send the lame duck shutdown signal to trigger a graceful shutdown
+              # nats-server will ignore the TERM signal it receives after this
               #
               command:
-              - "/bin/sh"
-              - "-c"
-              - "nats-server -sl=ldm=/var/run/nats/nats.pid"
+              - "nats-server"
+              - "-sl=ldm=/var/run/nats/nats.pid"
 
       #################################
       #                               #

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -45,7 +45,7 @@ nats:
       #  https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#probe-level-terminationgraceperiodseconds
       #  https://github.com/kubernetes/kubernetes/issues/64715
       #
-      periodSeconds: 60
+      periodSeconds: 30
       successThreshold: 1
       failureThreshold: 3
       # Only for Kubernetes +1.22 that have pod level probes enabled.
@@ -122,12 +122,15 @@ nats:
     # to a client that has no activity.
     pingInterval:
 
-    # NOTE: this should be at least the same as 'terminationGracePeriodSeconds'
-    lameDuckDuration: "120s"
+    # grace period after pod begins shutdown before starting to close client connections
+    lameDuckGracePeriod: "10s"
 
-  # terminationGracePeriodSeconds determines how long to allow for a pod
-  # to be restarted.
-  terminationGracePeriodSeconds: 120
+    # duration over which to slowly close close client connections after lameDuckGracePeriod has passed
+    lameDuckDuration: "30s"
+
+  # terminationGracePeriodSeconds determines how long to wait for graceful shutdown
+  # this should be at least `lameDuckGracePeriod` + `lameDuckDuration` + 20s shutdown overhead
+  terminationGracePeriodSeconds: 60
 
   logging:
     debug:


### PR DESCRIPTION
Adds defaults and recommendations for total graceful shutdown with [lame duck mode](https://docs.nats.io/running-a-nats-service/nats_admin/lame_duck_mode) using the formula:

```
lame_duck_grace_period + lame_duck_duration + 20s shutdown overhead
```

~Also adds `sleep {{ .Values.nats.terminationGracePeriodSeconds }}` to end of the `preStop` lifecycle hook to avoid process receiving TERM signal during lame duck shutdown~