### PR TITLE
release nats-0.14.0

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.13.2
+version: 0.14.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo


### PR DESCRIPTION
# nats-0.14.0

## Features

- Enable podDisruptionBudget by default ([#457](https://github.com/nats-io/k8s/pull/457))
- Faster rollouts for graceful shutdowns ([#460](https://github.com/nats-io/k8s/pull/460))
- Use config checksum in addition to reloader ([#464](https://github.com/nats-io/k8s/pull/464))


## Fixes

- Fix nindent levels ([#463](https://github.com/nats-io/k8s/pull/463))