### PR TITLE
[nats helm] Fix tests, and allow to override leafnodes and gateway ports

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -177,7 +177,7 @@ data:
     #################
     leafnodes {
       {{- if .Values.leafnodes.enabled }}
-      listen: "0.0.0.0:7422"
+      listen: "0.0.0.0:{{ .Values.leafnodes.port }}"
       {{- end }}
 
       {{- if and .Values.nats.advertise .Values.nats.externalAccess }}
@@ -277,7 +277,7 @@ data:
     #################
     gateway {
       name: {{ .Values.gateway.name }}
-      port: 7522
+      port: {{ .Values.gateway.port }}
 
       {{- if .Values.gateway.advertise }}
       advertise: {{ .Values.gateway.advertise }}

--- a/helm/charts/nats/templates/networkpolicy.yaml
+++ b/helm/charts/nats/templates/networkpolicy.yaml
@@ -20,7 +20,7 @@ spec:
       protocol: UDP
   # Allow outbound connections to other cluster pods
   - ports:
-    - port: 4222
+    - port: {{ .Values.nats.client.port }}
       protocol: TCP
     - port: 6222
       protocol: TCP
@@ -42,7 +42,7 @@ spec:
   ingress:
   # Allow inbound connections
   - ports:
-    - port: 4222
+    - port: {{ .Values.nats.client.port }}
       protocol: TCP
     - port: 6222
       protocol: TCP

--- a/helm/charts/nats/templates/networkpolicy.yaml
+++ b/helm/charts/nats/templates/networkpolicy.yaml
@@ -28,9 +28,9 @@ spec:
       protocol: TCP
     - port: 7777
       protocol: TCP
-    - port: 7422
+    - port: {{ .Values.leafnodes.port }}
       protocol: TCP
-    - port: 7522
+    - port: {{ .Values.gateway.port }}
       protocol: TCP
     to:
     - podSelector:
@@ -50,9 +50,9 @@ spec:
       protocol: TCP
     - port: 7777
       protocol: TCP
-    - port: 7422
+    - port: {{ .Values.leafnodes.port }}
       protocol: TCP
-    - port: 7522
+    - port: {{ .Values.gateway.port }}
       protocol: TCP
     {{- if not .Values.networkPolicy.allowExternal }}
     from:

--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -55,12 +55,12 @@ spec:
     appProtocol: http
     {{- end }}
   - name: leafnodes
-    port: 7422
+    port: {{ .Values.leafnodes.port }}
     {{- if .Values.appProtocol.enabled }}
     appProtocol: tcp
     {{- end }}
   - name: gateways
-    port: 7522
+    port: {{ .Values.gateway.port }}
     {{- if .Values.appProtocol.enabled }}
     appProtocol: tcp
     {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -260,15 +260,19 @@ spec:
           {{- if .Values.nats.externalAccess }}
           hostPort: {{ .Values.nats.client.port }}
           {{- end }}
-        - containerPort: 7422
+          {{- if .Values.leafnodes.enabled }}
+        - containerPort: {{ .Values.leafnodes.port }}
           name: leafnodes
           {{- if .Values.nats.externalAccess }}
-          hostPort: 7422
+          hostPort: {{ .Values.leafnodes.port }}
           {{- end }}
-        - containerPort: 7522
+          {{- end }}
+          {{- if .Values.gateway.enabled }}
+        - containerPort: {{ .Values.gateway.port }}
           name: gateways
           {{- if .Values.nats.externalAccess }}
-          hostPort: 7522
+          hostPort: {{ .Values.gateway.port }}
+          {{- end }}
           {{- end }}
         - containerPort: 6222
           name: cluster

--- a/helm/charts/nats/templates/tests/test-request-reply.yaml
+++ b/helm/charts/nats/templates/tests/test-request-reply.yaml
@@ -17,11 +17,11 @@ spec:
     - /bin/sh
     - -ec
     - |
-      nats reply -s nats://$NATS_HOST:4222 'name.>' --command "echo {{1}}" &
+      nats reply -s nats://$NATS_HOST:{{ .Values.nats.client.port }} 'name.>' --command "echo {{1}}" &
     - |
       "&&"
     - |
-      name=$(nats request -s nats://$NATS_HOST:4222 name.test '' 2>/dev/null)
+      name=$(nats request -s nats://$NATS_HOST:{{ .Values.nats.client.port }} name.test '' 2>/dev/null)
     - |
       "&&"
     - |

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -363,6 +363,7 @@ cluster:
 #
 leafnodes:
   enabled: false
+  port: 7422
   noAdvertise: false
   # remotes:
   #   - url: "tls://connect.ngs.global:7422"
@@ -392,6 +393,7 @@ leafnodes:
 #
 gateway:
   enabled: false
+  port: 7522
   name: "default"
   # authorization:
   #   user: foo


### PR DESCRIPTION
Sometime you may want to setup several clusters on a single minikube k8s cluster run in `--driver=none` mode. Then hardcoded default ports will prevent a second cluster to be up.
Fix this with allow to override leafnodes and gateway ports.

Also, fix tests which use the default `4222` port but not the `nats.client.port` from values.