### PR TITLE
[surveyor helm] make TLS CA optional

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: surveyor
 description: NATS Monitoring, Simplified.
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: 0.2.2

--- a/helm/charts/surveyor/templates/configmap.yaml
+++ b/helm/charts/surveyor/templates/configmap.yaml
@@ -11,7 +11,9 @@ data:
     {
       "name": "{{ .name }}",
       {{- if .tls }}
+      {{- if .tls.ca }}
       "tls_ca": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.ca }}",
+      {{- end }}
       "tls_cert": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.cert }}",
       "tls_key": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.key }}"
       {{- end }}

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -53,7 +53,9 @@ spec:
            {{- end }}
 
            {{- with .tls }}
+           {{- if .ca }}
             - -tlscacert=/etc/nats-certs/clients/{{ .ca }}
+           {{- end }}
             - -tlskey=/etc/nats-certs/clients/{{ .key }}
             - -tlscert=/etc/nats-certs/clients/{{ .cert }}
            {{- end }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -78,17 +78,17 @@ config:
   # Expected number of servers
   expectedServers: 1
 
-  # Required if auth is enabled.
+  # Required if NATS auth is enabled
   # credentials:
   #   secret:
   #     name: nats-sys-creds
   #     key: sys.creds
 
-  # Required if tls is enabled.
+  # Required for NATS mutual TLS
   # tls:
   #    secret:
   #      name: nats-client-tls
-  #    ca: "ca.crt"
+  #    ca: "ca.crt" # optional
   #    cert: "tls.crt"
   #    key: "tls.key"
 
@@ -99,6 +99,6 @@ config:
     #   tls:
     #     secret:
     #       name: test-user-tls
-    #     ca: "ca.crt"
+    #     ca: "ca.crt" # optional
     #     cert: "tls.crt"
     #     key: "tls.key"


### PR DESCRIPTION
Make TLS CA optional, as CA checking should fall back to the OS CA Store