### PR TITLE
update load balancer comments

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -174,7 +174,7 @@ nats:
   externalAccess: true
 
   # Toggle to disable client advertisements (connect_urls),
-  # in case of running behind a load balancer (which is not recommended)
+  # in case of running behind a load balancer
   # it might be required to disable advertisements.
   advertise: true
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -88,7 +88,7 @@ nats:
   externalAccess: false
 
   # Toggle to disable client advertisements (connect_urls),
-  # in case of running behind a load balancer (which is not recommended)
+  # in case of running behind a load balancer
   # it might be required to disable advertisements.
   advertise: true
 

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -307,7 +307,7 @@ nats:
   externalAccess: false
 
   # Toggle to disable client advertisements (connect_urls),
-  # in case of running behind a load balancer (which is not recommended)
+  # in case of running behind a load balancer
   # it might be required to disable advertisements.
   advertise: true
 


### PR DESCRIPTION
Comment to not recommend load balancer in documentation is confusing, as no reasons are given for why they should not be used.

Reasons may include increased latency or the fact that advertisements will need to be disabled.  We have documented how to disable advertisements in case of load balancer usage.

Many people running on k8s must use Load Balancers to expose NATS outside of their cluster due to network typologies.