### PR TITLE
fix: nats helm ignore cluster.authorization to generate route

### DIFF
--- a/examples/helm-do-nats-cluster-auth.yaml
+++ b/examples/helm-do-nats-cluster-auth.yaml
@@ -8,5 +8,5 @@ cluster:
 
   authorization:
     user: foo
-    password: pwd
+    password: pwd&pwd
     timeout: 0.5

--- a/examples/helm-do-nats-cluster-auth.yaml
+++ b/examples/helm-do-nats-cluster-auth.yaml
@@ -1,0 +1,12 @@
+nats:
+  image: nats:alpine
+
+cluster:
+  enabled: true
+  replicas: 3
+  noAdvertise: false
+
+  authorization:
+    user: foo
+    password: pwd
+    timeout: 0.5

--- a/examples/helm-do-nats-cluster-noauth.yaml
+++ b/examples/helm-do-nats-cluster-noauth.yaml
@@ -1,0 +1,7 @@
+nats:
+  image: nats:alpine
+
+cluster:
+  enabled: true
+  replicas: 3
+  noAdvertise: false

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -74,7 +74,7 @@ Return the NATS cluster auth.
 */}}
 {{- define "nats.clusterAuth" -}}
 {{- if $.Values.cluster.authorization }}
-{{- printf "%s:%s@" $.Values.cluster.authorization.user $.Values.cluster.authorization.password -}}
+{{- printf "%s:%s@" (urlquery $.Values.cluster.authorization.user) (urlquery $.Values.cluster.authorization.password) -}}
 {{- else }}
 {{- end }}
 {{- end }}

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -70,16 +70,27 @@ Return the proper NATS image name
 {{- end }}
 
 {{/*
+Return the NATS cluster auth.
+*/}}
+{{- define "nats.clusterAuth" -}}
+{{- if $.Values.cluster.authorization }}
+{{- printf "%s:%s@" $.Values.cluster.authorization.user $.Values.cluster.authorization.password -}}
+{{- else }}
+{{- end }}
+{{- end }}
+
+{{/*
 Return the NATS cluster routes.
 */}}
 {{- define "nats.clusterRoutes" -}}
 {{- $name := (include "nats.fullname" . ) -}}
 {{- $namespace := (include "nats.namespace" . ) -}}
+{{- $clusterauth := (include "nats.clusterAuth" . ) -}}
 {{- range $i, $e := until (.Values.cluster.replicas | int) -}}
 {{- if $.Values.useFQDN }}
-{{- printf "nats://%s-%d.%s.%s.svc.%s:6222," $name $i $name $namespace $.Values.k8sClusterDomain -}}
+{{- printf "nats://%s%s-%d.%s.%s.svc.%s:6222," $clusterauth $name $i $name $namespace $.Values.k8sClusterDomain -}}
 {{- else }}
-{{- printf "nats://%s-%d.%s.%s:6222," $name $i $name $namespace -}}
+{{- printf "nats://%s%s-%d.%s.%s:6222," $clusterauth $name $i $name $namespace -}}
 {{- end }}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
fix #288

# Summary

URLs in routes should has "user:password" part which values from authorization section.

This PR render auth part and fix issue.

# Output with no cluster auth values.yaml

This must keep existing behaviour.

```yaml
nats:
  image: nats:alpine

cluster:
  enabled: true
  replicas: 3
  noAdvertise: false
```

```
$ helm template . -n nats --values ../../../examples/helm-do-nats-cluster-noauth.yaml --debug
    cluster {
      port: 6222

      routes = [
        nats://RELEASE-NAME-nats-0.RELEASE-NAME-nats.nats.svc.cluster.local:6222,nats://RELEASE-NAME-nats-1.RELEASE-NAME-nats.nats.svc.cluster.local:6222,nats://RELEASE-NAME-nats-2.RELEASE-NAME-nats.nats.svc.cluster.local:6222,

      ]
      cluster_advertise: $CLUSTER_ADVERTISE
```

# Output with cluster auth values.yaml

This should add `foo:pwd%26pwd@` for each route.
`user:pass` should be url encoded.

```yaml
$ helm template . -n nats --values ../../../examples/helm-do-nats-cluster-auth.yaml --debug
```

```
$ helm template . -n nats --values ../../../examples/helm-do-nats-cluster-auth.yaml --debug
    cluster {
      port: 6222
      authorization {
        user: foo
        password: pwd&pwd
        timeout: 0.5
      }

      routes = [
        nats://foo:pwd%26pwd@RELEASE-NAME-nats-0.RELEASE-NAME-nats.nats.svc.cluster.local:6222,nats://foo:pwd%26pwd@RELEASE-NAME-nats-1.RELEASE-NAME-nats.nats.svc.cluster.local:6222,nats://foo:pwd%26pwd@RELEASE-NAME-nats-2.RELEASE-NAME-nats.nats.svc.cluster.local:6222,

      ]
      cluster_advertise: $CLUSTER_ADVERTISE
```