### PR TITLE
[nats helm] release 0.16.0

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.15.1
+version: 0.16.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo


### PR DESCRIPTION
## Features

- Create Service Account by default, optionally allowing named service account to be passed in values file (#481)

## Fixes

- Add Authorization string to Cluster Routes (#487)

## Improvements

- Update `natsio/nats` image version to 2.8.0 (#489)
- Update `natsio/nats-box` image version to 0.1.0 (#489)
- Add websocket.handshakeTimeout option (#480)