### PR TITLE
add a cache volume for controller

### DIFF
--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -74,6 +74,7 @@ spec:
         - name: jsc
           image: {{ .Values.jetstream.image }}
           imagePullPolicy: {{ .Values.jetstream.pullPolicy }}
+          workingDir: /nack
           command:
           - /jetstream-controller
           {{- if .Values.jetstream.klogLevel }}
@@ -118,6 +119,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+          - name: runtime
+            mountPath: /nack
           {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.secretName }}
           - name: jsc-client-tls-volume
             mountPath: /etc/nats/certs
@@ -126,3 +129,6 @@ spec:
           - name: jsc-sys-creds
             mountPath: /etc/jsc-creds
           {{- end }}
+      volumes:
+        - name : runtime
+          emptyDir : {}


### PR DESCRIPTION
Current nack chart allows to set `securityContext` but this doesn't work.

As per https://github.com/nats-io/nack/issues/48, the nack js controller will create a tmp directory in "/" which is not allowed if the container is not running as root

This PR adds a volume, so that the following works

```
securityContext:
  fsGroup: 1000
  runAsUser: 1000
  runAsNonRoot: true
```