### PR TITLE
Add index html for helm charts page

### DIFF
--- a/helm/charts/index.html
+++ b/helm/charts/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>NATS Helm Charts</title>
+    <meta http-equiv="Refresh" content="0; url='https://nats-io.github.io/k8s/'" />
+  </head>
+  <body>
+    Redirecting to NATS Helm Charts site...
+  </body>
+</html>


### PR DESCRIPTION
This is so that when visiting https://nats-io.github.io/k8s/helm/charts/  with the browser instead of 404 we redirect to main site of repo.

Signed-off-by: Waldemar Quevedo <wally@nats.io>