### PR TITLE
Fixed helm nats chart test labels so they don't match service selector

### DIFF
--- a/helm/charts/nats/templates/tests/test-request-reply.yaml
+++ b/helm/charts/nats/templates/tests/test-request-reply.yaml
@@ -3,7 +3,8 @@ kind: Pod
 metadata:
   name: "{{ include "nats.fullname" . }}-test-request-reply"
   labels:
-    {{- include "nats.labels" . | nindent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ include "nats.fullname" . }}-test-request-reply
   annotations:
     "helm.sh/hook": test
 spec:


### PR DESCRIPTION
- Removes the use of the nats.labels from the nats chart test, so the test pod is not picked up by the service selector
- Adds in a couple of replacement labels.