### PR TITLE
Allow the metrics port name to be specified

### DIFF
--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.appProtocol.enabled }}
     appProtocol: http
     {{- end }}
-  - name: metrics
+  - name: {{ .Values.exporter.portName }}
     port: 7777
     {{- if .Values.appProtocol.enabled }}
     appProtocol: http

--- a/helm/charts/nats/templates/serviceMonitor.yaml
+++ b/helm/charts/nats/templates/serviceMonitor.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - port: metrics
+  - port: {{ .Values.exporter.portName }}
   {{- if .Values.exporter.serviceMonitor.path }}
     path: {{ .Values.exporter.serviceMonitor.path }}
   {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -274,7 +274,7 @@ spec:
         - containerPort: 8222
           name: monitor
         - containerPort: 7777
-          name: metrics
+          name: {{ .Values.exporter.portName }}
         {{- if .Values.mqtt.enabled }}
         - containerPort: 1883
           name: mqtt
@@ -550,7 +550,7 @@ spec:
         - http://localhost:8222/
         ports:
         - containerPort: 7777
-          name: metrics
+          name: {{ .Values.exporter.portName }}
       {{- end }}
 
       {{- if .Values.additionalContainers }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -523,6 +523,7 @@ reloader:
 exporter:
   enabled: true
   image: natsio/prometheus-nats-exporter:0.9.3
+  portName: metrics
   pullPolicy: IfNotPresent
   securityContext: {}
   resources: {}


### PR DESCRIPTION
This allows Istio users in older k8s clusters to be able to specify the protocol selection by naming the port `http-metrics`.  See this [documentation](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) for more details.  Note using `appProtocol` in the service is the ideal way to specify the protocol, but it is unavailable on older versions of kubernetes.