### PR TITLE
[nats helm] detect service appProtocol

### DIFF
--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- $appProtocol := semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 ---
 apiVersion: v1
 kind: Service
@@ -23,51 +24,51 @@ spec:
   {{- if .Values.websocket.enabled }}
   - name: websocket
     port: {{ .Values.websocket.port }}
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: tcp
     {{- end }}
   {{- end }}
   {{- if .Values.nats.profiling.enabled }}
   - name: profiling
     port: {{ .Values.nats.profiling.port }}
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: http
     {{- end }}
   {{- end }}
   - name: {{ .Values.nats.client.portName }}
     port: {{ .Values.nats.client.port }}
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: tcp
     {{- end }}
   - name: cluster
     port: 6222
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: tcp
     {{- end }}
   - name: monitor
     port: 8222
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: http
     {{- end }}
   - name: {{ .Values.exporter.portName }}
     port: 7777
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: http
     {{- end }}
   - name: leafnodes
     port: {{ .Values.leafnodes.port }}
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: tcp
     {{- end }}
   - name: gateways
     port: {{ .Values.gateway.port }}
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: tcp
     {{- end }}
   {{- if .Values.mqtt.enabled }}
   - name: mqtt
     port: 1883
-    {{- if .Values.appProtocol.enabled }}
+    {{- if $appProtocol }}
     appProtocol: tcp
     {{- end }}
   {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -644,9 +644,6 @@ websocket:
   # Set the handshake timeout for websocket connections
   # handshakeTimeout: 5s
 
-appProtocol:
-  enabled: false
-
 # Network Policy configuration
 networkPolicy:
   enabled: false


### PR DESCRIPTION
- Detect if `service.appProtocol` is supported, instead of making the user supply a value