### PR TITLE
[nats helm] release 0.17.1

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.17.0
+version: 0.17.1
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -33,7 +33,7 @@ helm install my-nats nats/nats
 
 ```yaml
 nats:
-  image: nats:2.8.0-alpine
+  image: nats:2.8.4-alpine
   pullPolicy: IfNotPresent
 ```
 
@@ -575,7 +575,7 @@ Now we start the server with the NATS Account Resolver (`auth.resolver.type=full
 
 ```yaml
 nats:
-  image: nats:2.8.0-alpine
+  image: nats:2.8.4-alpine
 
   logging:
     debug: false


### PR DESCRIPTION
## Improvements

- Update `nats-server` version to 2.8.4 (#513)
- Allow the metrics port name to be specified (#514) 
- Detect service appProtocol (#515) 
- Add gateway flag to exporter arguments configuration (#516)