### PR TITLE
fix nats-box credential env variable

### DIFF
--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -75,9 +75,7 @@ spec:
         - name: NATS_URL
           value: {{ template "nats.fullname" . }}
         {{- if .Values.natsbox.credentials }}
-        - name: USER_CREDS
-          value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
-        - name: USER2_CREDS
+        - name: NATS_CREDS
           value: /etc/nats-config/creds/{{ .Values.natsbox.credentials.secret.key }}
         {{- end }}
         {{- with .Values.nats.tls }}


### PR DESCRIPTION
The current environment variables set in the Helm chart are not used by the CLI. 
This PR fixes the environment variables.