### PR TITLE
[nack helm] remove pod anti affinity from jsc

### DIFF
--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - nats
 - jetstream
 - cncf
-version: 0.14.1
+version: 0.14.2
 maintainers:
 - name: Waldemar Quevedo
   url: https://github.com/wallyqs

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -49,17 +49,8 @@ spec:
           secretName: {{ .Values.jetstream.nats.credentials.secret.name }}
       {{- end }}
 
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ template "jsc.name" . }}
-            topologyKey: kubernetes.io/hostname
 {{- with .Values.affinity }}
+      affinity:
 {{ toYaml . | indent 8 }}
 {{- end }}
 {{- with .Values.nodeSelector }}


### PR DESCRIPTION
- Nack JetStream deployment is hardcoded to 1 replica so it doesn't need Anti-Affinity - the Anti-Affinity is just freezing upgrades on single-node clusters
- Fixes #522 