### PR TITLE
[nats helm] use hasKey for automountServiceAccountToken detection

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.17.2
+version: 0.17.3
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or (eq .Values.natsbox.automountServiceAccountToken false) (eq .Values.natsbox.automountServiceAccountToken true) }}
+      {{- if hasKey .Values.natsbox "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.natsbox.automountServiceAccountToken }}
       {{- end }}
       containers:

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -197,7 +197,7 @@ spec:
       {{- end }}
 
       serviceAccountName: {{ include "nats.serviceAccountName" . }}
-      {{- if or (eq .Values.nats.automountServiceAccountToken false) (eq .Values.nats.automountServiceAccountToken true) }}
+      {{- if hasKey .Values.nats "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.nats.automountServiceAccountToken }}
       {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -110,8 +110,8 @@ nats:
     name: ""
 
   # Toggle whether to automatically mount Service Account token in the pod
-  # null means default value, boolean true/false overrides default value
-  automountServiceAccountToken: null
+  # not set means default value, boolean true/false overrides default value
+  # automountServiceAccountToken: true
 
   # The number of connect attempts against discovered routes.
   connectRetries: 120
@@ -516,8 +516,8 @@ natsbox:
   extraVolumes: []
 
   # Toggle whether to automatically mount Service Account token in the pod
-  # null means default value, boolean true/false overrides default value
-  automountServiceAccountToken: null
+  # not set means default value, boolean true/false overrides default value
+  # automountServiceAccountToken: true
 
 # The NATS config reloader image to use.
 reloader:


### PR DESCRIPTION
- Fixes #530 
- Fixes #529 

I cannot recreate the issue, and CI is passing, but multiple users are reporting a problem with comparing `boolean` to `nil` from #527  so this PR switches to use `hasKey` instead 