### PR TITLE
Fix nats cluster deployment failure caused by missing namespace.

### DIFF
--- a/helm/charts/nats/templates/rbac.yaml
+++ b/helm/charts/nats/templates/rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "nats.serviceAccountName" . }}
+  namespace: {{ include "nats.namespace" . }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
   {{- with .Values.nats.serviceAccount.annotations }}


### PR DESCRIPTION
Issue: https://github.com/nats-io/k8s/issues/532

When I tried to setup a cluster with a specified namespace e.g ‘nats’, it failed with this failure:

`create Pod nats-0 in StatefulSet nats failed error: pods "nats-0" is forbidden: error looking up service account nats-poc/nats: serviceaccount "nats" not found`