### PR TITLE
[nats helm] allow verify_cert_and_check_known_urls in tls config (#535)

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.17.2
+version: 0.17.3
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -121,6 +121,9 @@ tls {
 {{- if .verifyAndMap }}
     verify_and_map: {{ .verifyAndMap }}
 {{- end }}
+{{- if .verifyCertAndCheckKnownUrls }}
+    verify_cert_and_check_known_urls: {{ .verifyCertAndCheckKnownUrls }}
+{{- end }}
 {{- if .curvePreferences }}
     curve_preferences: {{ .curvePreferences }}
 {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -254,7 +254,7 @@ nats:
   #
 
   # tls:
-  #   allow_non_tls: false
+  #   allowNonTLS: false
   #   secret:
   #     name: nats-client-tls
   #   ca: "ca.crt"


### PR DESCRIPTION
Enable `verifyCertAndCheckKnownUrls` (valid under `cluster.tls`) by the `nats.tlsConfig` helper

- closes #535
- closes #534 
