### PR TITLE
add insecure variables

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -257,7 +257,11 @@ data:
 
         {{- with .tls }}
         tls: {
-          {{- if .custom }}
+          {{- if .insecure }}
+          {{- with .insecure }}
+          insecure: {{ . }}
+          {{- end }}
+          {{- else if .custom}}
           {{- .custom | nindent 10 }}
           {{- else }}
           {{ $secretName := tpl .secret.name $ }}


### PR DESCRIPTION
https://docs.nats.io/running-a-nats-service/configuration/leafnodes/leafnode_conf#tls-configuration-block

An important parameter that is often needed when using external access to LeafNodes