### PR TITLE
Add mem soft limit for Go 1.19 support

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -319,6 +319,11 @@ spec:
               fieldPath: metadata.namespace
         - name: CLUSTER_ADVERTISE
           value: {{ include "nats.clusterAdvertise" . }}
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: nats
+              resource: limits.memory
 
         {{- if .Values.nats.jetstream.enabled }}
         {{- with .Values.nats.jetstream.encryption }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -319,11 +319,10 @@ spec:
               fieldPath: metadata.namespace
         - name: CLUSTER_ADVERTISE
           value: {{ include "nats.clusterAdvertise" . }}
+        {{- if .Values.nats.gomemlimit }}
         - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: nats
-              resource: limits.memory
+          value: {{ .Values.nats.gomemlimit | quote }}
+        {{- end }}
 
         {{- if .Values.nats.jetstream.enabled }}
         {{- with .Values.nats.jetstream.encryption }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -16,6 +16,13 @@ nats:
   # - "foo"
   # - "bar"
 
+  # Sets GOMEMLIMIT environment variable which makes the Go GC be aware of memory limits
+  # from the container. Recommended to be set to about 90% of the resource memory limits.
+  #
+  # More info about the Go GC: https://go.dev/doc/gc-guide
+  #
+  # gomemlimit: "4GiB"
+
   # Toggle profiling.
   # This enables nats-server pprof (profiling) port, so you can see goroutines
   # stacks, memory heap sizes, etc.


### PR DESCRIPTION
This makes Go GC use the memory limit that it is allocatable for the container instead the one set for the host. In case there is no resource limit set, then it would use by default what is allocatable according to the K8S node.