### PR TITLE
Add support for custom TLS to all features

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -161,13 +161,17 @@ tls {
 #                     #
 #######################
 {{ $secretName := tpl .secret.name $ }}
+{{- if not .custom }}
 - name: {{ $secretName }}-clients-volume
   mountPath: /etc/nats-certs/clients/{{ $secretName }}
 {{- end }}
+{{- end }}
 {{- with .Values.mqtt.tls }}
+{{- if not .custom }}
 {{ $secretName := tpl .secret.name $ }}
 - name: {{ $secretName }}-mqtt-volume
   mountPath: /etc/nats-certs/mqtt/{{ $secretName }}
+{{- end }}
 {{- end }}
 {{- with .Values.cluster.tls }}
 {{- if not .custom }}
@@ -184,14 +188,18 @@ tls {
 {{- end }}
 {{- end }}
 {{- with .Values.gateway.tls }}
+{{- if not .custom }}
 {{ $secretName := tpl .secret.name $ }}
 - name: {{ $secretName }}-gateways-volume
   mountPath: /etc/nats-certs/gateways/{{ $secretName }}
 {{- end }}
+{{- end }}
 {{- with .Values.websocket.tls }}
+{{- if not .custom }}
 {{ $secretName := tpl .secret.name $ }}
 - name: {{ $secretName }}-ws-volume
   mountPath: /etc/nats-certs/ws/{{ $secretName }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -48,9 +48,15 @@ data:
     #                   #
     #####################
     {{- with .Values.nats.tls }}
+    {{- if .custom }}
+    tls {
+      {{- .custom | nindent 8 }}
+    }
+    {{- else }}
     {{- $nats_tls := merge (dict) . }}
     {{- $_ := set $nats_tls "secretPath" "/etc/nats-certs/clients" }}
     {{- tpl (include "nats.tlsConfig" $nats_tls) $ | nindent 4}}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.nats.tls.allowNonTLS }}
@@ -108,9 +114,15 @@ data:
       port: 1883
 
       {{- with .Values.mqtt.tls }}
+      {{- if .custom }}
+      tls {
+        {{- .custom | nindent 8 }}
+      }
+      {{- else }}
       {{-  $mqtt_tls := merge (dict) . }}
       {{- $_ := set $mqtt_tls "secretPath" "/etc/nats-certs/mqtt" }}
       {{- tpl (include "nats.tlsConfig" $mqtt_tls) $ | nindent 6}}
+      {{- end }}
       {{- end }}
 
       {{- if .Values.mqtt.noAuthUser }}
@@ -144,9 +156,15 @@ data:
       {{- end }}
 
       {{- with .Values.cluster.tls }}
+      {{- if .custom }}
+      tls {
+        {{- .custom | nindent 8 }}
+      }
+      {{- else }}
       {{-  $cluster_tls := merge (dict) . }}
       {{- $_ := set $cluster_tls "secretPath" "/etc/nats-certs/cluster" }}
       {{- tpl (include "nats.tlsConfig" $cluster_tls) $ | nindent 6}}
+      {{- end }}
       {{- end }}
 
       {{- if .Values.cluster.authorization }}
@@ -318,9 +336,15 @@ data:
       {{- end }}
 
       {{- with .Values.gateway.tls }}
+      {{- if .custom }}
+      tls {
+        {{- .custom | nindent 8 }}
+      }
+      {{- else }}
       {{-  $gateway_tls := merge (dict) . }}
       {{- $_ := set $gateway_tls "secretPath" "/etc/nats-certs/gateways" }}
       {{- tpl (include "nats.tlsConfig" $gateway_tls) $ | nindent 6}}
+      {{- end }}
       {{- end }}
 
       # Gateways array here
@@ -413,20 +437,15 @@ data:
     websocket {
       port: {{ .Values.websocket.port }}
       {{- with .Values.websocket.tls }}
-        {{ $secretName := tpl .secret.name $ }}
-        tls {
-        {{- with .cert }}
-        cert_file: /etc/nats-certs/ws/{{ $secretName }}/{{ . }}
-        {{- end }}
-
-        {{- with .key }}
-        key_file: /etc/nats-certs/ws/{{ $secretName }}/{{ . }}
-        {{- end }}
-
-        {{- with .ca }}
-        ca_file: /etc/nats-certs/ws/{{ $secretName }}/{{ . }}
-        {{- end }}
-        }
+      {{- if .custom }}
+      tls {
+        {{- .custom | nindent 8 }}
+      }
+      {{- else }}
+      {{-  $websocket_tls := merge (dict) . }}
+      {{- $_ := set $websocket_tls "secretPath" "/etc/nats-certs/ws" }}
+      {{- tpl (include "nats.tlsConfig" $websocket_tls) $ | nindent 6}}
+      {{- end }}
       {{- else }}
       no_tls: {{ .Values.websocket.noTLS }}
       {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -137,22 +137,28 @@ spec:
       #               #
       #################
       {{- with .Values.nats.tls }}
+      {{- if not .custom }}
       {{ $secretName := tpl .secret.name $ }}
       - name: {{ $secretName }}-clients-volume
         secret:
           secretName: {{ $secretName }}
       {{- end }}
+      {{- end }}
       {{- with .Values.mqtt.tls }}
+      {{- if not .custom }}
       {{ $secretName := tpl .secret.name $ }}
       - name: {{ $secretName }}-mqtt-volume
         secret:
           secretName: {{ $secretName }}
       {{- end }}
+      {{- end }}
       {{- with .Values.cluster.tls }}
+      {{- if not .custom }}
       {{ $secretName := tpl .secret.name $ }}
       - name: {{ $secretName }}-cluster-volume
         secret:
           secretName: {{ $secretName }}
+      {{- end }}
       {{- end }}
       {{- with .Values.leafnodes.tls }}
       {{- if not .custom }}
@@ -163,17 +169,22 @@ spec:
       {{- end }}
       {{- end }}
       {{- with .Values.gateway.tls }}
+      {{- if not .custom }}
       {{ $secretName := tpl .secret.name $ }}
       - name: {{ $secretName }}-gateways-volume
         secret:
           secretName: {{ $secretName }}
       {{- end }}
+      {{- end }}
       {{- with .Values.websocket.tls }}
+      {{- if not .custom }}
       {{ $secretName := tpl .secret.name $ }}
       - name: {{ $secretName }}-ws-volume
         secret:
           secretName: {{ $secretName }}
       {{- end }}
+      {{- end }}
+      
       {{- if .Values.leafnodes.enabled }}
       #
       # Leafnode credential volumes


### PR DESCRIPTION
Custom TLS support was added for leafnodes, but not for any of the other components. But for some more exotic secrets implementations (like secrets-csi-driver), you need the ability to provide your own mounts instead.

This change adds the custom TLS implementation for leafnodes to all other places where TLS is used.