### PR TITLE
Add support for custom env vars for configuration

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -101,6 +101,26 @@ Return the NATS cluster routes.
 {{- end -}}
 {{- end }}
 
+{{- define "nats.authenticationEnv" }}
+{{- if .existingSecret }}
+- name: {{ .envPrefix }}_AUTHORIZATION_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: {{ ((.secretKeys).userKey) | default "user" }}
+- name: {{ .envPrefix }}_AUTHORIZATION_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: {{ ((.secretKeys).passwordKey) | default "password" }}
+{{- else }}
+- name: {{ .envPrefix }}_AUTHORIZATION_USER
+  value: {{ .user }}
+- name: {{ .envPrefix }}_AUTHORIZATION_PASSWORD
+  value: {{ .password }}
+{{- end }}
+{{- end }}
+
 {{- define "nats.tlsConfig" -}}
 tls {
 {{- if .cert }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -301,12 +301,8 @@ data:
 
       {{- if .Values.gateway.authorization }}
       authorization {
-        {{- with .Values.gateway.authorization.user }}
-        user: {{ . }}
-        {{- end }}
-        {{- with .Values.gateway.authorization.password }}
-        password: {{ . }}
-        {{- end }}
+        user: $GATEWAY_AUTHORIZATION_USER
+        password: $GATEWAY_AUTHORIZATION_PASSWORD
         {{- with .Values.gateway.authorization.timeout }}
         timeout: {{ . }}
         {{- end }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -333,6 +333,24 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        
+        {{- range $key, $value := .Values.nats.extraEnvVars }}
+        - name: "{{ tpl $key $ }}"
+          value: "{{ tpl (print $value) $ }}"
+        {{- end }}
+        
+        {{- with .Values.gateway.authorization }}
+        {{- $gateway_auth := merge (dict) . }}
+        {{- $_ := set $gateway_auth "envPrefix" "GATEWAY" }}
+        {{- tpl (include "nats.authenticationEnv" $gateway_auth) $ | nindent 8 }}
+        {{- end }}
+        
+        {{- if .Values.nats.extraEnvVarsSecret }}
+        envFrom:
+          - secretRef:
+              name: "{{ .Values.nats.extraEnvVarsSecret }}"
+        {{- end }}
+
         volumeMounts:
         - name: config-volume
           mountPath: /etc/nats-config

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -188,6 +188,14 @@ nats:
   #      configMap:
   #        name: log-config
 
+  # Provide extra environment variables to NATS that may be used as variables in the configuration.
+  extraEnvVars: []
+  # FOO_ENV: foo
+  # BAR_ENV: bar
+
+  # Provide extra environment variables to NATS from a secret.
+  extraEnvVarsSecret: ""
+
   jetstream:
     enabled: false
 
@@ -418,6 +426,10 @@ gateway:
   #   user: foo
   #   password: pwd
   #   timeout: 0.5
+  #   existingSecret: ""
+  #   secretKeys:
+  #     userKey: "user"
+  #     passwordKey: "password"
   # rejectUnknownCluster: false
 
   # You can add an implicit advertise address instead of using from Node's IP


### PR DESCRIPTION
Also use env vars to configure gateway auth, so they can be loaded from secrets instead.

I made a generic snippet for generating the env vars for authentication, and I would _love_ to use it for cluster auth as well, but I can't figure out a way to parameterize them in the cluster peer URLs.