### PR TITLE
[nack helm] add nats.nkey

### DIFF
--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -49,6 +49,12 @@ spec:
           secretName: {{ .Values.jetstream.nats.credentials.secret.name }}
       {{- end }}
 
+      {{- with .Values.jetstream.nats.nkey }}
+      - name: jsc-sys-nkey
+        secret:
+          secretName: {{ .secret.name }}
+      {{- end}}
+
 {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
@@ -81,6 +87,9 @@ spec:
           {{- end }}
           {{- with .Values.jetstream.nats.credentials }}
           - --creds=/etc/jsc-creds/{{ .secret.key }}
+          {{- end }}
+          {{- with .Values.jetstream.nats.nkey }}
+          - --nkey=/etc/jsc-nkey/{{ .secret.key }}
           {{- end }}
           {{- if .Values.namespaced }}
           - --namespace={{ template "jsc.namespace" . }}
@@ -122,4 +131,8 @@ spec:
           {{- if .Values.jetstream.nats.credentials }}
           - name: jsc-sys-creds
             mountPath: /etc/jsc-creds
+          {{- end }}
+          {{- if .Values.jetstream.nats.nkey }}
+          - name: jsc-sys-nkey
+            mountPath: /etc/jsc-nkey
           {{- end }}

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -14,6 +14,13 @@ jetstream:
     url:
 
     #
+    # The nkey file to load in to connect to the NATS Server.
+    #
+    # nkey:
+    #   secret:
+    #     name: nats-sys-nkey
+    #     key: sys.nkey
+    #
     # The credentials file to load in to connect to the NATS Server.
     #
     # credentials:


### PR DESCRIPTION
https://github.com/nats-io/nack/blob/a36c58fd7ad7d2aeddf17ccd32caa569cdd5826f/cmd/jetstream-controller/main.go#L56

nack has `--nkey` option. but nack helm not support this.
So I added it and checked whether it works, and it works well.