### PR TITLE
surveyor: add accounts to monitor metrics

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: surveyor
 description: NATS Monitoring, Simplified.
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: 0.4.0

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - -s={{ . }}
            {{- end }}
 
+           {{- with .accounts }}
+            - --accounts
+           {{- end }}
+
            {{- with .timeout }}
             - --timeout={{ . }}
            {{- end }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -85,6 +85,9 @@ config:
   # Expected number of servers
   expectedServers: 1
 
+  # Enable monitoring account metrics.
+  accounts: false
+
   # Required if NATS auth is enabled
   # credentials:
   #   secret:


### PR DESCRIPTION
Example:

```yaml
config:
  servers: "nats://sys:sys@nats:4222"

  expectedServers: 3

  accounts: true
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>
