### PR TITLE
Enable external IPs microk8s

### DIFF
--- a/helm/charts/nats/templates/service.yaml
+++ b/helm/charts/nats/templates/service.yaml
@@ -14,7 +14,15 @@ metadata:
 spec:
   selector:
     {{- include "nats.selectorLabels" . | nindent 4 }}
+  {{- if not .Values.nats.requiresExternalIPs.enabled }}
   clusterIP: None
+  {{- end }}
+  {{- if .Values.nats.requiresExternalIPs.enabled }}
+  externalIPs:
+  {{- range $externalIP := .Values.nats.requiresExternalIPs.externalIPs }}
+    - {{- $externalIP | nindent 6 }}
+  {{- end }}
+  {{- end }}
   publishNotReadyAddresses: true
   {{- if .Values.topologyKeys }}
   topologyKeys:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -97,6 +97,11 @@ nats:
   # it might be required to disable advertisements.
   advertise: true
 
+  # Configuration for external IPs for MicroK8s
+  requiresExternalIPs:
+    enabled: false
+    externalIPs: []
+
   # In case both external access and advertise are enabled
   # then a service account would be required to be able to
   # gather the public ip from a node.


### PR DESCRIPTION
This PR introduces a way to enable external IPs to access NATS when the K8s cluster does not provide them.

Example:
```bash
helm install my-nats -n my-nats --create-namespace nats/nats --set "nats.requiresExternalIPs.enabled=true" --set "nats.requiresExternalIPs.externalIPs={<External IPs separated by comma>}"
```