### PR TITLE
[kine] add kine-nats development stack

### DIFF
--- a/kine-nats/.gitignore
+++ b/kine-nats/.gitignore
@@ -1,0 +1,2 @@
+/kine
+/k3s.yaml

--- a/kine-nats/Dockerfile
+++ b/kine-nats/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.19.1-bullseye
+
+# copy go.mod and download dependencies
+COPY /kine/go.mod /go/kine/go.mod
+WORKDIR /go/kine
+RUN go mod download
+
+# copy all src and build
+COPY /kine /go/kine
+RUN ./scripts/build \
+    && mv bin/kine /go/bin/kine
+
+ENTRYPOINT ["/go/bin/kine"]

--- a/kine-nats/README.md
+++ b/kine-nats/README.md
@@ -33,3 +33,13 @@ export KUBECONFIG="$(pwd)/k3s.yaml"
 # destroy docker compose stack
 docker compose down -v
 ```
+
+## Run Connection Test
+
+```bash
+cd kine
+./scripts/build
+./scripts/package
+. ./scripts/test-helpers
+. ./scripts/test-run-jetstream
+```

--- a/kine-nats/README.md
+++ b/kine-nats/README.md
@@ -1,0 +1,35 @@
+# kine-nats
+
+This directory contains instructions and scripts for creating a local testing environment against [kine](https://github.com/k3s-io/kine/) with a NATS JetStream backend.
+
+## Prerequisites
+
+```bash
+# clone the kine repo into this directory
+git clone git@github.com:k3s-io/kine.git
+
+# install python dependencies for load tests
+pip install kubernetes termplotlib
+```
+
+## Run Development Stack
+
+```bash
+# start docker compose stack
+docker compose up -d --build
+
+# wait until k3s has started
+# then copy the kubeconfig to current directory
+docker compose cp k3s:/etc/rancher/k3s/k3s.yaml ./k3s.yaml
+export KUBECONFIG="$(pwd)/k3s.yaml"
+
+# run load test
+./kine/scripts/test-load
+```
+
+## Destroy Stack
+
+```bash
+# destroy docker compose stack
+docker compose down -v
+```

--- a/kine-nats/docker-compose.yml
+++ b/kine-nats/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+
+services:
+  nats:
+    image: nats:2.9.0-alpine
+    ports:
+    - 4222:4222
+    volumes:
+    - ./nats-server.conf:/etc/nats/nats-server.conf
+
+  kine:
+    build: ./
+    command:
+    - --endpoint
+    - nats://?bucket=k3s&contextFile=/etc/nats-context.json
+    volumes:
+    - ./nats-context.json:/etc/nats-context.json
+    depends_on:
+    - nats
+
+  k3s:
+    image: rancher/k3s:v1.24.4-k3s1
+    command: server
+    hostname: k3s
+    tmpfs:
+    - /run
+    - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    environment:
+      K3S_DATASTORE_ENDPOINT: http://kine:2379
+    ports:
+    - 6443:6443
+    depends_on:
+    - kine

--- a/kine-nats/nats-context.json
+++ b/kine-nats/nats-context.json
@@ -1,0 +1,17 @@
+{
+    "description": "",
+    "url": "nats://nats:4222",
+    "token": "",
+    "user": "test",
+    "password": "test",
+    "creds": "",
+    "nkey": "",
+    "cert": "",
+    "key": "",
+    "ca": "",
+    "nsc": "",
+    "jetstream_domain": "",
+    "jetstream_api_prefix": "",
+    "jetstream_event_prefix": "",
+    "inbox_prefix": ""
+}

--- a/kine-nats/nats-server.conf
+++ b/kine-nats/nats-server.conf
@@ -1,0 +1,14 @@
+jetstream: {
+    max_mem: 10Gi
+    max_file: 10Gi
+    store_dir: /tmp
+}
+
+accounts {
+    test: {
+        jetstream: enabled
+        users: [
+            {user: test, password: test}
+        ]
+    }
+}


### PR DESCRIPTION
While working on [kine](https://github.com/k3s-io/kine/) PRs, I found it helpful to have a development stack that includes NATS

Since it is `k8s` related I thought it would fit well here, but I could make a separate repo for it to if that would be better