### PR TITLE
Fixed wrong command name to sub/pub via NATS Box

### DIFF
--- a/helm/charts/nats/templates/NOTES.txt
+++ b/helm/charts/nats/templates/NOTES.txt
@@ -17,8 +17,8 @@ now use the NATS tools within the container as follows:
 
   kubectl exec -n {{ template "nats.namespace" . }} -it deployment/{{ template "nats.fullname" . }}-box -- /bin/sh -l
 
-  nats-box:~# nats-sub test &
-  nats-box:~# nats-pub test hi
+  nats-box:~# nats sub test &
+  nats-box:~# nats pub test hi
   nats-box:~# nc {{ template "nats.fullname" . }} {{ .Values.nats.client.port }}
 
 {{- end }}


### PR DESCRIPTION
Got error when tried to run # nats-sub test &

nats-box v0.13.0
my-nats-box-dbd66985f-plrcd:~# nats-sub test &
/bin/sh: nats-sub: not found