### PR TITLE
[nats helm] add opt-in for /healthz liveness and readiness probe

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -410,12 +410,21 @@ spec:
         #                     #
         #######################
         {{- if .Values.nats.healthcheck }}
+        {{- $serverVersion := (split ":" .Values.nats.image)._1 | default "latest" | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.9.0" }}
+        {{- $enableHealthzStartup := and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $serverVersion)) }}
+        {{- $enableHealthzLivenessReadiness := and .Values.nats.healthcheck.enableHealthzLivenessReadiness (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.9.0" $serverVersion)) }}
 
         {{- with .Values.nats.healthcheck.liveness }}
         {{- if .enabled }}
         livenessProbe:
           httpGet:
+            {{- if $enableHealthzLivenessReadiness }}
+            # for NATS server versions >=2.9.0, /healthz?js-enabled=true will be enabled
+            # liveness probe checks that the JS server is enabled
+            path: /healthz?js-enabled=true
+            {{- else }}
             path: /
+            {{- end }}
             port: 8222
           initialDelaySeconds: {{ .initialDelaySeconds }}
           timeoutSeconds: {{ .timeoutSeconds }}
@@ -432,7 +441,13 @@ spec:
         {{- if .enabled }}
         readinessProbe:
           httpGet:
+            {{- if $enableHealthzLivenessReadiness }}
+            # for NATS server versions >=2.9.0, /healthz?js-server-only=true will be enabled
+            # readiness probe checks that the JS server is enabled, and is current with the meta leader
+            path: /healthz?js-server-only=true
+            {{- else }}
             path: /
+            {{- end }}
             port: 8222
           initialDelaySeconds: {{ .initialDelaySeconds }}
           timeoutSeconds: {{ .timeoutSeconds }}
@@ -442,20 +457,19 @@ spec:
         {{- end }}
         {{- end }}
 
-        {{- if .Values.nats.healthcheck.startup.enabled }}
+        {{- with .Values.nats.healthcheck.startup }}
+        {{- if .enabled }}
         startupProbe:
           httpGet:
-            {{- $parts := split ":" .Values.nats.image }}
-            {{- $simpleVersion := $parts._1 | default "latest" | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.7.1" }}
-            {{- if and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $simpleVersion)) }}
-            # for NATS server versions >=2.7.1, healthz will be enabled to allow for a grace period
-            # in case of JetStream enabled deployments to form quorum and streams to catch up.
+            {{- if $enableHealthzStartup }}
+            # for NATS server versions >=2.7.1, /healthz will be enabled
+            # startup probe checks that the JS server is enabled, is current with the meta leader,
+            # and that all streams and consumers assigned to this JS server are current
             path: /healthz
             {{- else }}
             path: /
             {{- end }}
             port: 8222
-        {{- with .Values.nats.healthcheck.startup }}
           initialDelaySeconds: {{ .initialDelaySeconds }}
           timeoutSeconds: {{ .timeoutSeconds }}
           periodSeconds: {{ .periodSeconds }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -37,6 +37,9 @@ nats:
     detectHealthz: true
     # Enable /healthz startupProbe for controlled upgrades of NATS JetStream
     enableHealthz: true
+    # Enable /healthz liveness and readiness probes (supported in >=2.9.0)
+    # This is a feature flag and will be removed in future releases
+    enableHealthzLivenessReadiness: false
 
     # Enable liveness checks.  If this fails, then the NATS Server will restarted.
     liveness:
@@ -65,10 +68,8 @@ nats:
 
     # Periodically check for the server to be ready for connections while
     # the NATS container is running.
-    # Disabled by default since covered by startup probe and it is the same
-    # as the liveness check.
     readiness:
-      enabled: false
+      enabled: true
 
       initialDelaySeconds: 10
       timeoutSeconds: 5


### PR DESCRIPTION
Resolves #576 

Supported in nats-server versions 2.9.0 and later

Defaults readiness probes to `enabled`, should not affect existing deployments because by default it is the same check as the liveness probe

Adds opt-in feature flag `nats.healthcheck.enableHealthzLivenessReadiness`

This feature flag will be removed and the feature defaulted to true once deemed stable

