### PR TITLE
Optional liveness and readiness path

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.18.1
+version: 0.19.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -411,14 +411,15 @@ spec:
         #######################
         {{- if .Values.nats.healthcheck }}
         {{- $serverVersion := (split ":" .Values.nats.image)._1 | default "latest" | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.9.0" }}
-        {{- $enableHealthzStartup := and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $serverVersion)) }}
-        {{- $enableHealthzLivenessReadiness := and .Values.nats.healthcheck.enableHealthzLivenessReadiness (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.9.0" $serverVersion)) }}
+        {{- $enableHealthzStartup := and .Values.nats.healthcheck.startup.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $serverVersion)) }}
+        {{- $enableHealthzLiveness := and .Values.nats.healthcheck.liveness.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.9.0" $serverVersion)) }}
+        {{- $enableHealthzReadiness := and .Values.nats.healthcheck.readiness.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.9.0" $serverVersion)) }}
 
         {{- with .Values.nats.healthcheck.liveness }}
         {{- if .enabled }}
         livenessProbe:
           httpGet:
-            {{- if $enableHealthzLivenessReadiness }}
+            {{- if $enableHealthzLiveness }}
             # for NATS server versions >=2.9.0, /healthz?js-enabled=true will be enabled
             # liveness probe checks that the JS server is enabled
             path: /healthz?js-enabled=true
@@ -441,7 +442,7 @@ spec:
         {{- if .enabled }}
         readinessProbe:
           httpGet:
-            {{- if $enableHealthzLivenessReadiness }}
+            {{- if $enableHealthzReadiness }}
             # for NATS server versions >=2.9.0, /healthz?js-server-only=true will be enabled
             # readiness probe checks that the JS server is enabled, and is current with the meta leader
             path: /healthz?js-server-only=true

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -35,15 +35,12 @@ nats:
     # /healthz health check endpoint was introduced in NATS Server 2.7.1
     # Attempt to detect /healthz support by inspecting if tag is >=2.7.1
     detectHealthz: true
-    # Enable /healthz startupProbe for controlled upgrades of NATS JetStream
-    enableHealthz: true
-    # Enable /healthz liveness and readiness probes (supported in >=2.9.0)
-    # This is a feature flag and will be removed in future releases
-    enableHealthzLivenessReadiness: false
 
     # Enable liveness checks.  If this fails, then the NATS Server will restarted.
     liveness:
       enabled: true
+      # Enable /healthz liveness probes (supported in >=2.9.0)
+      enableHealthz: false
 
       initialDelaySeconds: 10
       timeoutSeconds: 5
@@ -70,6 +67,8 @@ nats:
     # the NATS container is running.
     readiness:
       enabled: true
+      # Enable /healthz readiness probes (supported in >=2.9.0)
+      enableHealthz: false
 
       initialDelaySeconds: 10
       timeoutSeconds: 5
@@ -82,6 +81,8 @@ nats:
     # it will try to ensure that the server is ready to serve streams.
     startup:
       enabled: true
+      # Enable /healthz startupProbe for controlled upgrades of NATS JetStream (supported in >=2.7.1)
+      enableHealthz: true
 
       initialDelaySeconds: 10
       timeoutSeconds: 5


### PR DESCRIPTION
To control the health path for liveness and readiness probes independently we move the configuration to each probe.

Context:

In our case we don't want to restart Nats container when we fail the liveness probe (for example lost of meta leader quorum), but we want maintain the default check to make sure that the process is running.

