### PR TITLE
[nats helm] allow overriding probe paths

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -417,64 +417,49 @@ spec:
         {{- with .Values.nats.healthcheck.liveness }}
         {{- if .enabled }}
         livenessProbe:
-          httpGet:
-            {{- if $enableHealthzLivenessReadiness }}
-            # for NATS server versions >=2.9.0, /healthz?js-enabled=true will be enabled
-            # liveness probe checks that the JS server is enabled
-            path: /healthz?js-enabled=true
-            {{- else }}
-            path: /
-            {{- end }}
-            port: 8222
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          successThreshold: {{ .successThreshold }}
-          failureThreshold: {{ .failureThreshold }}
-          {{- if .terminationGracePeriodSeconds }}
-          terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+          {{- $probe := merge (dict) . }}
+          {{- $_ := unset $probe "enabled" }}
+          {{- $probeDefault := dict "httpGet" (dict "path" "/" "port" 8222) }}
+          {{- if $enableHealthzLivenessReadiness }}
+          # for NATS server versions >=2.9.0, /healthz?js-enabled=true will be enabled
+          # liveness probe checks that the JS server is enabled
+          {{- $_ := set $probeDefault.httpGet "path" "/healthz?js-enabled=true" }}
           {{- end }}
+          {{- $probe := merge $probe $probeDefault }}
+          {{- toYaml $probe | nindent 10}}
         {{- end }}
         {{- end }}
 
         {{- with .Values.nats.healthcheck.readiness }}
         {{- if .enabled }}
         readinessProbe:
-          httpGet:
-            {{- if $enableHealthzLivenessReadiness }}
-            # for NATS server versions >=2.9.0, /healthz?js-server-only=true will be enabled
-            # readiness probe checks that the JS server is enabled, and is current with the meta leader
-            path: /healthz?js-server-only=true
-            {{- else }}
-            path: /
-            {{- end }}
-            port: 8222
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          successThreshold: {{ .successThreshold }}
-          failureThreshold: {{ .failureThreshold }}
+          {{- $probe := merge (dict) . }}
+          {{- $_ := unset $probe "enabled" }}
+          {{- $probeDefault := dict "httpGet" (dict "path" "/" "port" 8222) }}
+          {{- if $enableHealthzLivenessReadiness }}
+          # for NATS server versions >=2.9.0, /healthz?js-server-only=true will be enabled
+          # readiness probe checks that the JS server is enabled, and is current with the meta leader
+          {{- $_ := set $probeDefault.httpGet "path" "/healthz?js-server-only=true" }}
+          {{- end }}
+          {{- $probe := merge $probe $probeDefault }}
+          {{- toYaml $probe | nindent 10}}
         {{- end }}
         {{- end }}
 
         {{- with .Values.nats.healthcheck.startup }}
         {{- if .enabled }}
         startupProbe:
-          httpGet:
-            {{- if $enableHealthzStartup }}
-            # for NATS server versions >=2.7.1, /healthz will be enabled
-            # startup probe checks that the JS server is enabled, is current with the meta leader,
-            # and that all streams and consumers assigned to this JS server are current
-            path: /healthz
-            {{- else }}
-            path: /
-            {{- end }}
-            port: 8222
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          successThreshold: {{ .successThreshold }}
-          failureThreshold: {{ .failureThreshold }}
+          {{- $probe := merge (dict) . }}
+          {{- $_ := unset $probe "enabled" }}
+          {{- $probeDefault := dict "httpGet" (dict "path" "/" "port" 8222) }}
+          {{- if $enableHealthzStartup }}
+          # for NATS server versions >=2.7.1, /healthz will be enabled
+          # startup probe checks that the JS server is enabled, is current with the meta leader,
+          # and that all streams and consumers assigned to this JS server are current
+          {{- $_ := set $probeDefault.httpGet "path" "/healthz" }}
+          {{- end }}
+          {{- $probe := merge $probe $probeDefault }}
+          {{- toYaml $probe | nindent 10}}
         {{- end }}
         {{- end }}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -47,7 +47,7 @@ nats:
 
       initialDelaySeconds: 10
       timeoutSeconds: 5
-      # NOTE: liveness check + terminationGracePeriodSeconds can introduce unecessarily long outages
+      # NOTE: liveness check + terminationGracePeriodSeconds can introduce unnecessarily long outages
       # due to the coupling between liveness probe and terminationGracePeriodSeconds.
       # To avoid this, we make the periodSeconds of the liveness check to be about half the default
       # time that it takes for lame duck graceful stop.
@@ -63,8 +63,13 @@ nats:
       periodSeconds: 30
       successThreshold: 1
       failureThreshold: 3
+
+      # Override the health check path
+      # httpGet:
+      #   path: /healthz?js-enabled=true
+
       # Only for Kubernetes +1.22 that have pod level probes enabled.
-      terminationGracePeriodSeconds:
+      # terminationGracePeriodSeconds: 5
 
     # Periodically check for the server to be ready for connections while
     # the NATS container is running.
@@ -77,6 +82,10 @@ nats:
       successThreshold: 1
       failureThreshold: 3
 
+      # Override the health check path
+      # httpGet:
+      #   path: /healthz?js-server-only=true
+
     # Enable startup checks to confirm server is ready for traffic.
     # This is recommended for JetStream deployments since in cluster mode
     # it will try to ensure that the server is ready to serve streams.
@@ -88,6 +97,10 @@ nats:
       periodSeconds: 10
       successThreshold: 1
       failureThreshold: 30
+
+      # Override the health check path
+      # httpGet:
+      #   path: /healthz
 
   # Adds a hash of the ConfigMap as a pod annotation
   # This will cause the StatefulSet to roll when the ConfigMap is updated


### PR DESCRIPTION
Allow overriding probe paths, such as:

```
nats.healthcheck.startup.httpGet.path=/
nats.healthcheck.readiness.httpGet.path=/
nats.healthcheck.liveness.httpGet.path=/
```

Also switches probes to use `toYaml` meaning that any supported option for probes that may be added to the future in k8s will be supported