### PR TITLE
Remove replicas from nack

### DIFF
--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -7,7 +7,6 @@ jetstream:
   enabled: true
   image: natsio/jetstream-controller:0.7.2
   pullPolicy: IfNotPresent
-  replicas: 1
 
   # NATS URL
   nats:


### PR DESCRIPTION
Replicas doesn't do anything. Nack is not safe run with multiple replicas (as far as I can tell), so remove from values