### PR TITLE
adding hostNetwork and dnsPolicy to helm chart

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -81,6 +81,12 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hostNetwork }}
+      hostNetwork: {{ toYaml . | nindent 8 }}
+      {{- end }}
       # Common volumes for the containers.
       volumes:
       - name: config-volume

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -81,11 +81,11 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
-      {{- with .Values.dnsPolicy }}
-      dnsPolicy: {{ toYaml . | nindent 8 }}
+      {{- with .Values.nats.dnsPolicy }}
+      dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.hostNetwork }}
-      hostNetwork: {{ toYaml . | nindent 8 }}
+      {{- with .Values.nats.hostNetwork }}
+      hostNetwork: {{ . }}
       {{- end }}
       # Common volumes for the containers.
       volumes:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -329,6 +329,13 @@ affinity: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 priorityClassName: null
 
+## hostNetwork
+hostNetwork: false
+
+## Pod Dns Policy. Default is ClusterFirst
+## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy: ClusterFirst
+
 # Service topology
 # ref: https://kubernetes.io/docs/concepts/services-networking/service-topology/
 topologyKeys: []

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -102,6 +102,13 @@ nats:
       # httpGet:
       #   path: /healthz
 
+  ## hostNetwork
+  hostNetwork: false
+
+  ## Pod Dns Policy. Default is ClusterFirst
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  dnsPolicy: ClusterFirst
+
   # Adds a hash of the ConfigMap as a pod annotation
   # This will cause the StatefulSet to roll when the ConfigMap is updated
   configChecksumAnnotation: true
@@ -328,13 +335,6 @@ affinity: {}
 ## Pod priority class name
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 priorityClassName: null
-
-## hostNetwork
-hostNetwork: false
-
-## Pod Dns Policy. Default is ClusterFirst
-## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-dnsPolicy: ClusterFirst
 
 # Service topology
 # ref: https://kubernetes.io/docs/concepts/services-networking/service-topology/


### PR DESCRIPTION
This PR allows you to configure hostNetwork'ing mode along with a dnsPolicy on the nats statefulset. This can be useful when nats traffic is required to run on specific interfaces attached to a VM.