### PR TITLE
feat: Allows to activate raft compression

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -96,6 +96,10 @@ data:
       {{- if .Values.nats.jetstream.uniqueTag }}
       unique_tag: {{ .Values.nats.jetstream.uniqueTag }}
       {{- end }}
+
+      {{- if .Values.nats.jetstream.compress }}
+      compress_ok: {{ .Values.nats.jetstream.compress }}
+      {{- end }}
     }
     {{- end }}
     {{- if .Values.mqtt.enabled }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -270,6 +270,9 @@ nats:
       annotations:
       # key: "value"
 
+    # Allow optional compression in raft and stream catchup
+    compress:
+
   #######################
   #                     #
   #  TLS Configuration  #


### PR DESCRIPTION
According to the change in tha nats-server
https://github.com/nats-io/nats-server/pull/3419, there is the possibility of enabling raft compression in the nats-server. The following PRs gives the possibility of changing that property in the helm release so we can activate it in the nats-server.