### PR TITLE
[helm] standardize image format

### DIFF
--- a/helm/charts/nack/README.md
+++ b/helm/charts/nack/README.md
@@ -23,8 +23,6 @@ one as follows:
 
 ```yaml
 nats:
-  image: nats:alpine
-
   jetstream:
     enabled: true
 

--- a/helm/charts/nack/templates/_helpers.tpl
+++ b/helm/charts/nack/templates/_helpers.tpl
@@ -18,3 +18,28 @@ Define the serviceaccountname
 {{- define "jsc.serviceAccountName" -}}
 {{- default "jetstream-controller" .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+Fix image keys for chart versions <= 0.17.5
+*/}}
+{{- define "jsc.fixImage" -}}
+{{- if kindIs "string" .image }}
+{{- $_ := set . "image" (dict "repository" (split ":" .image)._0 "tag" ((split ":" .image)._1 | default "latest") "pullPolicy" "IfNotPresent") }}
+{{- end }}
+{{- if kindIs "string" .pullPolicy }}
+{{- $_ := set .image "pullPolicy" .pullPolicy }}
+{{- $_ := unset . "pullPolicy" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Print the image
+*/}}
+{{- define "jsc.image" -}}
+{{- $image := printf "%s:%s" .repository .tag }}
+{{- if .registry }}
+{{- $image = printf "%s/%s" .registry $image }}
+{{- end }}
+{{- $image -}}
+{{- end }}

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -1,3 +1,4 @@
+{{- include "jsc.fixImage" .Values.jetstream -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -72,8 +73,8 @@ spec:
 
       containers:
         - name: jsc
-          image: {{ .Values.jetstream.image }}
-          imagePullPolicy: {{ .Values.jetstream.pullPolicy }}
+          image: {{ include "jsc.image" .Values.jetstream.image }}
+          imagePullPolicy: {{ .Values.jetstream.image.pullPolicy }}
           workingDir: /nack
           command:
           - /jetstream-controller

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -5,8 +5,11 @@
 ###############################
 jetstream:
   enabled: true
-  image: natsio/jetstream-controller:0.7.4
-  pullPolicy: IfNotPresent
+  image:
+    repository: natsio/jetstream-controller
+    tag: 0.7.4
+    pullPolicy: IfNotPresent
+    # registry: docker.io
 
   # NATS URL
   nats:

--- a/helm/charts/nats-kafka/templates/_helpers.tpl
+++ b/helm/charts/nats-kafka/templates/_helpers.tpl
@@ -67,3 +67,24 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Fix image keys for chart versions <= 0.13.1
+*/}}
+{{- define "nats-kafka.fixImage" -}}
+{{- if .tagOverride }}
+{{- $_ := set . "tag" .tagOverride }}
+{{- $_ := unset . "tagOverride" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Print the image
+*/}}
+{{- define "nats-kafka.image" -}}
+{{- $image := printf "%s:%s" .repository .tag }}
+{{- if .registry }}
+{{- $image = printf "%s/%s" .registry $image }}
+{{- end }}
+{{- $image -}}
+{{- end }}

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "nats-kafka.fixImage" .Values.image -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,7 +24,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tagOverride | default .Chart.AppVersion }}"
+          image: {{ include "nats-kafka.image" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.natskafka.resources | nindent 12 }}

--- a/helm/charts/nats-kafka/values.yaml
+++ b/helm/charts/nats-kafka/values.yaml
@@ -8,9 +8,9 @@ replicaCount: 1
 
 image:
   repository: natsio/nats-kafka
+  tag: 1.3.0
   pullPolicy: IfNotPresent
-  # tagOverride overrides .Chart.AppVersion
-  tagOverride: ""
+  # registry: docker.io
 
 natskafka:
   reconnectInterval: 5000

--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -32,9 +32,18 @@ helm install my-nats nats/nats
 ### Server Image
 
 ```yaml
+# use a specefic versions
 nats:
-  image: nats:2.9.3-alpine
-  pullPolicy: IfNotPresent
+  image:
+    tag: X.Y.Z-alpine
+
+# fully custom location
+nats:
+  image:
+    registry: my.custom.registry
+    repository: my-nats
+    tag: latest
+    pullPolicy: Always
 ```
 
 ### Limits
@@ -222,8 +231,8 @@ The container image of the initializer can be customized via:
 
 ```yaml
 bootconfig:
-  image: natsio/nats-boot-config:latest
-  pullPolicy: IfNotPresent
+  image:
+    tag: X.Y.Z
 ```
 
 ### Using LoadBalancers
@@ -233,9 +242,6 @@ so that internal ips from the NATS Servers are not advertised to the clients con
 the load balancer.
 
 ```yaml
-nats:
-  image: nats:alpine
-
 cluster:
   enabled: true
   noAdvertise: true
@@ -427,8 +433,6 @@ File Storage is **always** recommended, since JetStream's RAFT Meta Group will b
 
 ```yaml
 nats:
-  image: nats:alpine
-
   jetstream:
     enabled: true
 
@@ -466,8 +470,6 @@ You can start JetStream so that one pod is bounded to it:
 
 ```yaml
 nats:
-  image: nats:alpine
-
   jetstream:
     enabled: true
 
@@ -483,8 +485,6 @@ nats:
 ```yaml
 
 nats:
-  image: nats:alpine
-
   jetstream:
     enabled: true
 
@@ -507,8 +507,6 @@ cluster:
 
 ```yaml
 nats:
-  image: nats:alpine
-
   jetstream:
     enabled: true
 
@@ -621,8 +619,6 @@ Now we start the server with the NATS Account Resolver (`auth.resolver.type=full
 
 ```yaml
 nats:
-  image: nats:2.9.3-alpine
-
   logging:
     debug: false
     trace: false
@@ -694,8 +690,8 @@ You can find the image at: https://github.com/nats-io/nats-box
 ```yaml
 natsbox:
   enabled: true
-  image: natsio/nats-box:latest
-  pullPolicy: IfNotPresent
+  image:
+    tag: X.Y.Z
 
   # credentials:
   #   secret:
@@ -719,8 +715,8 @@ The NATS configuration reload sidecar is enabled by default; it passes the confi
 ```yaml
 reloader:
   enabled: true
-  image: natsio/nats-server-config-reloader:latest
-  pullPolicy: IfNotPresent
+  image:
+    tag: X.Y.Z
 ```
 
 ### Prometheus Exporter sidecar
@@ -730,8 +726,8 @@ The Prometheus Exporter sidecar is enabled by default; it can be used to feed me
 ```yaml
 exporter:
   enabled: true
-  image: natsio/prometheus-nats-exporter:latest
-  pullPolicy: IfNotPresent
+  image:
+    tag: X.Y.Z
 ```
 
 ### Prometheus operator ServiceMonitor support

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -230,3 +230,27 @@ Create the name of the service account to use
 {{- default "default" .Values.nats.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Fix image keys for chart versions <= 0.18.3
+*/}}
+{{- define "nats.fixImage" -}}
+{{- if kindIs "string" .image }}
+{{- $_ := set . "image" (dict "repository" (split ":" .image)._0 "tag" ((split ":" .image)._1 | default "latest") "pullPolicy" "IfNotPresent") }}
+{{- end }}
+{{- if kindIs "string" .pullPolicy }}
+{{- $_ := set .image "pullPolicy" .pullPolicy }}
+{{- $_ := unset . "pullPolicy" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Print the image
+*/}}
+{{- define "nats.image" -}}
+{{- $image := printf "%s:%s" .repository .tag }}
+{{- if .registry }}
+{{- $image = printf "%s/%s" .registry $image }}
+{{- end }}
+{{- $image -}}
+{{- end }}

--- a/helm/charts/nats/templates/nats-box.yaml
+++ b/helm/charts/nats/templates/nats-box.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.natsbox.enabled }}
+{{- include "nats.fixImage" .Values.natsbox -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -66,8 +67,8 @@ spec:
       {{- end }}
       containers:
       - name: nats-box
-        image: {{ .Values.natsbox.image }}
-        imagePullPolicy: {{ .Values.natsbox.pullPolicy }}
+        image: {{ include "nats.image" .Values.natsbox.image }}
+        imagePullPolicy: {{ .Values.natsbox.image.pullPolicy }}
         {{- if .Values.natsbox.securityContext }}
         securityContext:
           {{- toYaml .Values.natsbox.securityContext | nindent 10 }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -1,3 +1,7 @@
+{{- include "nats.fixImage" .Values.nats -}}
+{{- include "nats.fixImage" .Values.bootconfig -}}
+{{- include "nats.fixImage" .Values.reloader -}}
+{{- include "nats.fixImage" .Values.exporter -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -228,8 +232,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: {{ .Values.bootconfig.image }}
-        imagePullPolicy: {{ .Values.bootconfig.pullPolicy }}
+        image: {{ include "nats.fixImage" .Values.bootconfig.image }}
+        imagePullPolicy: {{ .Values.bootconfig.image.pullPolicy }}
         {{- if .Values.bootconfig.securityContext }}
         securityContext:
           {{- toYaml .Values.bootconfig.securityContext | nindent 10 }}
@@ -250,8 +254,8 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.nats.terminationGracePeriodSeconds }}
       containers:
       - name: nats
-        image: {{ .Values.nats.image }}
-        imagePullPolicy: {{ .Values.nats.pullPolicy }}
+        image: {{ include "nats.image" .Values.nats.image }}
+        imagePullPolicy: {{ .Values.nats.image.pullPolicy }}
         {{- if .Values.nats.securityContext }}
         securityContext:
           {{- toYaml .Values.nats.securityContext | nindent 10 }}
@@ -416,7 +420,7 @@ spec:
         #                     #
         #######################
         {{- if .Values.nats.healthcheck }}
-        {{- $serverVersion := (split ":" .Values.nats.image)._1 | default "latest" | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.9.0" }}
+        {{- $serverVersion := .Values.nats.image.tag | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.9.0" }}
         {{- $enableHealthzStartup := and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $serverVersion)) }}
         {{- $enableHealthzLivenessReadiness := and .Values.nats.healthcheck.enableHealthzLivenessReadiness (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.9.0" $serverVersion)) }}
 
@@ -490,8 +494,8 @@ spec:
       #################################
       {{- if .Values.reloader.enabled }}
       - name: reloader
-        image: {{ .Values.reloader.image }}
-        imagePullPolicy: {{ .Values.reloader.pullPolicy }}
+        image: {{ include "nats.image" .Values.reloader.image }}
+        imagePullPolicy: {{ .Values.reloader.image.pullPolicy }}
         {{- if .Values.reloader.securityContext }}
         securityContext:
           {{- toYaml .Values.reloader.securityContext | nindent 10 }}
@@ -536,8 +540,8 @@ spec:
       ##############################
       {{- if .Values.exporter.enabled }}
       - name: metrics
-        image: {{ .Values.exporter.image }}
-        imagePullPolicy: {{ .Values.exporter.pullPolicy }}
+        image: {{ include "nats.image" .Values.exporter.image }}
+        imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
         {{- if .Values.exporter.securityContext }}
         securityContext:
           {{- toYaml .Values.exporter.securityContext | nindent 10 }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -4,8 +4,11 @@
 #                             #
 ###############################
 nats:
-  image: nats:2.9.8-alpine
-  pullPolicy: IfNotPresent
+  image:
+    repository: nats
+    tag: 2.9.8-alpine
+    pullPolicy: IfNotPresent
+    # registry: docker.io
 
   # The servers name prefix, must be used for example when we want a NATS cluster
   # spanning multiple Kubernetes clusters.
@@ -482,8 +485,12 @@ gateway:
 # enabled, an initializer container will be used to gather
 # the public ips.
 bootconfig:
-  image: natsio/nats-boot-config:0.7.4
-  pullPolicy: IfNotPresent
+  image:
+    repository: natsio/nats-boot-config
+    tag: 0.7.4
+    pullPolicy: IfNotPresent
+    # registry: docker.io
+
   securityContext: {}
 
 # NATS Box
@@ -492,8 +499,12 @@ bootconfig:
 #
 natsbox:
   enabled: true
-  image: natsio/nats-box:0.13.2
-  pullPolicy: IfNotPresent
+  image:
+    repository: natsio/nats-box
+    tag: 0.13.2
+    pullPolicy: IfNotPresent
+    # registry: docker.io
+
   securityContext: {}
 
   # Labels to add to the natsbox deployment
@@ -550,17 +561,25 @@ natsbox:
 # The NATS config reloader image to use.
 reloader:
   enabled: true
-  image: natsio/nats-server-config-reloader:0.7.4
-  pullPolicy: IfNotPresent
+  image:
+    repository: natsio/nats-server-config-reloader
+    tag: 0.7.4
+    pullPolicy: IfNotPresent
+    # registry: docker.io
+
   securityContext: {}
   extraConfigs: []
 
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: natsio/prometheus-nats-exporter:0.10.0
+  image:
+    repository: natsio/prometheus-nats-exporter
+    tag: 0.10.0
+    pullPolicy: IfNotPresent
+    # registry: docker.io
+
   portName: metrics
-  pullPolicy: IfNotPresent
   securityContext: {}
   resources: {}
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled

--- a/helm/charts/surveyor/templates/_helpers.tpl
+++ b/helm/charts/surveyor/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Print the image
+*/}}
+{{- define "surveyor.image" -}}
+{{- $image := printf "%s:%s" .repository .tag }}
+{{- if .registry }}
+{{- $image = printf "%s/%s" .registry $image }}
+{{- end }}
+{{- $image -}}
+{{- end }}

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "surveyor.image" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -p

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -6,8 +6,9 @@ replicaCount: 1
 
 image:
   repository: natsio/nats-surveyor
-  pullPolicy: IfNotPresent
   tag: 0.4.1
+  pullPolicy: IfNotPresent
+  # registry: docker.io
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Standardizes image formats across `nats`, `nats-kafka`, `surveyor`, and `nack` and also includes option for overriding registry.  Dependabot also understands this format

```
image:
  repository: image-repo
  tag: x.y.z
  pullPolicy: IfNotPresent
  # registry: docker.io
```

Performs backward-compatible upgrades

## Manually tested these cases for the `nats` chart:

No modification:

```yaml
        image: nats:2.9.8-alpine
        imagePullPolicy: IfNotPresent
```     
        
        
Old string image format

`--set nats.image=my-nats:1.2.3`:

```yaml
        image: my-nats:1.2.3
        imagePullPolicy: IfNotPresent
```     

Old pull policy format

`--set nats.pullPolicy=Always`:

```yaml
        image: nats:2.9.8-alpine
        imagePullPolicy: Always
```

New pull policy format

`--set nats.image.pullPolicy=Always`:

```yaml
        image: nats:2.9.8-alpine
        imagePullPolicy: Always
```

All new options:

`--set "nats.image.registry=localhost" --set "nats.image.repository=my-nats" --set "nats.image.tag=1.2.3" --set "nats.image.pullPolicy=Always"`:

```yaml
        image: localhost/my-nats:1.2.3
        imagePullPolicy: Always
```

All images registry: `--set reloader.image.registry=localhost --set exporter.image.registry=localhost --set nats.image.registry=localhost --set natsbox.image.registry=localhost`

```yaml
        image: localhost/natsio/nats-box:0.13.2
        imagePullPolicy: IfNotPresent
--
        image: localhost/nats:2.9.8-alpine
        imagePullPolicy: IfNotPresent
--
        image: localhost/natsio/nats-server-config-reloader:0.7.4
        imagePullPolicy: IfNotPresent
--
        image: localhost/natsio/prometheus-nats-exporter:0.10.0
        imagePullPolicy: IfNotPresent
```

## Manually tested these cases for the `surveyor` chart:

No modification:

```yaml
          image: natsio/nats-surveyor:0.4.1
          imagePullPolicy: IfNotPresent
```

Registry override `--set image.registry=test`:

```yaml
          image: test/natsio/nats-surveyor:0.4.1
          imagePullPolicy: IfNotPresent
```

## Manually tested these cases for the `nats-kafka` chart:

No modification:

```yaml
          image: natsio/nats-kafka:1.3.0
          imagePullPolicy: IfNotPresent
```

Old tag format `--set image.tagOverride=test`:
          image: natsio/nats-kafka:test
          imagePullPolicy: IfNotPresent
```yaml

```

Override registry `--set image.registry=test`:

```yaml
          image: test/natsio/nats-kafka:1.3.0
          imagePullPolicy: IfNotPresent
```

## Manually tested these cases for the `nack` chart:

No modification:

```yaml
          image: natsio/jetstream-controller:0.7.4
          imagePullPolicy: IfNotPresent
```

Override registry `--set jetstream.image.registry=test`:

```yaml
          image: test/natsio/jetstream-controller:0.7.4
          imagePullPolicy: IfNotPresent
```