### PR TITLE
[nats helm] fix healthz liveness/readiness probes

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.19.2
+version: 0.19.3
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -426,7 +426,7 @@ spec:
         {{- $healthzStartupEndpoint := "/healthz" }}
         {{- $healthzLivenessEndpoint := "/healthz?js-enabled-only=true" }}
         {{- $healthzReadinessEndpoint := "/healthz?js-server-only=true" }}
-        
+
         {{- /* healthz options behaved differently in 2.9.0 - 2.9.9 https://github.com/nats-io/nats-server/pull/3704 */}}
         {{- if (semverCompare "<=2.9.9" $serverVersion) }}
         {{- $healthzLivenessEndpoint = "/healthz?js-server-only=true" }}
@@ -476,10 +476,10 @@ spec:
           {{- $_ := unset $probe "enabled" }}
           {{- $probeDefault := dict "httpGet" (dict "path" "/" "port" 8222) }}
           {{- if $enableHealthzStartup }}
-          # for NATS server versions >=2.7.1, /healthz will be enabled
+          # for NATS server versions >=2.7.1, {{ $healthzStartupEndpoint}} will be enabled
           # startup probe checks that the JS server is enabled, is current with the meta leader,
           # and that all streams and consumers assigned to this JS server are current
-          {{- $_ := set $probeDefault.httpGet "path" "/healthz" }}
+          {{- $_ := set $probeDefault.httpGet "path" $healthzStartupEndpoint }}
           {{- end }}
           {{- $probe := merge $probe $probeDefault }}
           {{- toYaml $probe | nindent 10}}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -423,6 +423,19 @@ spec:
         {{- $serverVersion := .Values.nats.image.tag | regexFind "\\d+(\\.\\d+)?(\\.\\d+)?" | default "2.9.0" }}
         {{- $enableHealthzStartup := and .Values.nats.healthcheck.enableHealthz (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.7.1" $serverVersion)) }}
         {{- $enableHealthzLivenessReadiness := and .Values.nats.healthcheck.enableHealthzLivenessReadiness (or (not .Values.nats.healthcheck.detectHealthz) (semverCompare ">=2.9.0" $serverVersion)) }}
+        {{- $healthzStartupEndpoint := "/healthz" }}
+        {{- $healthzLivenessEndpoint := "/healthz?js-enabled-only=true" }}
+        {{- $healthzReadinessEndpoint := "/healthz?js-server-only=true" }}
+        
+        {{- /* healthz options behaved differently in 2.9.0 - 2.9.9 https://github.com/nats-io/nats-server/pull/3704 */}}
+        {{- if (semverCompare "<=2.9.9" $serverVersion) }}
+        {{- $healthzLivenessEndpoint = "/healthz?js-server-only=true" }}
+        {{- $healthzReadinessEndpoint = "/healthz?js-server-only=true" }}
+        {{- if .Values.nats.jetstream.enabled }}
+        {{- $healthzLivenessEndpoint = print $healthzLivenessEndpoint "&js-enabled=true" }}
+        {{- $healthzReadinessEndpoint = print $healthzReadinessEndpoint "&js-enabled=true" }}
+        {{- end }}
+        {{- end }}
 
         {{- with .Values.nats.healthcheck.liveness }}
         {{- if .enabled }}
@@ -431,9 +444,9 @@ spec:
           {{- $_ := unset $probe "enabled" }}
           {{- $probeDefault := dict "httpGet" (dict "path" "/" "port" 8222) }}
           {{- if $enableHealthzLivenessReadiness }}
-          # for NATS server versions >=2.9.0, /healthz?js-enabled=true will be enabled
+          # for NATS server versions >=2.9.0, {{ $healthzLivenessEndpoint }} will be enabled
           # liveness probe checks that the JS server is enabled
-          {{- $_ := set $probeDefault.httpGet "path" "/healthz?js-enabled=true" }}
+          {{- $_ := set $probeDefault.httpGet "path" $healthzLivenessEndpoint }}
           {{- end }}
           {{- $probe := merge $probe $probeDefault }}
           {{- toYaml $probe | nindent 10}}
@@ -447,9 +460,9 @@ spec:
           {{- $_ := unset $probe "enabled" }}
           {{- $probeDefault := dict "httpGet" (dict "path" "/" "port" 8222) }}
           {{- if $enableHealthzLivenessReadiness }}
-          # for NATS server versions >=2.9.0, /healthz?js-server-only=true will be enabled
+          # for NATS server versions >=2.9.0, {{ $healthzReadinessEndpoint }} will be enabled
           # readiness probe checks that the JS server is enabled, and is current with the meta leader
-          {{- $_ := set $probeDefault.httpGet "path" "/healthz?js-server-only=true" }}
+          {{- $_ := set $probeDefault.httpGet "path" $healthzReadinessEndpoint }}
           {{- end }}
           {{- $probe := merge $probe $probeDefault }}
           {{- toYaml $probe | nindent 10}}


### PR DESCRIPTION
Fixes an invalid assumption about the health check in the liveness probe to align with https://github.com/nats-io/nats-server/pull/3704


### Server Version `<2.9.0` or  setting of `nats.healthcheck.enableHealthzLivenessReadiness=false`

No Change

### Server Version `>=2.9.0` but `<2.9.10` with setting of `nats.healthcheck.enableHealthzLivenessReadiness=true`

- Liveness Probe:
  - JS Enabled: `/healthz?js-server-only=true&js-enabled=true`
  - JS Disabled: `/healthz?js-server-only=true`

- Readiness Probe:
  - JS Enabled: `/healthz?js-server-only=true&js-enabled=true`
  - JS Disabled: `/healthz?js-server-only=true`

### Server Version `>=2.9.10` with setting of `nats.healthcheck.enableHealthzLivenessReadiness=true`

- Liveness Probe: `/healthz?js-enabled-only=true`
- Readiness Probe: `/healthz?js-server-only=true`
