### PR TITLE
Fixes to support enabling default $SYS account for JS

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -471,7 +471,7 @@ data:
             {{- end }}
 
             {{- if .systemAccount }}
-            system_account: {{ .systemAccount }}
+            system_account: {{ .systemAccount | quote }}
             {{- end }}
           {{- end }}
 
@@ -501,7 +501,7 @@ data:
     {{- end }}
 
     {{- with .Values.auth.systemAccount }}
-    system_account: {{ . }}
+    system_account: {{ . | quote }}
     {{- end }}
 
     {{- with .Values.auth.token }}
@@ -578,7 +578,6 @@ data:
       timeout: {{ $.Values.auth.timeout }}
       {{- end }}
     }
-
     accounts: {{- toRawJson . }}
     {{- end }}
 


### PR DESCRIPTION
Fixes #617 

Signed-off-by: Waldemar Quevedo <wally@nats.io>