### PR TITLE
Disable config checksum restart by default

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -114,7 +114,7 @@ nats:
 
   # Adds a hash of the ConfigMap as a pod annotation
   # This will cause the StatefulSet to roll when the ConfigMap is updated
-  configChecksumAnnotation: true
+  configChecksumAnnotation: false
 
   # securityContext for the nats container
   securityContext: {}


### PR DESCRIPTION
Follow up from #617 

A server can restart with an incompatible config that was not possible to reload and break JS quorum accidentally for example, also reloading of leafnode remotes is supported since v2.9.X so we could opt-out for default now.

Signed-off-by: Waldemar Quevedo <wally@nats.io>