### PR TITLE
Add JS encryption cipher option

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -72,6 +72,9 @@ data:
       {{- else if .Values.nats.jetstream.encryption.secret }}
       key: $JS_KEY
       {{- end}}
+      {{- if .Values.nats.jetstream.encryption.cipher }}
+      cipher: {{ .Values.nats.jetstream.encryption.cipher }}
+      {{- end}}
       {{- end}}
 
       {{- if .Values.nats.jetstream.memStorage.enabled }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -242,6 +242,9 @@ nats:
       #   name: "nats-jetstream-encryption"
       #   key: "key"
 
+      # Use cipher if you want to choose a different cipher from the default.
+      # cipher: aes
+
     #############################
     #                           #
     #  Jetstream Memory Storage #


### PR DESCRIPTION
Add cipher to JetStream encryption.

Nats Documentation: https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/encryption_at_rest