### PR TITLE
feat: add extra nats config to reloader

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -535,6 +535,10 @@ spec:
         - "-config"
         - {{ . | quote }}
         {{- end }}
+        {{- range .Values.nats.config }}
+        - "-config"
+        - "/etc/nats-config/{{ .name }}/{{ .name }}.conf"
+        {{- end}}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/nats-config
@@ -543,6 +547,12 @@ spec:
         {{- include "nats.tlsVolumeMounts" . | nindent 8 }}
         {{- if .Values.additionalVolumeMounts }}
         {{- toYaml .Values.additionalVolumeMounts | nindent 8 }}
+        {{- end }}
+        {{- /* User extended config volumes*/}}
+        {{- range .Values.nats.config }}
+        # User extended config volumes
+        - name: {{ .name }}
+          mountPath: /etc/nats-config/{{ .name }}
         {{- end }}
       {{- end }}
 


### PR DESCRIPTION
Automatically add additional config files to the reloader.

This allows the reloader to pick up any changes to included files in nats-config.