### PR TITLE
feat: add JS max_outstanding_catchup config option

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -99,6 +99,10 @@ data:
       {{- if .Values.nats.jetstream.uniqueTag }}
       unique_tag: {{ .Values.nats.jetstream.uniqueTag }}
       {{- end }}
+
+      {{- if .Values.nats.jetstream.max_outstanding_catchup }}
+      max_outstanding_catchup: {{ .Values.nats.jetstream.max_outstanding_catchup }}
+      {{- end }}
     }
     {{- end }}
     {{- if .Values.mqtt.enabled }}

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -100,8 +100,8 @@ data:
       unique_tag: {{ .Values.nats.jetstream.uniqueTag }}
       {{- end }}
 
-      {{- if .Values.nats.jetstream.max_outstanding_catchup }}
-      max_outstanding_catchup: {{ .Values.nats.jetstream.max_outstanding_catchup }}
+      {{- if .Values.nats.jetstream.maxOutstandingCatchup }}
+      max_outstanding_catchup: {{ .Values.nats.jetstream.maxOutstandingCatchup }}
       {{- end }}
     }
     {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -228,6 +228,8 @@ nats:
     # Jetstream Unique Tag prevent placing a stream in the same availability zone twice.
     uniqueTag:
 
+    max_outstanding_catchup:
+
     ##########################
     #                        #
     #  Jetstream Encryption  #


### PR DESCRIPTION
Add the ability to set `max_outstanding_catchup` to JetStream Config.