### PR TITLE
feat: create and set Surveyor ServiceAccount

### DIFF
--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "surveyor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/charts/surveyor/templates/serviceAccountyaml
+++ b/helm/charts/surveyor/templates/serviceAccountyaml
@@ -1,0 +1,12 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "surveyor.serviceAccountName" . }}
+  labels:
+    {{- include "surveyor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -27,6 +27,15 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 service:
   type: ClusterIP
   port: 7777


### PR DESCRIPTION
Adding the ability to set a `ServiceAccount` for Surveyor.

The chart already had the functionality for generating the name with `"surveyor.serviceAccountName"`, but didn't actually create or set it.