### PR TITLE
fix: ServiceAccount token mount

### DIFF
--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -34,6 +34,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name : runtime
@@ -55,6 +58,9 @@ spec:
         secret:
           secretName: {{ .secret.name }}
       {{- end}}
+      {{- if .Values.additionalVolumes }}
+      {{- toYaml .Values.additionalVolumes | nindent 6 }}
+      {{- end }}
 
 {{- with .Values.affinity }}
       affinity:
@@ -70,7 +76,9 @@ spec:
 {{- end }}
 
       serviceAccountName: {{ template "jsc.serviceAccountName" . }}
-
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       containers:
         - name: jsc
           image: {{ include "jsc.image" .Values.jetstream.image }}
@@ -136,4 +144,7 @@ spec:
           {{- if .Values.jetstream.nats.nkey }}
           - name: jsc-sys-nkey
             mountPath: /etc/jsc-nkey
+          {{- end }}
+          {{- if .Values.additionalVolumeMounts }}
+          {{- toYaml .Values.additionalVolumeMounts | nindent 10 }}
           {{- end }}

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -52,6 +52,19 @@ nameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []
 serviceAccountName: ""
+# Toggle whether to automatically mount Service Account token in the pod
+# not set means default value, boolean true/false overrides default value
+# automountServiceAccountToken: true
+
+## Pod priority class name
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: null
+
+# additionalVolumes are the additional volumes to add
+additionalVolumes: []
+
+# additionalVolumeMounts are the additional volume mounts to add
+additionalVolumeMounts: []
 
 # Rules to be applied to ClusterRole or Role
 # Set as a string so that it can be templated to allow further customization


### PR DESCRIPTION
We have a security requirement across all K8s resources that `automountServiceAccountToken` must be set to `false`
In this scenario you can still mount the token manually using the `additionalVolumes` and `additionalVolumeMounts`. 

For example:
```yaml
  automountServiceAccountToken: false
  additionalVolumes:
    - name: serviceaccount-token
      projected:
        defaultMode: 420
        sources:
          - serviceAccountToken:
              expirationSeconds: 3607
              path: token
          - configMap:
              name: kube-root-ca.crt
              items:
                - key: ca.crt
                  path: ca.crt
          - downwardAPI:
              items:
                - path: namespace
                  fieldRef:
                    apiVersion: v1
                    fieldPath: metadata.namespace
  additionalVolumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: serviceaccount-token
```