### PR TITLE
NACK: Add additionalArgs value to provide to the controller

### DIFF
--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - nats
 - jetstream
 - cncf
-version: 0.20.3
+version: 0.20.4
 maintainers:
 - name: Waldemar Quevedo
   url: https://github.com/wallyqs

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -86,6 +86,7 @@ spec:
           workingDir: /nack
           command:
           - /jetstream-controller
+          args:
           {{- if .Values.jetstream.klogLevel }}
           - -v={{ .Values.jetstream.klogLevel }}
           {{- end }}
@@ -112,10 +113,9 @@ spec:
           {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.settings.client_ca }}
           - --tlsca={{ .Values.jetstream.tls.settings.client_ca }}
           {{- end }}
-          {{- if .Values.additionalArgs }}
-          {{- toYaml .Values.additionalArgs | nindent 10 }}
+          {{- with .Values.jetstream.additionalArgs }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
-
           env:
           - name: POD_NAME
             valueFrom:

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -112,6 +112,9 @@ spec:
           {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.settings.client_ca }}
           - --tlsca={{ .Values.jetstream.tls.settings.client_ca }}
           {{- end }}
+          {{- if .Values.additionalArgs }}
+          {{- toYaml .Values.additionalArgs | nindent 10 }}
+          {{- end }}
 
           env:
           - name: POD_NAME

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -45,11 +45,11 @@ jetstream:
       client_ca: "/etc/nats/certs/ca.crt"
       timeout: 3
 
+  # additional arguments to pass to the controller process
+  additionalArgs: []
+
 # restrict the controller to only watch resources in it's current namespace
 namespaced: false
-
-# Additional arguments to pass to the controller process
-additionalArgs: []
 
 nameOverride: ""
 namespaceOverride: ""

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -48,6 +48,9 @@ jetstream:
 # restrict the controller to only watch resources in it's current namespace
 namespaced: false
 
+# Additional arguments to pass to the controller process
+additionalArgs: []
+
 nameOverride: ""
 namespaceOverride: ""
 imagePullSecrets: []


### PR DESCRIPTION
Allow to specify a dedicated namespace for `nack` to watch instead of the same namespace it's deployed to.
The use case for us is that we have several `nats servers` and corresponding `nacks` running in the same cluster that should be looking in specific namespaces for CRD resources.

UPD: as suggested by @caleblloyd - introducing generic `additionalArgs` value to pass to the controller process.
In our case it will be:
```
additionalArgs:
  - "--namespace=<dedicated namespace>"
```