### PR TITLE
make emptyDir volumes configurable

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.20.0
+version: 0.19.10
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.19.9
+version: 0.20.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -112,7 +112,7 @@ spec:
 
       # Local volume shared with the reloader.
       - name: pid
-        emptyDir: {}
+        {{- toYaml .Values.pidVolume | nindent 8 }}
 
       {{- if and .Values.auth.enabled .Values.auth.resolver }}
       {{- if .Values.auth.resolver.configMap }}
@@ -131,7 +131,7 @@ spec:
       {{- if and .Values.nats.externalAccess .Values.nats.advertise }}
       # Local volume shared with the advertise config initializer.
       - name: advertiseconfig
-        emptyDir: {}
+        {{- toYaml .Values.advertiseconfigVolume | nindent 8 }}
       {{- end }}
 
       {{- if and .Values.nats.jetstream.enabled .Values.nats.jetstream.fileStorage.enabled .Values.nats.jetstream.fileStorage.existingClaim }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -766,3 +766,11 @@ commonLabels: {}
 # podManagementPolicy controls how pods are created during initial scale up,
 # when replacing pods on nodes, or when scaling down.
 podManagementPolicy: Parallel
+
+# Shared volume to be mounted in pods for pid
+pidVolume:
+  emptyDir: {}
+
+# Shared volume to be mounted in pods for advertiseconfig
+advertiseconfigVolume:
+  emptyDir: {}


### PR DESCRIPTION
This pr makes emptyDir volumes pid & advertiseconfig configurable.

Normal "emptyDir" volume stays the default but now you can also set a sizeLimit for the emptyDir for example or even configure to use another volumetype, like a pvc.
