### PR TITLE
NATS: Alternate [Optional] Jetstream store_dir and max_file Configuration

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.19.9
+version: 0.19.10
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -94,6 +94,13 @@ data:
       {{- else }}
       {{- .Values.nats.jetstream.fileStorage.size }}
       {{- end }}
+      {{- else }}
+      {{- if .Values.nats.jetstream.store_dir }}
+      store_dir: {{ .Values.nats.jetstream.store_dir }}
+      {{- end }}
+      {{- if .Values.nats.jetstream.max_file }}
+      max_file: {{ .Values.nats.jetstream.max_file }}
+      {{- end }}
       {{- end }}
 
       {{- if .Values.nats.jetstream.uniqueTag }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -333,6 +333,9 @@ spec:
         - name: GOMEMLIMIT
           value: {{ .Values.nats.gomemlimit | quote }}
         {{- end }}
+        {{- if .Values.nats.extraEnv }}
+        {{- toYaml .Values.nats.extraEnv | nindent 8 }}
+        {{- end }}
 
         {{- if .Values.nats.jetstream.enabled }}
         {{- with .Values.nats.jetstream.encryption }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -158,6 +158,9 @@ nats:
     port: 4222
     portName: "client"
 
+  # extraEnv is the list of environment variables to add to the nats-server container
+  extraEnv: []
+
   # Server settings.
   limits:
     maxConnections:
@@ -291,6 +294,12 @@ nats:
         - ReadWriteOnce
       annotations:
       # key: "value"
+
+    # Use below if fileStorage is not enabled but you are persisting
+    # data using an alternative to PVC (e.g. hostPath)
+    # These set the corresponding jetstream configuration in nats.conf.
+    # store_dir: "/data"
+    # max_file: "10Gi"
 
   #######################
   #                     #


### PR DESCRIPTION
In the case where Jetstream is enabled but `fileStorage` is not enabled (e.g. when using `hostPath` storage), optionally allow specifying `store_dir` and `max_file` via `values.yaml`. These will be directly set in the `jetstream` section of `nats.conf` configuration file.

Also allow for specifying additional environment variables (`.Values.nats.extraEnv`) to the `nats-server` container for convenience.