### PR TITLE
Allow possibility to pass desired flags for prometheus exporter

### DIFF
--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -593,8 +593,8 @@ spec:
         {{- if .Values.gateway.enabled }}
         - -gatewayz
         {{- end }}
-        {{- end }}
         - http://localhost:8222/
+        {{- end }}
         ports:
         - containerPort: 7777
           name: {{ .Values.exporter.portName }}

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -575,10 +575,8 @@ spec:
         resources:
           {{- toYaml .Values.exporter.resources | nindent 10 }}
         args:
-        {{- if .Values.exporter.flags }}
-        {{- range .Values.exporter.flags }}
-        - {{ . }}
-        {{- end }}
+        {{- if .Values.exporter.args }}
+        {{- toYaml .Values.exporter.args | nindent 8 }}
         {{- else }}
         - -connz
         - -routez

--- a/helm/charts/nats/templates/statefulset.yaml
+++ b/helm/charts/nats/templates/statefulset.yaml
@@ -575,6 +575,11 @@ spec:
         resources:
           {{- toYaml .Values.exporter.resources | nindent 10 }}
         args:
+        {{- if .Values.exporter.flags }}
+        {{- range .Values.exporter.flags }}
+        - {{ . }}
+        {{- end }}
+        {{- else }}
         - -connz
         - -routez
         - -subz
@@ -589,6 +594,7 @@ spec:
         {{- end }}
         {{- if .Values.gateway.enabled }}
         - -gatewayz
+        {{- end }}
         {{- end }}
         - http://localhost:8222/
         ports:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -610,8 +610,9 @@ exporter:
   portName: metrics
   securityContext: {}
   resources: {}
-  # an array of flags to pass to exporter. See https://github.com/nats-io/prometheus-nats-exporter#usage
-  flags: ~
+  # override the default args passed to the exporter
+  # see https://github.com/nats-io/prometheus-nats-exporter#usage
+  args: []
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -610,6 +610,8 @@ exporter:
   portName: metrics
   securityContext: {}
   resources: {}
+  # an array of flags to pass to exporter. See https://github.com/nats-io/prometheus-nats-exporter#usage
+  flags: ~
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -612,6 +612,7 @@ exporter:
   resources: {}
   # override the default args passed to the exporter
   # see https://github.com/nats-io/prometheus-nats-exporter#usage
+  # make sure to pass HTTP monitoring port URL as last arg, e.g ["-connz", "http://localhost:8222/"]
   args: []
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -307,12 +307,18 @@ spec:
             {{- toYaml .Values.exporter.securityContext | nindent 12 }}
           {{- end }}
           args:
+          {{- if .Values.exporter.flags }}
+          {{- range .Values.exporter.flags }}
+          - {{ . }}
+          {{- end }}
+          {{- else }}
           - -connz
           - -routez
           - -subz
           - -varz
           - -channelz
           - -serverz
+          {{- end }}
           - http://localhost:8222/
           ports:
           - containerPort: 7777

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -307,10 +307,8 @@ spec:
             {{- toYaml .Values.exporter.securityContext | nindent 12 }}
           {{- end }}
           args:
-          {{- if .Values.exporter.flags }}
-          {{- range .Values.exporter.flags }}
-          - {{ . }}
-          {{- end }}
+          {{- if .Values.exporter.args }}
+          {{- toYaml .Values.exporter.args | nindent 10 }}
           {{- else }}
           - -connz
           - -routez

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -316,8 +316,8 @@ spec:
           - -varz
           - -channelz
           - -serverz
-          {{- end }}
           - http://localhost:8222/
+          {{- end }}
           ports:
           - containerPort: 7777
             name: metrics

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -273,8 +273,9 @@ exporter:
   pullPolicy: IfNotPresent
   securityContext: {}
   resources: {}
-  # an array of flags to pass to exporter. See https://github.com/nats-io/prometheus-nats-exporter#usage
-  flags: ~
+  # override the default args passed to the exporter
+  # see https://github.com/nats-io/prometheus-nats-exporter#usage
+  args: []
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -275,6 +275,7 @@ exporter:
   resources: {}
   # override the default args passed to the exporter
   # see https://github.com/nats-io/prometheus-nats-exporter#usage
+  # make sure to pass HTTP monitoring port URL as last arg, e.g ["-connz", "http://localhost:8222/"]
   args: []
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:

--- a/helm/charts/stan/values.yaml
+++ b/helm/charts/stan/values.yaml
@@ -273,6 +273,8 @@ exporter:
   pullPolicy: IfNotPresent
   securityContext: {}
   resources: {}
+  # an array of flags to pass to exporter. See https://github.com/nats-io/prometheus-nats-exporter#usage
+  flags: ~
   # Prometheus operator ServiceMonitor support. Exporter has to be enabled
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
It should be possible to select the metrics to fetch from the prometheus exporters. This PR allows for `flags` as describe [here](https://github.com/nats-io/prometheus-nats-exporter#usage) to be passed through `values` and not take the default.

Sample snippet for prometheus exporter configuration when requiring desired flags
```yaml
# Prometheus NATS Exporter configuration.
exporter:
  enabled: true
  image:
    repository: natsio/prometheus-nats-exporter
    tag: 0.10.1
    pullPolicy: IfNotPresent
    # registry: docker.io

  portName: metrics
  securityContext: {}
  resources: {}
  # an array of flags to pass to exporter. See https://github.com/nats-io/prometheus-nats-exporter#usage
  flags:
  - -connz
  - -routez
  # Prometheus operator ServiceMonitor support. Exporter has to be enabled
  serviceMonitor:
    enabled: false
    ## Specify the namespace where Prometheus Operator is running
    ##
    # namespace: monitoring
    labels: {}
    annotations: {}
    path: /metrics
    # interval:
    # scrapeTimeout:
```