### PR TITLE
Add configurable test image in chart

### DIFF
--- a/helm/charts/nats/templates/tests/test-request-reply.yaml
+++ b/helm/charts/nats/templates/tests/test-request-reply.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
   - name: nats-box
-    image: {{ .Values.natsbox.image }}
+    image: {{ include "nats.image" .Values.natsbox.image }}
     env:
     - name: NATS_HOST
       value: {{ template "nats.fullname" . }}


### PR DESCRIPTION
make the nats box image used in tests from static to configurable in the helm chart