### PR TITLE
Bump startup timeout to be longer by default

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -99,7 +99,7 @@ nats:
       timeoutSeconds: 5
       periodSeconds: 10
       successThreshold: 1
-      failureThreshold: 30
+      failureThreshold: 90
 
       # Override the health check path
       # httpGet:


### PR DESCRIPTION
When having a larger number of streams it was seen  this 5m timeout causing extra restarts which caused systems to take longer than needed to catchup.