### PR TITLE
Bump initial delay seconds to 90

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -95,7 +95,7 @@ nats:
     startup:
       enabled: true
 
-      initialDelaySeconds: 10
+      initialDelaySeconds: 90
       timeoutSeconds: 5
       periodSeconds: 10
       successThreshold: 1


### PR DESCRIPTION
Wait longer to ensure that the JetStream server has at least attempted to start and avoid getting an early ok healthz.