### PR TITLE
Fix nats cluster authorization when empty user/pass

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 0.19.12
+version: 0.19.13
 home: http://github.com/nats-io/k8s
 maintainers:
 - name: Waldemar Quevedo

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -73,9 +73,9 @@ Return the proper NATS image name
 Return the NATS cluster auth.
 */}}
 {{- define "nats.clusterAuth" -}}
-{{- if $.Values.cluster.authorization }}
-{{- printf "%s:%s@" (urlquery $.Values.cluster.authorization.user) (urlquery $.Values.cluster.authorization.password) -}}
-{{- else }}
+{{- with .Values.cluster.authorization }}
+{{- if (and .user .password) }}
+{{- printf "%s:%s@" (urlquery .user) (urlquery .password) -}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
# Problem

Stumbled upon an interesting, and very chaotic issue.

Installing the chart with a simple values file like this:

```yaml
cluster:
  enabled: true
authorization:
  timeout: 10
```

will be templates into a bad nats server config.
The config will parse, but the generated `routes` will contain bad values:

```
cluster {
  port: 6222
  name: nats
  authorization {
    timeout: 10
  }

  routes = [
    nats://%3Cno+value%3E:%3Cno+value%3E@nats-0.nats.nats.svc.cluster.local:6222,nats://%3Cno+value%3E:%3Cno+value%3E@nats-1.nats.nats.svc.cluster.local:6222,nats://%3Cno+value%3E:%3Cno+value%3E@nats-2.nats.nats.svc.cluster.local:6222,
    
  ]
  cluster_advertise: $CLUSTER_ADVERTISE
  no_advertise: true

  connect_retries: 120
}
```

Since the `cluster.authorization.timeout` is set, `username:password@` will be added to the cluster node URLs.
But, there are no default values for username or password, so when url-encoding the values they turn into `<no value>`.

The consequence of this seems to have been very chaotic coordination between cluster nodes.

# Fix

I've added an extra conditional around the authorization template.