### PR TITLE
Fix error: x509: certificate is not valid for any names

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -105,7 +105,7 @@ https://docs.nats.io/nats-server/configuration/securing_nats/tls
 nats:
   tls:
     secret:
-      name: nats-client-tls
+      name: nats-server-tls
     ca: "ca.crt"
     cert: "tls.crt"
     key: "tls.key"


### PR DESCRIPTION
Problem:

Following the TLS setup for client connections instructions in the helm chart README results in nsc and nats failing to connect to nats-server with the following error despite `nats` being listed in the server tls subject alt dns names.

```
nats: error: x509: certificate is not valid for any names, but wanted to match nats
```

Solution:
Use the nats-server-tls cert instead of the client cert.

Result:
nsc push through a port-forward works as expected, nats in the nats-box works as expected and `TLS required for client connections` is visible in the nats stateful set logs.
