### PR TITLE
fix(surveryor): make configmap fully agnostic

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -4,4 +4,4 @@ name: surveyor
 description: NATS Monitoring, Simplified.
 type: application
 version: 0.16.0
-appVersion: 0.5.0
+appVersion: 0.5.1

--- a/helm/charts/surveyor/templates/configmap.yaml
+++ b/helm/charts/surveyor/templates/configmap.yaml
@@ -2,21 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nats-surveyor-accounts
+  name: {{ include "surveyor.fullname" . }}-accounts
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
 data:
   {{- range .Values.config.jetstream.accounts }}
   {{ .name }}.json: |
-    {
-      "name": "{{ .name }}",
-      {{- if .tls }}
-      {{- if .tls.ca }}
-      "tls_ca": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.ca }}",
-      {{- end }}
-      "tls_cert": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.cert }}",
-      "tls_key": "/etc/nats-certs/accounts/{{ .name }}/{{ .tls.key }}"
-      {{- end }}
-    }
+    {{ . | toJson }}
   {{- end }}
 {{- end }}

--- a/helm/charts/surveyor/templates/configmap.yaml
+++ b/helm/charts/surveyor/templates/configmap.yaml
@@ -7,7 +7,19 @@ metadata:
     {{- include "surveyor.labels" . | nindent 4 }}
 data:
   {{- range .Values.config.jetstream.accounts }}
+  {{- $d := dict }}  
+  {{- if .tls }}
+  {{- if .tls.ca }}  
+  {{- $_ := set $d "tls_ca" (printf "/etc/nats-certs/accounts/%s/%s" .name .tls.ca)}}
+  {{- end }}
+  {{- if .tls.cert }}
+  {{- $_ := set $d "tls_cert" (printf "/etc/nats-certs/accounts/%s/%s" .name .tls.cert)}}
+  {{- end }}
+  {{- if .tls.key }}  
+  {{- $_ := set $d "tls_key" (printf "/etc/nats-certs/accounts/%s/%s" .name .tls.key)}}
+  {{- end }}
+  {{- end }}
   {{ .name }}.json: |
-    {{ . | toJson }}
+    {{ merge $d (omit . "tls") | toJson }}
   {{- end }}
 {{- end }}

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
         # Mount accounts configmap
         - name: accounts-config-map
           configMap:
-            name: {{ include "surveyor.fullname" . }}-accounts
+            name: {{- include "surveyor.fullname" $ }}-accounts
         {{- end }}
         {{- end }}
 

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
         # Mount accounts configmap
         - name: accounts-config-map
           configMap:
-            name: nats-surveyor-accounts
+            name: {{ include "surveyor.fullname" . }}-accounts
         {{- end }}
         {{- end }}
 

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -130,3 +130,6 @@ config:
     #     ca: "ca.crt" # optional
     #     cert: "tls.crt"
     #     key: "tls.key"
+    # - name: basic
+    #   username: username
+    #   password: password


### PR DESCRIPTION
This PR:
- makes the ConfigMap name prefixed by the release name. With the current implementation we cannot deploy 2 surveryor chart in the same namespace
- Able to pass any yaml to the configmap such that we can fit the json output depending of the user need.
```
{
  "name":       "my service",
  "topic":      "email.subscribe.>",
  "jwt":        "jwt portion of creds, must include seed also",
  "seed":       "seed portion of creds, must include jwt also",
  "credential": "/path/to/file.creds",
  "nkey":       "nkey seed",
  "token":      "token",
  "username":   "username, must include password also",
  "password":   "password, must include user also",
  "tls_ca":     "/path/to/ca.pem, defaults to surveyor's ca if one exists",
  "tls_cert":   "/path/to/cert.pem, defaults to surveyor's cert if one exists",
  "tls_key":    "/path/to/key.pem, defaults to surveyor's key if one exists"
}
```


With the values:
```
  jetstream:
    enabled: true
    accounts:
    - name: basic
      username: username
      password: password
```
This will output
```
# Source: surveyor/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: RELEASE-NAME-surveyor-accounts
  labels:
    helm.sh/chart: surveyor-0.16.0
    app.kubernetes.io/name: surveyor
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "0.5.0"
    app.kubernetes.io/managed-by: Helm
data:
  basic.json: |
    {"name":"basic","password":"password","username":"username"}
```

For context, I cannot use surveyor right now for the 2 fixes