### PR TITLE
Copy CRDs into the `crds` directory of the NACK chart

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,14 +6,14 @@ on:
     branches:
       - main
     paths:
-      - "helm/charts/**"
-      - "!helm/charts/index.yaml"
-      - ".github/workflows/test.yaml"
+      - 'helm/charts/**'
+      - '!helm/charts/index.yaml'
+      - '.github/workflows/test.yaml'
   pull_request:
     paths:
-      - "helm/charts/**"
-      - "!helm/charts/index.yaml"
-      - ".github/workflows/test.yaml"
+      - 'helm/charts/**'
+      - '!helm/charts/index.yaml'
+      - '.github/workflows/test.yaml'
 
 jobs:
   lint-test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,14 +6,14 @@ on:
     branches:
       - main
     paths:
-      - 'helm/charts/**'
-      - '!helm/charts/index.yaml'
-      - '.github/workflows/test.yaml'
+      - "helm/charts/**"
+      - "!helm/charts/index.yaml"
+      - ".github/workflows/test.yaml"
   pull_request:
     paths:
-      - 'helm/charts/**'
-      - '!helm/charts/index.yaml'
-      - '.github/workflows/test.yaml'
+      - "helm/charts/**"
+      - "!helm/charts/index.yaml"
+      - ".github/workflows/test.yaml"
 
 jobs:
   lint-test:
@@ -85,8 +85,11 @@ jobs:
 
       - name: Run chart-testing (install)
         run: |-
-          sudo microk8s.kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/crds.yml
           ct install \
             --all \
             --chart-dirs helm/charts \
             --excluded-charts nats-account-server,nats-kafka,nats-operator,surveyor
+
+      - name: Run chart-testing (CRD upgrade)
+        run: |-
+          sudo microk8s.kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/main/deploy/crds.yml

--- a/helm/charts/nack/README.md
+++ b/helm/charts/nack/README.md
@@ -3,9 +3,6 @@
 ## TL;DR;
 
 ```console
-# First, need to install the CRDs manually.
-kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/v0.6.0/deploy/crds.yml
-
 helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm install nats nats/nats
 helm install nack-jsc nats/nack --set jetstream.nats.url=nats://nats:4222
@@ -43,7 +40,7 @@ natsbox:
 helm install nats nats/nats -f deploy-nats.yaml
 ```
 
-Now install the JetStream CRDs and Controller.  In case of using credentials, you need to make them available as a secret:
+Now install the JetStream Controller. In case of using credentials, you need to make them available as a secret:
 
 ```sh
 kubectl create secret generic nats-user-creds --from-file ./nsc/nkeys/creds/KO/JS1/js.creds
@@ -158,6 +155,14 @@ order 1
 [#2] Received JetStream message: consumer: mystream > my-push-consumer / subject: orders.received /
 delivered: 1 / consumer seq: 2 / stream seq: 2 / ack: false
 order 2
+```
+
+### CRDs & upgrading the chart version
+
+As part of the Helm chart, CRDs are installed. Should you update the underlying NACK version through an Chart version update, you might want to reapply the CRDs as Helm is not updating CRDs during an upgrade:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/nats-io/nack/v0.6.0/deploy/crds.yml
 ```
 
 ### Local Development

--- a/helm/charts/nack/crds/crds.yml
+++ b/helm/charts/nack/crds/crds.yml
@@ -1,0 +1,944 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: streams.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Stream
+    singular: stream
+    plural: streams
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  description: A unique name for the Stream.
+                  type: string
+                  pattern: "^[^.*>]*$"
+                  minLength: 1
+                subjects:
+                  description: A list of subjects to consume, supports wildcards.
+                  type: array
+                  minLength: 1
+                  items:
+                    type: string
+                    minLength: 1
+                retention:
+                  description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                  type: string
+                  enum:
+                    - limits
+                    - interest
+                    - workqueue
+                  default: limits
+                maxConsumers:
+                  description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxMsgs:
+                  description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxBytes:
+                  description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxAge:
+                  description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                  type: string
+                  default: ""
+                maxMsgSize:
+                  description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                storage:
+                  description: The storage backend to use for the Stream.
+                  type: string
+                  enum:
+                    - file
+                    - memory
+                  default: memory
+                replicas:
+                  description: How many replicas to keep for each message.
+                  type: integer
+                  minimum: 1
+                  default: 1
+                noAck:
+                  description: Disables acknowledging messages that are received by the Stream.
+                  type: boolean
+                  default: false
+                discard:
+                  description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                  type: string
+                  enum:
+                    - old
+                    - new
+                  default: old
+                duplicateWindow:
+                  description: The duration window to track duplicate messages for.
+                  type: string
+                description:
+                  description: The description of the stream.
+                  type: string
+                maxMsgsPerSubject:
+                  description: The maximum of messages per subject.
+                  type: integer
+                  default: 0
+                mirror:
+                  description: A stream mirror.
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    optStartSeq:
+                      type: integer
+                    optStartTime:
+                      description: Time format must be RFC3339.
+                      type: string
+                    filterSubject:
+                      type: string
+                    externalApiPrefix:
+                      type: string
+                    externalDeliverPrefix:
+                      type: string
+                placement:
+                  description: A stream's placement.
+                  type: object
+                  properties:
+                    cluster:
+                      type: string
+                    tags:
+                      type: array
+                      items:
+                        type: string
+                sources:
+                  description: A stream's sources.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      optStartSeq:
+                        type: integer
+                      optStartTime:
+                        description: Time format must be RFC3339.
+                        type: string
+                      filterSubject:
+                        type: string
+                      externalApiPrefix:
+                        type: string
+                      externalDeliverPrefix:
+                        type: string
+                servers:
+                  description: A list of servers for creating stream
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                creds:
+                  description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                  type: string
+                  default: ""
+                nkey:
+                  description: NATS user NKey for connecting to servers.
+                  type: string
+                  default: ""
+                tls:
+                  description: A client's TLS certs and keys.
+                  type: object
+                  properties:
+                    clientCert:
+                      description: A client's cert filepath. Should be mounted.
+                      type: string
+                    clientKey:
+                      description: A client's key filepath. Should be mounted.
+                      type: string
+                    rootCas:
+                      description: A list of filepaths to CAs. Should be mounted.
+                      type: array
+                      items:
+                        type: string
+                account:
+                  description: Name of the account to which the Stream belongs.
+                  type: string
+                  pattern: "^[^.*>]*$"
+                republish:
+                  description: Republish configuration of the stream.
+                  type: object
+                  properties:
+                    destination:
+                      type: string
+                      description: Messages will be additionally published to that subject.
+                    source:
+                      type: string
+                      description: Messages will be published from that subject to the destination subject.
+                preventDelete:
+                  description: When true, the managed Stream will not be deleted when the resource is deleted
+                  type: boolean
+                  default: false
+                preventUpdate:
+                  description: When true, the managed Stream will not be updated when the resource is updated
+                  type: boolean
+                  default: false
+                allowDirect:
+                  description: When true, allow higher performance, direct access to get individual messages
+                  type: boolean
+                  default: false
+                allowRollup:
+                  description: When true, allows the use of the Nats-Rollup header to replace all contents of a stream, or subject in a stream, with a single new message.
+                  type: boolean
+                  default: false
+                denyDelete:
+                  description: When true, restricts the ability to delete messages from a stream via the API. Cannot be changed once set to true.
+                  type: boolean
+                  default: false
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          description: The current state of the stream.
+          jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+        - name: Stream Name
+          type: string
+          description: The name of the Jetstream Stream.
+          jsonPath: .spec.name
+        - name: Subjects
+          type: string
+          description: The subjects this Stream produces.
+          jsonPath: .spec.subjects
+    - name: v1beta1
+      served: false
+      storage: false
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  description: A unique name for the Stream.
+                  type: string
+                  pattern: "^[^.*>]*$"
+                  minLength: 1
+                subjects:
+                  description: A list of subjects to consume, supports wildcards.
+                  type: array
+                  minLength: 1
+                  items:
+                    type: string
+                    minLength: 1
+                retention:
+                  description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                  type: string
+                  enum:
+                    - limits
+                    - interest
+                    - workqueue
+                  default: limits
+                maxConsumers:
+                  description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxMsgs:
+                  description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxBytes:
+                  description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxAge:
+                  description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                  type: string
+                  default: ""
+                maxMsgSize:
+                  description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                storage:
+                  description: The storage backend to use for the Stream.
+                  type: string
+                  enum:
+                    - file
+                    - memory
+                  default: memory
+                replicas:
+                  description: How many replicas to keep for each message.
+                  type: integer
+                  minimum: 1
+                  default: 1
+                noAck:
+                  description: Disables acknowledging messages that are received by the Stream.
+                  type: boolean
+                  default: false
+                discard:
+                  description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                  type: string
+                  enum:
+                    - old
+                    - new
+                  default: old
+                duplicateWindow:
+                  description: The duration window to track duplicate messages for.
+                  type: string
+                description:
+                  description: The description of the stream.
+                  type: string
+                maxMsgsPerSubject:
+                  description: The maximum of messages per subject.
+                  type: integer
+                  default: 0
+                mirror:
+                  description: A stream mirror.
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    optStartSeq:
+                      type: integer
+                    optStartTime:
+                      description: Time format must be RFC3339.
+                      type: string
+                    filterSubject:
+                      type: string
+                    externalApiPrefix:
+                      type: string
+                    externalDeliverPrefix:
+                      type: string
+                placement:
+                  description: A stream's placement.
+                  type: object
+                  properties:
+                    cluster:
+                      type: string
+                    tags:
+                      type: array
+                      items:
+                        type: string
+                sources:
+                  description: A stream's sources.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      optStartSeq:
+                        type: integer
+                      optStartTime:
+                        description: Time format must be RFC3339.
+                        type: string
+                      filterSubject:
+                        type: string
+                      externalApiPrefix:
+                        type: string
+                      externalDeliverPrefix:
+                        type: string
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          description: The current state of the stream.
+          jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+        - name: Stream Name
+          type: string
+          description: The name of the Jetstream Stream.
+          jsonPath: .spec.name
+        - name: Subjects
+          type: string
+          description: The subjects this Stream produces.
+          jsonPath: .spec.subjects
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: consumers.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Consumer
+    singular: consumer
+    plural: consumers
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                streamName:
+                  description: The name of the Stream to create the Consumer in.
+                  type: string
+                deliverPolicy:
+                  type: string
+                  enum:
+                    - all
+                    - last
+                    - new
+                    # Requires optStartSeq
+                    - byStartSequence
+                    # Requires optStartTime
+                    - byStartTime
+                  default: all
+                optStartSeq:
+                  type: integer
+                  minimum: 0
+                optStartTime:
+                  description: Time format must be RFC3339.
+                  type: string
+                durableName:
+                  description: The name of the Consumer.
+                  type: string
+                  pattern: "^[^.*>]+$"
+                  minLength: 1
+                deliverSubject:
+                  description: The subject to deliver observed messages, when not set, a pull-based Consumer is created.
+                  type: string
+                ackPolicy:
+                  description: How messages should be acknowledged.
+                  type: string
+                  enum:
+                    - none
+                    - all
+                    - explicit
+                  default: none
+                ackWait:
+                  description: How long to allow messages to remain un-acknowledged before attempting redelivery.
+                  type: string
+                  default: 1ns
+                maxDeliver:
+                  type: integer
+                  minimum: -1
+                backoff:
+                  description: List of durations representing a retry time scale for NaK'd or retried messages
+                  type: array
+                  items:
+                    type: string
+                filterSubject:
+                  description: Select only a specific incoming subjects, supports wildcards.
+                  type: string
+                replayPolicy:
+                  description: How messages are sent.
+                  type: string
+                  enum:
+                    - instant
+                    - original
+                  default: instant
+                sampleFreq:
+                  description: What percentage of acknowledgements should be samples for observability.
+                  type: string
+                maxWaiting:
+                  description: The number of pulls that can be outstanding on a pull consumer, pulls received after this is reached are ignored.
+                  type: integer
+                rateLimitBps:
+                  description: rate at which messages will be delivered to clients, expressed in bit per second.
+                  type: integer
+                maxAckPending:
+                  description: Maximum pending Acks before consumers are paused.
+                  type: integer
+                deliverGroup:
+                  description: The name of a queue group.
+                  type: string
+                description:
+                  description: The description of the consumer.
+                  type: string
+                flowControl:
+                  description: Enables flow control.
+                  type: boolean
+                  default: false
+                headersOnly:
+                  description: When set, only the headers of messages in the stream are delivered, and not the bodies. Additionally, Nats-Msg-Size header is added to indicate the size of the removed payload
+                  type: boolean
+                  default: false
+                heartbeatInterval:
+                  description: The interval used to deliver idle heartbeats for push-based consumers, in Go's time.Duration format.
+                  type: string
+                maxRequestBatch:
+                  description: The largest batch property that may be specified when doing a pull on a Pull Consumer.
+                  type: integer
+                maxRequestExpires:
+                  description: The maximum expires duration that may be set when doing a pull on a Pull Consumer.
+                  type: string
+                maxRequestMaxBytes:
+                  description: The maximum max_bytes value that maybe set when dong a pull on a Pull Consumer.
+                  type: integer
+                replicas:
+                  description: When set do not inherit the replica count from the stream but specifically set it to this amount.
+                  type: integer
+                memStorage:
+                  description: Force the consumer state to be kept in memory rather than inherit the setting from the stream.
+                  type: boolean
+                  default: false
+                tls:
+                  description: A client's TLS certs and keys.
+                  type: object
+                  properties:
+                    clientCert:
+                      description: A client's cert filepath. Should be mounted.
+                      type: string
+                    clientKey:
+                      description: A client's key filepath. Should be mounted.
+                      type: string
+                    rootCas:
+                      description: A list of filepaths to CAs. Should be mounted.
+                      type: array
+                      items:
+                        type: string
+                servers:
+                  description: A list of servers for creating consumer
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                creds:
+                  description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                  type: string
+                  default: ""
+                nkey:
+                  description: NATS user NKey for connecting to servers.
+                  type: string
+                  default: ""
+                account:
+                  description: Name of the account to which the Consumer belongs.
+                  type: string
+                  pattern: "^[^.*>]*$"
+                preventDelete:
+                  description: When true, the managed Consumer will not be deleted when the resource is deleted
+                  type: boolean
+                  default: false
+                preventUpdate:
+                  description: When true, the managed Consumer will not be updated when the resource is updated
+                  type: boolean
+                  default: false
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          description: The current state of the consumer.
+          jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+        - name: Stream
+          type: string
+          description: The name of the Jetstream Stream.
+          jsonPath: .spec.streamName
+        - name: Consumer
+          type: string
+          description: The name of the Jetstream Consumer.
+          jsonPath: .spec.durableName
+        - name: Ack Policy
+          type: string
+          description: The ack policy.
+          jsonPath: .spec.ackPolicy
+    - name: v1beta1
+      served: false
+      storage: false
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                streamName:
+                  description: The name of the Stream to create the Consumer in.
+                  type: string
+                deliverPolicy:
+                  type: string
+                  enum:
+                    - all
+                    - last
+                    - new
+                    # Requires optStartSeq
+                    - byStartSequence
+                    # Requires optStartTime
+                    - byStartTime
+                  default: all
+                optStartSeq:
+                  type: integer
+                  minimum: 0
+                optStartTime:
+                  description: Time format must be RFC3339.
+                  type: string
+                durableName:
+                  description: The name of the Consumer.
+                  type: string
+                  pattern: "^[^.*>]+$"
+                  minLength: 1
+                deliverSubject:
+                  description: The subject to deliver observed messages, when not set, a pull-based Consumer is created.
+                  type: string
+                ackPolicy:
+                  description: How messages should be acknowledged.
+                  type: string
+                  enum:
+                    - none
+                    - all
+                    - explicit
+                  default: none
+                ackWait:
+                  description: How long to allow messages to remain un-acknowledged before attempting redelivery.
+                  type: string
+                  default: 1ns
+                maxDeliver:
+                  type: integer
+                  minimum: -1
+                filterSubject:
+                  description: Select only a specific incoming subjects, supports wildcards.
+                  type: string
+                replayPolicy:
+                  description: How messages are sent.
+                  type: string
+                  enum:
+                    - instant
+                    - original
+                  default: instant
+                sampleFreq:
+                  description: What percentage of acknowledgements should be samples for observability.
+                  type: string
+                rateLimitBps:
+                  description: rate at which messages will be delivered to clients, expressed in bit per second.
+                  type: integer
+                maxAckPending:
+                  description: Maximum pending Acks before consumers are paused.
+                  type: integer
+                deliverGroup:
+                  description: The name of a queue group.
+                  type: string
+                description:
+                  description: The description of the consumer.
+                  type: string
+                flowControl:
+                  description: Enables flow control.
+                  type: boolean
+                  default: false
+                heartbeatInterval:
+                  description: The interval used to deliver idle heartbeats for push-based consumers, in Go's time.Duration format.
+                  type: string
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          description: The current state of the consumer.
+          jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+        - name: Stream
+          type: string
+          description: The name of the Jetstream Stream.
+          jsonPath: .spec.streamName
+        - name: Consumer
+          type: string
+          description: The name of the Jetstream Consumer.
+          jsonPath: .spec.durableName
+        - name: Ack Policy
+          type: string
+          description: The ack policy.
+          jsonPath: .spec.ackPolicy
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: streamtemplates.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: StreamTemplate
+    singular: streamtemplate
+    plural: streamtemplates
+  versions:
+    - name: v1beta1
+      served: false
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  description: A unique name for the Stream Template.
+                  type: string
+                  pattern: "^[^.*>]*$"
+                  minLength: 1
+                maxStreams:
+                  description: The maximum number of Streams this Template can create, -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                subjects:
+                  description: A list of subjects to consume, supports wildcards.
+                  type: array
+                  minLength: 1
+                  items:
+                    type: string
+                    minLength: 1
+                retention:
+                  description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                  type: string
+                  enum:
+                    - limits
+                    - interest
+                    - workqueue
+                  default: limits
+                maxConsumers:
+                  description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxMsgs:
+                  description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxBytes:
+                  description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                maxAge:
+                  description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                  type: string
+                  default: ""
+                maxMsgSize:
+                  description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                  type: integer
+                  minimum: -1
+                  default: -1
+                storage:
+                  description: The storage backend to use for the Stream.
+                  type: string
+                  enum:
+                    - file
+                    - memory
+                  default: memory
+                replicas:
+                  description: How many replicas to keep for each message.
+                  type: integer
+                  minimum: 1
+                  default: 1
+                noAck:
+                  description: Disables acknowledging messages that are received by the Stream.
+                  type: boolean
+                  default: false
+                discard:
+                  description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                  type: string
+                  enum:
+                    - old
+                    - new
+                  default: old
+                duplicateWindow:
+                  description: The duration window to track duplicate messages for.
+                  type: string
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          description: The current state of the stream.
+          jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+        - name: Stream Template Name
+          type: string
+          description: The name of the Jetstream Stream Template.
+          jsonPath: .spec.name
+        - name: Subjects
+          type: string
+          description: The subjects this Stream produces.
+          jsonPath: .spec.subjects
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: accounts.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Account
+    singular: account
+    plural: accounts
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  description: A unique name for the Account.
+                  type: string
+                  pattern: "^[^.*>]*$"
+                  minLength: 1
+                servers:
+                  description: A list of servers to connect.
+                  type: array
+                  minLength: 1
+                  items:
+                    type: string
+                    minLength: 1
+                tls:
+                  description: The TLS certs to be used to connect to the NATS Service.
+                  type: object
+                  properties:
+                    secret:
+                      type: object
+                      properties:
+                        name:
+                          description: Name of the TLS secret with the certs.
+                          type: string
+                    ca:
+                      description: Filename of the Root CA of the TLS cert.
+                      type: string
+                    cert:
+                      description: Filename of the TLS cert.
+                      type: string
+                    key:
+                      description: Filename of the TLS cert key.
+                      type: string
+                creds:
+                  description: The creds to be used to connect to the NATS Service.
+                  type: object
+                  properties:
+                    secret:
+                      type: object
+                      properties:
+                        name:
+                          description: Name of the secret with the creds.
+                          type: string
+                    file:
+                      description: Credentials file, generated with github.com/nats-io/nsc tool.
+                      type: string


### PR DESCRIPTION
## Summary

Based on the discussions in https://github.com/nats-io/k8s/issues/398, this PR copies the [required CRDs](https://github.com/nats-io/nack/blob/main/deploy/crds.yml) for NACK into the special `crds` directory of NACK helm chart and updates the README as well as the tests. Drawback is the increased maintenance in keeping the CRDs in sync with the `nack` repo. 

## Motivation

In my opinion, providing a caveat that CRDs have to be manually upgraded as part of a chart upgrade is necessary also when no `crds` directory is used. Thus its more user friendly if CRDs are provided as part of the chart. Not having an extra step to manually install & maintain CRDs when using this chart is also super helpful for GitOps users. Flux for example specifically has [a special configuration object](https://github.com/fluxcd/helm-controller/blob/main/docs/api/helmrelease.md#helm.toolkit.fluxcd.io/v2beta1.CRDsPolicy) that allows to reinstall CRDs as part of an chart upgrade. 
