### PR TITLE
fix(surveyor): configmap name as string

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: surveyor
 description: NATS Monitoring, Simplified.
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: 0.5.0

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
         # Mount accounts configmap
         - name: accounts-config-map
           configMap:
-            name: "{{- include "surveyor.fullname" $ }}-accounts"
+            name: {{ include "surveyor.fullname" $ }}-accounts
         {{- end }}
         {{- end }}
 

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
         # Mount accounts configmap
         - name: accounts-config-map
           configMap:
-            name: {{- include "surveyor.fullname" $ }}-accounts
+            name: "{{- include "surveyor.fullname" $ }}-accounts"
         {{- end }}
         {{- end }}
 


### PR DESCRIPTION
For some reason I got the following error:

```
error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.volumes[0].configMap): invalid type for io.k8s.api.core.v1.ConfigMapVolumeSource: got "string", expected "map"
```

Putting the ConfigMap name under quote solves the issue