### PR TITLE
helm: remove deprecated charts_repo_url option

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: helm/charts
-          charts_repo_url: https://nats-io.github.io/k8s/helm/charts
           config: helm/cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
`helm/chart-releaser-action@v1.5.0` removes the `charts_repo_url` option

```
Warning: Unexpected input(s) 'charts_repo_url', valid inputs are ['version', 'config', 'charts_dir', 'install_dir', 'install_only', 'skip_packaging']
```