### PR TITLE
[nats helm 1.x] remove break statement

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/files/stateful-set/reloader-container.yaml
+++ b/helm/charts/nats/files/stateful-set/reloader-container.yaml
@@ -17,10 +17,11 @@ volumeMounts:
 - name: pid
   mountPath: /var/run/nats
 {{- range $mnt := .natsVolumeMounts }}
+{{- $found := false }}
 {{- range $.Values.reloader.natsVolumeMountPrefixes }}
-{{- if (hasPrefix . $mnt.mountPath) }}
+{{- if and (not $found) (hasPrefix . $mnt.mountPath) }}
+{{- $found = true }}
 - {{ toYaml $mnt | nindent 2}}
-{{- break }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/charts/nats/templates/_jsonpatch.tpl
+++ b/helm/charts/nats/templates/_jsonpatch.tpl
@@ -8,8 +8,10 @@ output: JSON encoded map with 1 key:
 */}}
 {{- define "jsonpatch" -}}
   {{- $params := fromJson (toJson .) -}}
+  {{- $patches := $params.patch -}}
+  {{- $docContainer := pick $params "doc" -}}
 
-  {{- range $patch := $params.patch -}}
+  {{- range $patch := $patches -}}
     {{- if not (hasKey $patch "op") -}}
       {{- fail "patch is missing op key" -}}
     {{- end -}}
@@ -33,9 +35,9 @@ output: JSON encoded map with 1 key:
     {{- $reSlice := list -}}
 
     {{- range $opPathKey := $opPathKeys -}}
-      {{- $obj := $params -}}
+      {{- $obj := $docContainer -}}
       {{- if and (eq $patch.op "copy") (eq $opPathKey "from") -}}
-        {{- $obj := fromJson (toJson $params) -}}
+        {{- $obj = (fromJson (toJson $docContainer)) -}}
       {{- end -}}
       {{- $key := "doc" -}}
       {{- $lastMap := dict "root" $obj -}}
@@ -213,5 +215,5 @@ output: JSON encoded map with 1 key:
     {{- end -}}
 
   {{- end -}}
-  {{- toJson (dict "doc" $params.doc) -}}
+  {{- toJson $docContainer -}}
 {{- end -}}


### PR DESCRIPTION
The `break` statement was not available until Helm `3.10.0`

Removing it will give us better compatibility with versions of Helm prior to that