### PR TITLE
[nats helm 1.x] fix JS mount

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -15,6 +15,9 @@ helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm upgrade --install nats nats/nats --devel
 ```
 
+## 1.x Beta Upgrade Notes
+- If using `1.0.0-beta.2` or lower with JetStream enabled, upgrade to `1.0.0-beta.3` first
+
 ## Values
 
 There are a handful of explicitly defined options which are documented with comments in the [values.yaml](values.yaml) file.
@@ -113,6 +116,7 @@ podTemplate:
   topologySpreadConstraints:
     kubernetes.io/hostname:
       maxSkew: 1
+      whenUnsatisfiable: DoNotSchedule
 ```
 
 ### NATS Container Resources

--- a/helm/charts/nats/files/config/jetstream.yaml
+++ b/helm/charts/nats/files/config/jetstream.yaml
@@ -11,8 +11,10 @@ max_memory_store: 0
 {{- with .fileStore }}
 {{- if .enabled }}
 store_dir: {{ .dir }}
-{{- with .maxSize }}
-max_file_store: << {{ . }} >>
+{{- if .maxSize }}
+max_file_store: << {{ .maxSize }} >>
+{{- else if .pvc.enabled }}
+max_file_store: << {{ .pvc.size }} >>
 {{- end }}
 {{- else }}
 max_file_store: 0

--- a/helm/charts/nats/files/stateful-set/beta2-mount-fix-container.yaml
+++ b/helm/charts/nats/files/stateful-set/beta2-mount-fix-container.yaml
@@ -1,0 +1,16 @@
+name: beta2-mount-fix
+{{ include "nats.image" (merge (pick $.Values "global") .Values.natsBox.container.image) }}
+
+command:
+- sh
+- -ec
+- |
+  cd {{ .Values.config.jetstream.fileStore.dir | quote }}
+  mkdir -p jetstream
+  find . -maxdepth 1 -mindepth 1 -not -name 'lost+found' -not -name 'jetstream' -exec mv {} jetstream \;
+
+volumeMounts:
+{{- with .Values.config.jetstream.fileStore }}
+- name: {{ .pvc.name }}
+  mountPath: {{ .dir | quote }}
+{{- end }}

--- a/helm/charts/nats/files/stateful-set/nats-container.yaml
+++ b/helm/charts/nats/files/stateful-set/nats-container.yaml
@@ -73,7 +73,7 @@ volumeMounts:
 {{- if and .enabled .fileStore.enabled .fileStore.pvc.enabled }}
 {{- with .fileStore }}
 - name: {{ .pvc.name }}
-  mountPath: {{ printf "%s/jetstream" .dir | quote }}
+  mountPath: {{ .dir | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -7,6 +7,15 @@ metadata:
     checksum/config: {{ sha256sum $configMap }}
     {{- end }}
 spec:
+  {{- with .Values.config.jetstream }}
+  {{- if and .enabled .fileStore.enabled .fileStore.pvc.enabled }}
+  # just for 1.0.0-beta.3
+  # add an init container in order to fix mount from <= 1.0.0-beta.2
+  initContainers:
+  - {{ include "nats.loadMergePatch" (merge (dict "file" "stateful-set/beta2-mount-fix-container.yaml" "ctx" $) dict) | nindent 4 }}
+  {{- end }}
+  {{- end }}
+
   containers:
   # nats
   {{- $nats := dict }}

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -192,8 +192,8 @@ output: JSON encoded map with 1 key:
 */}}
 {{- define "nats.loadMergePatch" -}}
 {{- $doc := tpl (.ctx.Files.Get (printf "files/%s" .file)) .ctx | fromYaml | default dict -}}
-{{- $doc = mergeOverwrite $doc (deepCopy .merge) -}}
-{{- get (include "jsonpatch" (dict "doc" $doc "patch" .patch) | fromJson ) "doc" | toYaml -}}
+{{- $doc = mergeOverwrite $doc (deepCopy (.merge | default dict)) -}}
+{{- get (include "jsonpatch" (dict "doc" $doc "patch" (.patch | default list)) | fromJson ) "doc" | toYaml -}}
 {{- end }}
 
 

--- a/helm/charts/nats/test/config_test.go
+++ b/helm/charts/nats/test/config_test.go
@@ -65,7 +65,7 @@ config:
 
 	vm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts
 	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts = append(vm, corev1.VolumeMount{
-		MountPath: "/data/jetstream",
+		MountPath: "/data",
 		Name:      test.FullName + "-js",
 	})
 
@@ -83,6 +83,29 @@ config:
 					Requests: corev1.ResourceList{
 						"storage": resource10Gi,
 					},
+				},
+			},
+		},
+	}
+
+	nbc := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0]
+	expected.StatefulSet.Value.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Command: []string{
+				"sh",
+				"-ec",
+				`cd "/data"
+mkdir -p jetstream
+find . -maxdepth 1 -mindepth 1 -not -name 'lost+found' -not -name 'jetstream' -exec mv {} jetstream \;
+`,
+			},
+			Image:           nbc.Image,
+			ImagePullPolicy: nbc.ImagePullPolicy,
+			Name:            "beta2-mount-fix",
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/data",
+					Name:      test.FullName + "-js",
 				},
 			},
 		},
@@ -210,9 +233,32 @@ config:
 		},
 	}
 
+	nbc := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0]
+	expected.StatefulSet.Value.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Command: []string{
+				"sh",
+				"-ec",
+				`cd "/mnt"
+mkdir -p jetstream
+find . -maxdepth 1 -mindepth 1 -not -name 'lost+found' -not -name 'jetstream' -exec mv {} jetstream \;
+`,
+			},
+			Image:           nbc.Image,
+			ImagePullPolicy: nbc.ImagePullPolicy,
+			Name:            "beta2-mount-fix",
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/mnt",
+					Name:      test.FullName + "-js",
+				},
+			},
+		},
+	}
+
 	vm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts
 	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts = append(vm, corev1.VolumeMount{
-		MountPath: "/mnt/jetstream",
+		MountPath: "/mnt",
 		Name:      test.FullName + "-js",
 	}, corev1.VolumeMount{
 		MountPath: "/mnt/resolver",
@@ -370,7 +416,7 @@ config:
 
 	vm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts
 	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts = append(vm, corev1.VolumeMount{
-		MountPath: "/data/jetstream",
+		MountPath: "/data",
 		Name:      test.FullName + "-js",
 	}, corev1.VolumeMount{
 		MountPath: "/data/resolver",
@@ -413,6 +459,29 @@ config:
 					},
 				},
 				StorageClassName: &storageClassGp3,
+			},
+		},
+	}
+
+	nbc := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0]
+	expected.StatefulSet.Value.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Command: []string{
+				"sh",
+				"-ec",
+				`cd "/data"
+mkdir -p jetstream
+find . -maxdepth 1 -mindepth 1 -not -name 'lost+found' -not -name 'jetstream' -exec mv {} jetstream \;
+`,
+			},
+			Image:           nbc.Image,
+			ImagePullPolicy: nbc.ImagePullPolicy,
+			Name:            "beta2-mount-fix",
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/data",
+					Name:      test.FullName + "-js",
+				},
 			},
 		},
 	}
@@ -780,7 +849,7 @@ max_outstanding_catchup: 64MB
 
 	vm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts
 	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts = append(vm, corev1.VolumeMount{
-		MountPath: "/data/jetstream",
+		MountPath: "/data",
 		Name:      test.FullName + "-js",
 	})
 
@@ -798,6 +867,29 @@ max_outstanding_catchup: 64MB
 					Requests: corev1.ResourceList{
 						"storage": resource10Gi,
 					},
+				},
+			},
+		},
+	}
+
+	nbc := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0]
+	expected.StatefulSet.Value.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Command: []string{
+				"sh",
+				"-ec",
+				`cd "/data"
+mkdir -p jetstream
+find . -maxdepth 1 -mindepth 1 -not -name 'lost+found' -not -name 'jetstream' -exec mv {} jetstream \;
+`,
+			},
+			Image:           nbc.Image,
+			ImagePullPolicy: nbc.ImagePullPolicy,
+			Name:            "beta2-mount-fix",
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/data",
+					Name:      test.FullName + "-js",
 				},
 			},
 		},

--- a/helm/charts/nats/test/config_test.go
+++ b/helm/charts/nats/test/config_test.go
@@ -56,6 +56,7 @@ config:
 		},
 	}
 	expected.Conf.Value["jetstream"] = map[string]any{
+		"max_file_store":   int64(10737418240),
 		"max_memory_store": int64(0),
 		"store_dir":        "/data",
 	}
@@ -806,7 +807,7 @@ config:
   jetstream:
     enabled: true
     merge:
-      000$include: "js.conf"
+      zzz$include: "js.conf"
   merge:
     $include: "my-config.conf"
     zzz$include: "my-config-last.conf"

--- a/helm/charts/nats/test/resources_test.go
+++ b/helm/charts/nats/test/resources_test.go
@@ -51,7 +51,7 @@ reloader:
           key: token
   natsVolumeMountPrefixes:
   - /etc/
-  - /data/
+  - /data
 promExporter:
   enabled: true
   port: 7778
@@ -141,7 +141,7 @@ natsBox:
 	ctr[0].ImagePullPolicy = "IfNotPresent"
 	ctr[0].VolumeMounts = append(ctr[0].VolumeMounts, corev1.VolumeMount{
 		Name:      test.FullName + "-js",
-		MountPath: "/data/jetstream",
+		MountPath: "/data",
 	})
 
 	// reloader
@@ -150,7 +150,7 @@ natsBox:
 	ctr[1].ImagePullPolicy = "Always"
 	ctr[1].VolumeMounts = append(ctr[1].VolumeMounts, corev1.VolumeMount{
 		Name:      test.FullName + "-js",
-		MountPath: "/data/jetstream",
+		MountPath: "/data",
 	})
 
 	// promExporter
@@ -303,6 +303,29 @@ natsBox:
 					Requests: corev1.ResourceList{
 						"storage": resource10Gi,
 					},
+				},
+			},
+		},
+	}
+
+	nbc := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0]
+	expected.StatefulSet.Value.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Command: []string{
+				"sh",
+				"-ec",
+				`cd "/data"
+mkdir -p jetstream
+find . -maxdepth 1 -mindepth 1 -not -name 'lost+found' -not -name 'jetstream' -exec mv {} jetstream \;
+`,
+			},
+			Image:           nbc.Image,
+			ImagePullPolicy: nbc.ImagePullPolicy,
+			Name:            "beta2-mount-fix",
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/data",
+					Name:      test.FullName + "-js",
 				},
 			},
 		},

--- a/helm/charts/nats/test/resources_test.go
+++ b/helm/charts/nats/test/resources_test.go
@@ -101,6 +101,7 @@ natsBox:
 	expected := DefaultResources(t, test)
 
 	expected.Conf.Value["jetstream"] = map[string]any{
+		"max_file_store":   int64(10737418240),
 		"max_memory_store": int64(0),
 		"store_dir":        "/data",
 	}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -50,7 +50,6 @@ config:
 
     fileStore:
       enabled: true
-      # disk will be mounted to <dir>/jetstream
       dir: /data
 
       ############################################################

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -67,7 +67,7 @@ config:
         # defaults to "{{ include "nats.fullname" $ }}-js"
         name:
 
-      # defaults to use all of the available pvc size
+      # defaults to the PVC size
       maxSize:
 
     memoryStore:


### PR DESCRIPTION
Fixes #716 

In `1.0.0-beta.2` and below  we are mounting to `/data/jetstream` and the store dir is `/data`

So it looks like NATS Server is detecting the size of `/data` which is outside of the PVC mount

This is going to be a problem when upgrading from 0.x anyways, because in 0.x we are mounting to `/data` and the store dir is `/data`

This updates the mount dir and store dir to match and default to `/data`

There is a one-time-fix initContainer that will be released as part of `1.0.0-beta.3` and removed after that