### PR TITLE
ConfigMap annotations

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ include "nats.namespace" . }}
   labels:
     {{- include "nats.labels" . | nindent 4 }}
+  {{- if .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml .Values.configMap.annotations | nindent 4 }}
+  {{- end }}
 data:
   nats.conf: |
     # NATS Clients Port

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -140,6 +140,11 @@ nats:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
 
+      # Default ConfigMap settings:
+  configMap:
+    # Annotations to add to the config
+    annotations: {}
+
   # Toggle whether to automatically mount Service Account token in the pod
   # not set means default value, boolean true/false overrides default value
   # automountServiceAccountToken: true


### PR DESCRIPTION
I'm using helm-hook annotations to install `nats` as a Sub-Chart of another application Chart:
```
helm.sh/hook: pre-install
```

The issue with this approach is that the statefulset manifest requires the `nats-config` ConfigMap to mount; but this is not available at the `pre-install` stage. 

With this PR I would like to add annotations to the `ConfigMap` as well as the other resources.

Thanks!