### PR TITLE
[helm nats 1.x] config.cluster.routeURLs options

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -183,43 +183,13 @@ Anything in `values.yaml` can be templated:
     yaml template
   ```
 
-Example - add cluster authorization:
+Example - change service name:
 
 ```yaml
-config:
-  cluster:
-    enabled: true
-    merge:
-      authorization:
-        user: foo
-        password:
-          $tplYaml: >
-            {{ bcrypt "bar" }}
-      routes:
-      - $tplYamlSpread: |
-          {{- range $i, $_ := until (int $.Values.config.cluster.replicas) }}
-          - {{ printf "nats://foo:bar@%s-%d.%s:6222" $.Values.statefulSet.name $i $.Values.headlessService.name }}
-          {{- end }}
-```
-
-templates to the `nats.conf`:
-
-```
-{
-  "cluster": {
-    "authorization": {
-      "password": "$2a$10$iPs.JbHVKFlFnE.NAN.jF.I1PNi72UycEE83TzyUd1rZsXfFQteQ6",
-      "user": "foo"
-    },
-    "routes": [
-      "nats://foo:bar@nats-0.nats-headless:6222",
-      "nats://foo:bar@nats-1.nats-headless:6222",
-      "nats://foo:bar@nats-2.nats-headless:6222"
-    ]
-  },
-  "port": 4222,
-  ...
-}
+service:
+  name:
+    $tplYaml: >-
+      {{ include "nats.fullname" . }}-svc
 ```
 
 ### NATS Config Units and Variables

--- a/helm/charts/nats/files/config/cluster.yaml
+++ b/helm/charts/nats/files/config/cluster.yaml
@@ -4,8 +4,23 @@ port: {{ .port }}
 no_advertise: true
 routes:
 {{- $proto := ternary "tls" "nats" .tls.enabled }}
+{{- $auth := "" }}
+{{- if and .routeURLs.user .routeURLs.password }}
+  {{- $auth = printf "%s:%s@" (urlquery .routeURLs.user) (urlquery .routeURLs.password) -}}
+{{- end }}
+{{- $domain := $.Values.headlessService.name  }}
+{{- if .routeURLs.useFQDN }}
+  {{- $domain = printf "%s.%s.svc.%s" $domain $.Release.Namespace .routeURLs.k8sClusterDomain }}
+{{- end }}
+{{- $port := (int .port) }}
 {{- range $i, $_ := until (int .replicas) }}
-- {{ printf "%s://%s-%d.%s:6222" $proto $.Values.statefulSet.name $i $.Values.headlessService.name }}
+- {{ printf "%s://%s%s-%d.%s:%d" $proto $auth $.Values.statefulSet.name $i $domain $port }}
+{{- end }}
+
+{{- if and .routeURLs.user .routeURLs.password }}
+authorization:
+  user: {{ .routeURLs.user | quote }}
+  password: {{ .routeURLs.password | quote }}
 {{- end }}
 
 {{- with .tls }}

--- a/helm/charts/nats/test/ports_test.go
+++ b/helm/charts/nats/test/ports_test.go
@@ -111,9 +111,9 @@ service:
 		"no_advertise": true,
 		"port":         int64(1005),
 		"routes": []any{
-			"nats://nats-0.nats-headless:6222",
-			"nats://nats-1.nats-headless:6222",
-			"nats://nats-2.nats-headless:6222",
+			"nats://nats-0.nats-headless:1005",
+			"nats://nats-1.nats-headless:1005",
+			"nats://nats-2.nats-headless:1005",
 		},
 	}
 	expected.Conf.Value["gateway"] = map[string]any{

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -27,9 +27,10 @@ config:
     # must be 2 or higher when jetstream is enabled
     replicas: 3
 
-    # settings for routeURLs generated to discover other pods in the Stateful Set
+    # apply to generated route URLs that connect to other pods in the StatefulSet
     routeURLs:
-      # if both user and password are set, they will be added to route URLs and the cluster authorization block
+      # if both user and password are set, they will be added to route URLs
+      # and the cluster authorization block
       user:
       password:
       # set to true to use FQDN in route URLs

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -27,6 +27,15 @@ config:
     # must be 2 or higher when jetstream is enabled
     replicas: 3
 
+    # settings for routeURLs generated to discover other pods in the Stateful Set
+    routeURLs:
+      # if both user and password are set, they will be added to route URLs and the cluster authorization block
+      user:
+      password:
+      # set to true to use FQDN in route URLs
+      useFQDN: false
+      k8sClusterDomain: cluster.local
+
     tls:
       enabled: false
       # set secretName in order to mount an existing secret to dir


### PR DESCRIPTION
Resolves #744 

Adds `config.cluster.routeURLs` section to more easily customize route URLs

The `user` and `password` settings go multiple places - both in the route URLs and the `authorization` block - so it makes sense to add a defined setting for those

The `useFQDN` setting is present in 0.x and may be a part of SANs for Route TLS certificates already