### PR TITLE
modify template syntax to generate correct yaml content

### DIFF
--- a/helm/charts/nats/templates/configmap.yaml
+++ b/helm/charts/nats/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
     #             #
     ###############
     http: 8222
-    server_name: {{- if .Values.nats.serverNamePrefix  }}$SERVER_NAME{{- else }}$POD_NAME{{- end }}
+    server_name: {{ if .Values.nats.serverNamePrefix  }}$SERVER_NAME{{ else }}$POD_NAME{{ end }}
 
     {{- if .Values.nats.serverTags }}
     server_tags: [


### PR DESCRIPTION
Originally would generate: `server:$POD_NAME`
Will now generate: `server: $POD_NAME`