### PR TITLE
Fix `maxOutstandingCatchup` in nats helm values.yaml

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -247,7 +247,7 @@ nats:
     # Jetstream Unique Tag prevent placing a stream in the same availability zone twice.
     uniqueTag:
 
-    max_outstanding_catchup:
+    maxOutstandingCatchup:
 
     ##########################
     #                        #


### PR DESCRIPTION
Used in config map: https://github.com/nats-io/k8s/blob/main/helm/charts/nats/templates/configmap.yaml#L110-L112
