### PR TITLE
[nats helm] always use emptyDir for pidfile volume

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.0.1
+version: 1.0.2
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/files/config/config.yaml
+++ b/helm/charts/nats/files/config/config.yaml
@@ -1,10 +1,9 @@
-{{- $pidFile := ternary "/var/run/nats/nats.pid" "/var/run/nats.pid" .Values.reloader.enabled }}
 {{- with .Values.config }}
 
 server_name: << $SERVER_NAME >>
 lame_duck_grace_period: 10s
 lame_duck_duration: 30s
-pid_file: {{ $pidFile }}
+pid_file: /var/run/nats/nats.pid
 
 ########################################
 # NATS

--- a/helm/charts/nats/files/stateful-set/nats-container.yaml
+++ b/helm/charts/nats/files/stateful-set/nats-container.yaml
@@ -1,4 +1,3 @@
-{{- $pidFile := ternary "/var/run/nats/nats.pid" "/var/run/nats.pid" .Values.reloader.enabled }}
 name: nats
 {{ include "nats.image" (merge (pick $.Values "global") .Values.container.image) }}
 
@@ -32,7 +31,7 @@ lifecycle:
       # send the lame duck shutdown signal to trigger a graceful shutdown
       command:
       - nats-server
-      - -sl=ldm={{ $pidFile }}
+      - -sl=ldm=/var/run/nats/nats.pid
 
 {{- if .Values.config.monitor.enabled }}
 startupProbe:
@@ -69,10 +68,8 @@ volumeMounts:
 - name: config
   mountPath: /etc/nats-config
 # PID volume
-{{- if .Values.reloader.enabled }}
 - name: pid
   mountPath: /var/run/nats
-{{- end}}
 # JetStream PVC
 {{- with .Values.config.jetstream }}
 {{- if and .enabled .fileStore.enabled .fileStore.pvc.enabled }}

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -45,10 +45,8 @@ spec:
     configMap:
       name: {{ .Values.configMap.name }}
   # PID volume
-  {{- if .Values.reloader.enabled }}
   - name: pid
     emptyDir: {}
-  {{- end }}
   # tlsCA
   {{- include "nats.tlsCAVolume" $ | nindent 2 }}
   # secrets


### PR DESCRIPTION
Fixes #759 

Always use an `emptyDir` for the pidfile volume.  Many users run NATS as unprivileged.  Unprivileged users can't write to `/var/run`.  Making an emptyDir volume will use `fsGroup` from the security context and let the unprivileged user write the pidfile