### PR TITLE
[nats helm] Allow specifying pullSecrets

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.1.3
+version: 1.2.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.2.0
+version: 1.1.3
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
+++ b/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
@@ -2,6 +2,10 @@ metadata:
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
 spec:
+  {{- with .Values.global.image.pullSecrets }}
+  imagePullSecrets:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
   {{- with .Values.natsBox.container }}
   - {{ include "nats.loadMergePatch" (merge (dict "file" "nats-box/deployment/container.yaml" "ctx" $) .) | nindent 4 }}

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -7,6 +7,10 @@ metadata:
     checksum/config: {{ sha256sum $configMap }}
     {{- end }}
 spec:
+  {{- with .Values.global.image.pullSecrets }}
+  imagePullSecrets:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
   # nats
   {{- $nats := dict }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -6,12 +6,9 @@ global:
     # global image pull policy to use for all container images in the chart
     # can be overridden by individual image pullPolicy
     pullPolicy:
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistrKeySecretName
+    # global image pull secrets to use for all pod templates in the chart
+    # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    pullSecrets: []
     # global registry to use for all container images in the chart
     # can be overridden by individual image registry
     registry:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -6,6 +6,12 @@ global:
     # global image pull policy to use for all container images in the chart
     # can be overridden by individual image pullPolicy
     pullPolicy:
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
     # global registry to use for all container images in the chart
     # can be overridden by individual image registry
     registry:


### PR DESCRIPTION
Allow the use of `pullSecrets` to pull from a different registry than default (https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).