### PR TITLE
tests for global.image.pullSecretNames

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: 3.9
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (lint)
         run: |-

--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.1.3
+version: 1.1.4
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
+++ b/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
@@ -2,10 +2,6 @@ metadata:
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
 spec:
-  {{- with .Values.global.image.pullSecrets }}
-  imagePullSecrets:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
   containers:
   {{- with .Values.natsBox.container }}
   - {{ include "nats.loadMergePatch" (merge (dict "file" "nats-box/deployment/container.yaml" "ctx" $) .) | nindent 4 }}
@@ -13,6 +9,13 @@ spec:
 
   # service discovery uses DNS; don't need service env vars
   enableServiceLinks: false
+  
+  {{- with .Values.global.image.pullSecretNames }}
+  imagePullSecrets:
+  {{- range . }}
+  - name: {{ . | quote }}
+  {{- end }}
+  {{- end }}
 
   {{- with .Values.natsBox.serviceAccount }}
   {{- if .enabled }}

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -7,10 +7,6 @@ metadata:
     checksum/config: {{ sha256sum $configMap }}
     {{- end }}
 spec:
-  {{- with .Values.global.image.pullSecrets }}
-  imagePullSecrets:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
   containers:
   # nats
   {{- $nats := dict }}
@@ -32,6 +28,13 @@ spec:
 
   # service discovery uses DNS; don't need service env vars
   enableServiceLinks: false
+  
+  {{- with .Values.global.image.pullSecretNames }}
+  imagePullSecrets:
+  {{- range . }}
+  - name: {{ . | quote }}
+  {{- end }}
+  {{- end }}
 
   {{- with .Values.serviceAccount }}
   {{- if .enabled }}

--- a/helm/charts/nats/test/defaults_test.go
+++ b/helm/charts/nats/test/defaults_test.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	"sync"
 	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	policyv1 "k8s.io/api/policy/v1"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -312,6 +313,7 @@ exec sh -ec "$0"
 								},
 							},
 							EnableServiceLinks: &falseBool,
+							ImagePullSecrets:   make([]corev1.LocalObjectReference, 0),
 							Volumes: []corev1.Volume{
 								{
 									Name: "contexts",
@@ -560,6 +562,7 @@ exec sh -ec "$0"
 								},
 							},
 							EnableServiceLinks:    &falseBool,
+							ImagePullSecrets:      make([]corev1.LocalObjectReference, 0),
 							ShareProcessNamespace: &trueBool,
 							Volumes: []corev1.Volume{
 								{

--- a/helm/charts/nats/test/defaults_test.go
+++ b/helm/charts/nats/test/defaults_test.go
@@ -313,7 +313,6 @@ exec sh -ec "$0"
 								},
 							},
 							EnableServiceLinks: &falseBool,
-							ImagePullSecrets:   make([]corev1.LocalObjectReference, 0),
 							Volumes: []corev1.Volume{
 								{
 									Name: "contexts",
@@ -562,7 +561,6 @@ exec sh -ec "$0"
 								},
 							},
 							EnableServiceLinks:    &falseBool,
-							ImagePullSecrets:      make([]corev1.LocalObjectReference, 0),
 							ShareProcessNamespace: &trueBool,
 							Volumes: []corev1.Volume{
 								{

--- a/helm/charts/nats/test/resources_test.go
+++ b/helm/charts/nats/test/resources_test.go
@@ -17,6 +17,8 @@ func TestResourceOptions(t *testing.T) {
 global:
   image:
     pullPolicy: Always
+    pullSecretNames:
+    - testPullSecret
     registry: docker.io
   labels:
     global: global
@@ -133,6 +135,11 @@ natsBox:
 	expected.StatefulSet.Value.ObjectMeta.Labels["global"] = "global"
 	expected.StatefulSet.Value.ObjectMeta.Namespace = "foo"
 	expected.StatefulSet.Value.Spec.Template.ObjectMeta.Labels["global"] = "global"
+	expected.StatefulSet.Value.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+		{
+			Name: "testPullSecret",
+		},
+	}
 
 	dd := ddg.Get(t)
 	ctr := expected.StatefulSet.Value.Spec.Template.Spec.Containers
@@ -192,6 +199,12 @@ natsBox:
 	expected.NatsBoxDeployment.Value.ObjectMeta.Labels["global"] = "global"
 	expected.NatsBoxDeployment.Value.ObjectMeta.Namespace = "foo"
 	expected.NatsBoxDeployment.Value.Spec.Template.ObjectMeta.Labels["global"] = "global"
+	expected.NatsBoxDeployment.Value.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+		{
+			Name: "testPullSecret",
+		},
+	}
+
 	nbCtr := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0]
 	// nats-box
 	nbCtr.Env = env

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -6,9 +6,10 @@ global:
     # global image pull policy to use for all container images in the chart
     # can be overridden by individual image pullPolicy
     pullPolicy:
-    # global image pull secrets to use for all pod templates in the chart
+    # global list of secret names to use as image pull secrets for all pod specs in the chart
+    # secrets must exist in the same namespace
     # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    pullSecrets: []
+    pullSecretNames: []
     # global registry to use for all container images in the chart
     # can be overridden by individual image registry
     registry:


### PR DESCRIPTION
Tests for #814 

Changes un-released `global.image.pullSecrets` to `global.image.pullSecretNames`

This is because `imagePullSecrets` takes an array of `{name: secretName}` objects

I thought it was better to be more specefic that we are only taking the `secretName` portion in `pullSecretNames`, and we are adding the `name: ` key

This is consistent with the use of `secretName` many other places in the chart values