### PR TITLE
Prometheus Exporter Port Name

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.1.5
+version: 1.1.6
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/files/stateful-set/prom-exporter-container.yaml
+++ b/helm/charts/nats/files/stateful-set/prom-exporter-container.yaml
@@ -2,7 +2,7 @@ name: prom-exporter
 {{ include "nats.image" (merge (pick $.Values "global") .Values.promExporter.image) }}
 
 ports:
-- name: prom-metrics
+- name: {{ .Values.promExporter.portName }}
   containerPort: {{ .Values.promExporter.port }}
 
 {{- with .Values.promExporter.env }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -382,6 +382,7 @@ promExporter:
     pullPolicy:
     registry:
 
+  portName: prom-metrics
   port: 7777
   # env var map, see nats.env for an example
   env: {}


### PR DESCRIPTION
## What this PR does / why we need it
In this PR we add ability to rewrite Prometheus exporter container port name to be able to avoid hardcoded `prom-metrics` value.

## Which issue this PR fixes
For our particular case, we use internal rule to name all ports targets of `ClusterPodMonitor` as `metrics` with `NetworkPolicy` where we allow `gmp-system` to collect metrics from named port.

