### PR TITLE
[surveyor helm] add support for nkey in the same way as credentials

### DIFF
--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - --creds=/creds/{{ .secret.key }}
            {{- end }}
 
+           {{- with .nkey }}
+            - --nkey=/nkey/{{ .secret.key }}
+           {{- end }}
+
            {{- with .servers }}
             - -s={{ . }}
            {{- end }}
@@ -86,6 +90,11 @@ spec:
               mountPath: /creds/
               readOnly: true
             {{- end }}
+            {{- with .Values.config.nkey }}
+            - name: nkey
+              mountPath: /nkey/
+              readOnly: true
+            {{- end }}
             {{- with .Values.config.tls }}
             - name: {{ .secret.name }}-volume
               mountPath: /etc/nats-certs/clients/
@@ -113,6 +122,11 @@ spec:
       volumes:
         {{- with .Values.config.credentials }}
         - name: creds
+          secret:
+            secretName: {{ .secret.name }}
+        {{- end }}
+        {{- with .Values.config.nkey }}
+        - name: nkey
           secret:
             secretName: {{ .secret.name }}
         {{- end }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -112,6 +112,11 @@ config:
   #     name: nats-sys-creds
   #     key: sys.creds
 
+  # nkey:
+  #   secret:
+  #     name: nats-sys-nkey
+  #     key: sys.nkey
+
   # Required for NATS mutual TLS
   # tls:
   #    secret:


### PR DESCRIPTION
Add support for specification of an nkey file for auth. Everything is exactly identical to credentials.