### PR TITLE
Add optional Credentials to nats-kafka

### DIFF
--- a/helm/charts/nats-kafka/Chart.yaml
+++ b/helm/charts/nats-kafka/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.15.2
+version: 0.15.3
 appVersion: 1.4.2
 type: application
 name: nats-kafka

--- a/helm/charts/nats-kafka/README.md
+++ b/helm/charts/nats-kafka/README.md
@@ -96,3 +96,31 @@ natskafka:
       topic: bar
       subject: baz
 ```
+
+**Using Nats Credentials**
+
+If you need a nats credential for authentication:
+
+```yaml
+natskafka:
+  nats:
+    servers:
+      - "nats://1.2.3.4:4222"
+    credentials:
+      secret:
+        name: nats-sys-creds
+        key: sys.creds
+  connect:
+    - type: "NATSToKafka"
+      brokers:
+        - "1.2.3.4:9092"
+      id: whizz
+      topic: bar
+      subject: bang
+    - type: "KafkaToNATS"
+      brokers:
+        - "1.2.3.4:9092"
+      id: foo
+      topic: bar
+      subject: baz
+```

--- a/helm/charts/nats-kafka/templates/configmap.yaml
+++ b/helm/charts/nats-kafka/templates/configmap.yaml
@@ -27,6 +27,9 @@ data:
       ConnectTimeout: {{ .Values.natskafka.nats.connectTimeout }},
       MaxReconnects: {{ .Values.natskafka.nats.maxReconnects }},
       ReconnectWait: {{ .Values.natskafka.nats.reconnectWait }},
+      {{ if .Values.natskafka.nats.userCredentials }}
+      {{ with .Values.natskafka.nats.userCredentials }} UserCredentials: /etc/nats-kafka/credentials/{{ . }}, {{ end }}
+      {{ end }}
     }
 
     {{ if or .Values.natskafka.monitoring.httpPort .Values.natskafka.monitoring.httpsPort }}

--- a/helm/charts/nats-kafka/templates/configmap.yaml
+++ b/helm/charts/nats-kafka/templates/configmap.yaml
@@ -27,8 +27,8 @@ data:
       ConnectTimeout: {{ .Values.natskafka.nats.connectTimeout }},
       MaxReconnects: {{ .Values.natskafka.nats.maxReconnects }},
       ReconnectWait: {{ .Values.natskafka.nats.reconnectWait }},
-      {{ if .Values.natskafka.nats.userCredentials }}
-      {{ with .Values.natskafka.nats.userCredentials }} UserCredentials: /etc/nats-kafka/credentials/{{ . }}, {{ end }}
+      {{ if .Values.natskafka.nats.credentials }}
+      UserCredentials: /etc/nats-kafka/creds/{{ .Values.natskafka.nats.credentials.secret.key }}, {{ end }}
       {{ end }}
     }
 

--- a/helm/charts/nats-kafka/templates/configmap.yaml
+++ b/helm/charts/nats-kafka/templates/configmap.yaml
@@ -27,9 +27,9 @@ data:
       ConnectTimeout: {{ .Values.natskafka.nats.connectTimeout }},
       MaxReconnects: {{ .Values.natskafka.nats.maxReconnects }},
       ReconnectWait: {{ .Values.natskafka.nats.reconnectWait }},
-      {{ if .Values.natskafka.nats.credentials }}
-      UserCredentials: /etc/nats-kafka/creds/{{ .Values.natskafka.nats.credentials.secret.key }}, {{ end }}
-      {{ end }}
+      {{- with .Values.natskafka.nats.credentials }}
+      UserCredentials: /etc/nats-kafka/creds/{{ .secret.key }},
+      {{- end }}
     }
 
     {{ if or .Values.natskafka.monitoring.httpPort .Values.natskafka.monitoring.httpsPort }}

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -36,11 +36,11 @@ spec:
               mountPath: /etc/nats-kafka/tls
               readOnly: true
             {{ end }}
-            {{ if .Values.natskafka.nats.credentials }}
+            {{- if .Values.natskafka.nats.credentials }}
             - name: creds-volume
               mountPath: /etc/nats-kafka/creds
               readOnly: true
-            {{ end }}
+            {{- end }}
             {{- if .Values.natskafka.additionalVolumeMounts }}
               {{- toYaml .Values.natskafka.additionalVolumeMounts | nindent 12 }}
             {{- end }}

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -36,6 +36,11 @@ spec:
               mountPath: /etc/nats-kafka/tls
               readOnly: true
             {{ end }}
+            {{ if .Values.natskafka.nats.userCredentials }}
+            - name: credentials-volume
+              mountPath: /etc/nats-kafka/credentials
+              readOnly: true
+            {{ end }}
             {{- if .Values.natskafka.additionalVolumeMounts }}
               {{- toYaml .Values.natskafka.additionalVolumeMounts | nindent 12 }}
             {{- end }}
@@ -82,6 +87,11 @@ spec:
         - name: tls-volume
           secret:
             secretName: {{ .Values.natskafka.monitoring.tls.secret }}
+        {{ end }}
+        {{ if .Values.natskafka.nats.userCredentials }}
+        - name: credentials-volume
+          secret:
+            secretName: {{ .Values.natskafka.nats.userCredentials }}
         {{ end }}
         {{- if .Values.natskafka.additionalVolumes }}
           {{- toYaml .Values.natskafka.additionalVolumes | nindent 8 }}

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -36,9 +36,9 @@ spec:
               mountPath: /etc/nats-kafka/tls
               readOnly: true
             {{ end }}
-            {{ if .Values.natskafka.nats.userCredentials }}
-            - name: credentials-volume
-              mountPath: /etc/nats-kafka/credentials
+            {{ if .Values.natskafka.nats.credentials }}
+            - name: creds-volume
+              mountPath: /etc/nats-kafka/creds
               readOnly: true
             {{ end }}
             {{- if .Values.natskafka.additionalVolumeMounts }}
@@ -88,10 +88,10 @@ spec:
           secret:
             secretName: {{ .Values.natskafka.monitoring.tls.secret }}
         {{ end }}
-        {{ if .Values.natskafka.nats.userCredentials }}
-        - name: credentials-volume
+        {{ if .Values.natskafka.nats.credentials }}
+        - name: creds-volume
           secret:
-            secretName: {{ .Values.natskafka.nats.userCredentials }}
+            secretName: {{ .Values.natskafka.nats.credentials.secret.name }}
         {{ end }}
         {{- if .Values.natskafka.additionalVolumes }}
           {{- toYaml .Values.natskafka.additionalVolumes | nindent 8 }}

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -88,11 +88,11 @@ spec:
           secret:
             secretName: {{ .Values.natskafka.monitoring.tls.secret }}
         {{ end }}
-        {{ if .Values.natskafka.nats.credentials }}
+        {{- with .Values.natskafka.nats.credentials }}
         - name: creds-volume
           secret:
-            secretName: {{ .Values.natskafka.nats.credentials.secret.name }}
-        {{ end }}
+            secretName: {{ .secret.name }}
+        {{- end }}
         {{- if .Values.natskafka.additionalVolumes }}
           {{- toYaml .Values.natskafka.additionalVolumes | nindent 8 }}
         {{- end }}

--- a/helm/charts/nats-kafka/values.yaml
+++ b/helm/charts/nats-kafka/values.yaml
@@ -64,4 +64,12 @@ natskafka:
     connectTimeout: 5000
     maxReconnects: 120
     reconnectWait: 5000
+
+    # The credentials file to load in to connect to the NATS Server.
+    #
+    # credentials:
+    #   secret:
+    #     name: nats-sys-creds
+    #     key: sys.creds
+    
   connect: []


### PR DESCRIPTION
# Description

The nats-kafka helm chart does not allow for passing in the `UserCredential` variable defined in the [nats-kafka config here](userCredentials). 

This PR allows for the creation of a credential volume, the credential as a secret to the credential volume, and adds the usercredential file-path using the secret key to the UserCredential field in the `nats` section of the `nats-kafka` config.

# Testing

Tested the forked changes on our end and was able to use a secret to connect to a nats server with credentialed authentication.