### PR TITLE
[Fix #847] Fix out of sync issue for argocd regarding volumeClaimTemplate

### DIFF
--- a/helm/charts/nats/files/stateful-set/jetstream-pvc.yaml
+++ b/helm/charts/nats/files/stateful-set/jetstream-pvc.yaml
@@ -1,4 +1,6 @@
 {{- with .Values.config.jetstream.fileStore.pvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: {{ .name }}
 spec:


### PR DESCRIPTION
See #847 for details about the issue that is fixed with this PR.

In short it solves the fact that with jetstream filestore, sometimes the app gets out of sync in argocd because the volumeClaimTemplate is not described enough.