### PR TITLE
Update reloader image to latest patch version

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -353,7 +353,7 @@ reloader:
   enabled: true
   image:
     repository: natsio/nats-server-config-reloader
-    tag: 0.14.0
+    tag: 0.14.1
     pullPolicy:
     registry:
 


### PR DESCRIPTION
This patch fixes vulnerability scan finding critical vulns. This prevent the image to be imported into hardened kubernetes env and associated local registry.