### PR TITLE
Nats-Kafka Service Account Support

### DIFF
--- a/helm/charts/nats-kafka/Chart.yaml
+++ b/helm/charts/nats-kafka/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.15.3
+version: 0.15.4
 appVersion: 1.4.2
 type: application
 name: nats-kafka

--- a/helm/charts/nats-kafka/templates/deployment.yaml
+++ b/helm/charts/nats-kafka/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- toYaml .Values.natskafka.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "nats-kafka.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "nats-kafka.image" .Values.image }}

--- a/helm/charts/nats-kafka/templates/serviceaccount.yaml
+++ b/helm/charts/nats-kafka/templates/serviceaccount.yaml
@@ -4,8 +4,4 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nats-kafka.serviceAccountName" . }}
   namespace: {{ include "nats-kafka.namespace" . }}
-{{ if .Values.serviceAccount.annotations }}
-  annotations: 
-    {{- toYaml .Values.serviceAccount.annotations | nindent 2 }}
-{{ end }}
 {{ end }}

--- a/helm/charts/nats-kafka/templates/serviceaccount.yaml
+++ b/helm/charts/nats-kafka/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nats-kafka.serviceAccountName" . }}
+  namespace: {{ include "nats-kafka.namespace" . }}
+{{ if .Values.serviceAccount.annotations }}
+  annotations: 
+    {{- toYaml .Values.serviceAccount.annotations | nindent 2 }}
+{{ end }}
+{{ end }}

--- a/helm/charts/nats-kafka/values.yaml
+++ b/helm/charts/nats-kafka/values.yaml
@@ -6,6 +6,10 @@ fullnameOverride: ""
 namespaceOverride: ""
 replicaCount: 1
 
+serviceAccount:
+  create: false
+  name: default
+
 image:
   repository: natsio/nats-kafka
   tag: 1.4.2


### PR DESCRIPTION
# Description

The Nats-Kafka `_helpers.tpl` already had the service account setup, but it seemed incomplete:

```
{{/*
Create the name of the service account to use
*/}}
{{- define "nats-kafka.serviceAccountName" -}}
{{- if .Values.serviceAccount.create }}
{{- default (include "nats-kafka.fullname" .) .Values.serviceAccount.name }}
{{- else }}
{{- default "default" .Values.serviceAccount.name }}
{{- end }}
{{- end }}
```

There was no usage of `nats-kafka.serviceAccountName`, so this PR just adds the usage of that. If create is true it creates a service account, if not it uses the value from serviceAccount.name.

# Testing

Tested the helm chart from our internal branch and worked as intended.