### PR TITLE
revert erroneuos dependabot bump of nats-server-config-reloader

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -353,7 +353,7 @@ reloader:
   enabled: true
   image:
     repository: natsio/nats-server-config-reloader
-    tag: 0.14.2
+    tag: 0.14.1
     pullPolicy:
     registry:
 


### PR DESCRIPTION
Resolves #856

This change was un-released so we should not need to bump the chart version