### PR TITLE
Bump NATS server to 2.10.10-alpine in /helm/charts/nats

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: 2.10.9
+appVersion: 2.10.10
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications Technology.
 name: nats
 keywords:
 - nats
 - messaging
 - cncf
-version: 1.1.7
+version: 1.1.8
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -312,7 +312,7 @@ config:
 container:
   image:
     repository: nats
-    tag: 2.10.9-alpine
+    tag: 2.10.10-alpine
     pullPolicy:
     registry:
 


### PR DESCRIPTION
Might make sense to try to restore the `dependabot` setup that used to do this until it stopped working at some point end of last year. For now, here's another PR to do the update manually.