### PR TITLE
[nats helm] natsbox check tls enabled before adding CA

### DIFF
--- a/helm/charts/nats/files/nats-box/contexts-secret/context.yaml
+++ b/helm/charts/nats/files/nats-box/contexts-secret/context.yaml
@@ -39,10 +39,12 @@ key: {{ printf "%s/%s" $dir (.key | default "tls.key") | quote }}
 {{- end }}
 
 # tlsCA
+{{- if $.Values.config.nats.tls.enabled }}
 {{- with $.Values.tlsCA }}
 {{- if and .enabled (or .configMapName .secretName) }}
 {{- $dir := trimSuffix "/" .dir }}
 ca: {{ printf "%s/%s" $dir (.key | default "ca.crt") | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Fixes #871 

Check that TLS is enabled on the NATS Port prior to adding the `tls_ca` to NATS Box context