### PR TITLE
[nats helm] add chart-specific value support for imagePullSecrets

### DIFF
--- a/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
+++ b/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
@@ -10,9 +10,10 @@ spec:
   # service discovery uses DNS; don't need service env vars
   enableServiceLinks: false
   
-  {{- with .Values.global.image.pullSecretNames }}
+  {{- $imagePullSecrets := default .Values.global.image.pullSecretNames .Values.natsBox.container.image.pullSecretNames }}
+  {{- if $imagePullSecrets }}
   imagePullSecrets:
-  {{- range . }}
+  {{- range $imagePullSecrets }}
   - name: {{ . | quote }}
   {{- end }}
   {{- end }}

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -29,9 +29,10 @@ spec:
   # service discovery uses DNS; don't need service env vars
   enableServiceLinks: false
   
-  {{- with .Values.global.image.pullSecretNames }}
+  {{- $imagePullSecrets := default .Values.global.image.pullSecretNames .Values.container.image.pullSecretNames }}
+  {{- if $imagePullSecrets }}
   imagePullSecrets:
-  {{- range . }}
+  {{- range $imagePullSecrets }}
   - name: {{ . | quote }}
   {{- end }}
   {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -315,6 +315,7 @@ container:
     tag: 2.10.12-alpine
     pullPolicy:
     registry:
+    pullSecretNames: []
 
   # container port options
   # must be enabled in the config section also
@@ -567,6 +568,7 @@ natsBox:
       tag: 0.14.2
       pullPolicy:
       registry:
+      pullSecretNames: []
 
     # env var map, see nats.env for an example
     env: {}


### PR DESCRIPTION
This commit takes care of allowing a user to explicitly set imagePullSecrets at the NATS and NATS Box level instead of needing to do it via a global value.

Supporting this like it is currently via only a **global** value could be problematic for a couple of reasons when this NATS chart is a dependency of another chart:
- when you define **imagePullSecrets** at the global level, it affects all dependencies using that Helm value. This may not be desirable if you have multiple dependencies, each needing different image pull secrets.
- users might need different image pull secrets for different dependencies or even within different components of the same dependency. By only having a global override, this fine-grained control is limited.
- managing **imagePullSecrets** for different dependencies solely through a global Helm value could lead to complexity and potential confusion.