### PR TITLE
fix nats-box deployment so nats user can be used

### DIFF
--- a/helm/charts/nats/files/nats-box/deployment/container.yaml
+++ b/helm/charts/nats/files/nats-box/deployment/container.yaml
@@ -10,7 +10,6 @@ command:
 - sh
 - -ec
 - |
-  work_dir="$(pwd)"
   mkdir -p "$XDG_CONFIG_HOME/nats"
   cd "$XDG_CONFIG_HOME/nats"
   if ! [ -s context ]; then
@@ -21,7 +20,7 @@ command:
     echo -n {{ .Values.natsBox.defaultContextName | quote }} > context.txt
   fi
   {{- end }}
-  cd "$work_dir"
+  cd "$HOME"
   exec sh -ec "$0"
 args:
 - trap true INT TERM; sleep infinity & wait


### PR DESCRIPTION
When installing nats-box with the helm chart the current implementation saves the current directory as the "work_dir". In the Dockerfile that is "/root". Even though the user "nats" with uid 1000 is created in the Dockerfile, if the current deployment (which just does a sleep infinity) starts as uid 1000, work_dir gets saved as "/root" and when the cd $work_dir comes, the container crashes. This fixes that issue.

Sorry if this doesn't quite adhere to your PR guidelines - this is just a quick and dirty commit