### PR TITLE
Update README.md

### DIFF
--- a/helm/charts/nack/README.md
+++ b/helm/charts/nack/README.md
@@ -33,7 +33,7 @@ config:
       enabled: true
       maxSize: 256Mi
 
-    memoryStore:
+    fileStore:
       enabled: true
       pvc:
         enabled: true


### PR DESCRIPTION
Erroneous example config for jetStream. 

memoryStore mentioned twice in sample config. Second mention should be for fileStore.