### PR TITLE
Don't enable WebSocket compression by default

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.1.12
+version: 1.2.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/files/config/websocket.yaml
+++ b/helm/charts/nats/files/config/websocket.yaml
@@ -1,6 +1,5 @@
 {{- with .Values.config.websocket }}
 port: {{ .port }}
-compression: true
 
 {{- if .tls.enabled }}
 {{- with .tls }}

--- a/helm/charts/nats/test/config_test.go
+++ b/helm/charts/nats/test/config_test.go
@@ -306,7 +306,7 @@ config:
   websocket:
     enabled: true
     merge:
-      compression: false
+      compression: true
     patch: [{op: add, path: /same_origin, value: true}]
   mqtt:
     enabled: true
@@ -358,7 +358,7 @@ config:
 	}
 	expected.Conf.Value["websocket"] = map[string]any{
 		"port":        int64(8080),
-		"compression": false,
+		"compression": true,
 		"no_tls":      true,
 		"same_origin": true,
 	}

--- a/helm/charts/nats/test/ports_test.go
+++ b/helm/charts/nats/test/ports_test.go
@@ -99,9 +99,8 @@ service:
 		"no_advertise": true,
 	}
 	expected.Conf.Value["websocket"] = map[string]any{
-		"port":        int64(1003),
-		"compression": true,
-		"no_tls":      true,
+		"port":   int64(1003),
+		"no_tls": true,
 	}
 	expected.Conf.Value["mqtt"] = map[string]any{
 		"port": int64(1004),

--- a/helm/charts/nats/test/resources_test.go
+++ b/helm/charts/nats/test/resources_test.go
@@ -109,9 +109,8 @@ natsBox:
 	}
 
 	expected.Conf.Value["websocket"] = map[string]any{
-		"port":        int64(8080),
-		"no_tls":      true,
-		"compression": true,
+		"port":   int64(8080),
+		"no_tls": true,
 	}
 
 	env := []corev1.EnvVar{
@@ -513,9 +512,8 @@ natsBox:
 	expected := DefaultResources(t, test)
 
 	expected.Conf.Value["websocket"] = map[string]any{
-		"port":        int64(8080),
-		"no_tls":      true,
-		"compression": true,
+		"port":   int64(8080),
+		"no_tls": true,
 	}
 
 	annotations := func() map[string]string {

--- a/helm/charts/nats/test/tls_test.go
+++ b/helm/charts/nats/test/tls_test.go
@@ -65,8 +65,7 @@ config:
 		"no_advertise": true,
 	}
 	expected.Conf.Value["websocket"] = map[string]any{
-		"port":        int64(8080),
-		"compression": true,
+		"port": int64(8080),
 	}
 	expected.Conf.Value["mqtt"] = map[string]any{
 		"port": int64(1883),


### PR DESCRIPTION
Currently there are some problems where the flate writer might take up more allocations than expected when there are lots of WebSocket clients.

Signed-off-by: Neil Twigg <neil@nats.io>