### PR TITLE
Add tlsFirst support to NACK

### DIFF
--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -113,6 +113,9 @@ spec:
           {{- if and .Values.jetstream.tls.enabled .Values.jetstream.tls.settings.client_ca }}
           - --tlsca={{ .Values.jetstream.tls.settings.client_ca }}
           {{- end }}
+          {{- if .Values.jetstream.tls.tlsFirst }}
+          - --tlsfirst={{ .Values.jetstream.tls.tlsFirst }}
+          {{- end }}
           {{- with .Values.jetstream.additionalArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -35,6 +35,7 @@ jetstream:
   # Enabled must be true, and a secret name specified for this to work
   tls:
     enabled: false
+    tlsFirst: false
     # the secret containing the client ca.crt, tls.crt, and tls.key for NATS
     secretName:
     # Reference


### PR DESCRIPTION
Adds support for TLS First flag in NACK.
Related NACK PR: https://github.com/nats-io/nack/pull/189

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>