### PR TITLE
fix image tag for natsio/prometheus-nats-exporter

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -378,7 +378,7 @@ promExporter:
   enabled: false
   image:
     repository: natsio/prometheus-nats-exporter
-    tag: 0.15.1
+    tag: 0.15.0
     pullPolicy:
     registry:
 


### PR DESCRIPTION
tag: 0.15.1 does not exist in Docker Hub. Latest 0.15.0.

image 0.15.0. works.