### PR TITLE
feat(nats): Add support for global annotations

### DIFF
--- a/helm/charts/nats/files/config-map.yaml
+++ b/helm/charts/nats/files/config-map.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.configMap.name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
 data:
   nats.conf: |
     {{- include "nats.formatConfig" .config | nindent 4 }}

--- a/helm/charts/nats/files/headless-service.yaml
+++ b/helm/charts/nats/files/headless-service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.headlessService.name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
 spec:
   selector:
     {{- include "nats.selectorLabels" $ | nindent 4 }}

--- a/helm/charts/nats/files/ingress.yaml
+++ b/helm/charts/nats/files/ingress.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ .name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
 spec:
   {{- with .className }}
   ingressClassName: {{ . | quote }}

--- a/helm/charts/nats/files/nats-box/contents-secret.yaml
+++ b/helm/charts/nats/files/nats-box/contents-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.natsBox.contentsSecret.name }}
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "natsBox.annotations" $ | nindent 4 }}
 type: Opaque
 stringData:
   {{- range $ctxKey, $ctxVal := .Values.natsBox.contexts }}

--- a/helm/charts/nats/files/nats-box/contexts-secret/contexts-secret.yaml
+++ b/helm/charts/nats/files/nats-box/contexts-secret/contexts-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.natsBox.contextsSecret.name }}
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "natsBox.annotations" $ | nindent 4 }}
 type: Opaque
 stringData:
 {{- range $ctxKey, $ctxVal := .Values.natsBox.contexts }}

--- a/helm/charts/nats/files/nats-box/deployment/deployment.yaml
+++ b/helm/charts/nats/files/nats-box/deployment/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.natsBox.deployment.name }}
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "natsBox.annotations" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
+++ b/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
@@ -1,6 +1,8 @@
 metadata:
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "natsBox.annotations" $ | nindent 4 }}
 spec:
   containers:
   {{- with .Values.natsBox.container }}

--- a/helm/charts/nats/files/nats-box/service-account.yaml
+++ b/helm/charts/nats/files/nats-box/service-account.yaml
@@ -5,3 +5,5 @@ metadata:
   name: {{ .Values.natsBox.serviceAccount.name }}
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "natsBox.annotations" $ | nindent 4 }}

--- a/helm/charts/nats/files/pod-disruption-budget.yaml
+++ b/helm/charts/nats/files/pod-disruption-budget.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.podDisruptionBudget.name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
 spec:
   maxUnavailable: 1
   selector:

--- a/helm/charts/nats/files/pod-monitor.yaml
+++ b/helm/charts/nats/files/pod-monitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.promExporter.podMonitor.name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/helm/charts/nats/files/service-account.yaml
+++ b/helm/charts/nats/files/service-account.yaml
@@ -5,3 +5,5 @@ metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}

--- a/helm/charts/nats/files/service.yaml
+++ b/helm/charts/nats/files/service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.service.name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
 spec:
   selector:
     {{- include "nats.selectorLabels" $ | nindent 4 }}

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -2,6 +2,7 @@ metadata:
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
   annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
     {{- if .Values.podTemplate.configChecksumAnnotation }}
     {{- $configMap := include "nats.loadMergePatch" (merge (dict "file" "config-map.yaml" "ctx" $) $.Values.configMap) }}
     checksum/config: {{ sha256sum $configMap }}

--- a/helm/charts/nats/files/stateful-set/stateful-set.yaml
+++ b/helm/charts/nats/files/stateful-set/stateful-set.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.statefulSet.name }}
   labels:
     {{- include "nats.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "nats.annotations" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -144,6 +144,25 @@ app.kubernetes.io/component: nats-box
 {{- end }}
 
 {{/*
+NATS annotations
+*/}}
+{{- define "nats.annotations" -}}
+{{- with .Values.global.annotations -}}
+{{ toYaml . }}
+{{ end -}}
+{{- end }}
+
+
+{{/*
+NATS Box annotations
+*/}}
+{{- define "natsBox.annotations" -}}
+{{- with .Values.global.annotations -}}
+{{ toYaml . }}
+{{ end -}}
+{{- end }}
+
+{{/*
 Print the image
 */}}
 {{- define "nats.image" }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -17,6 +17,9 @@ global:
   # global labels will be applied to all resources deployed by the chart
   labels: {}
 
+  # global annotations will be applied to all resources deployed by the chart
+  annotations: {}
+
 ################################################################################
 # Common options
 ################################################################################


### PR DESCRIPTION
The purpose of this PR is to add support for global annotations across resources deployed by the **nats** chart.

This was mentioned as a request / proposal under https://github.com/nats-io/k8s/issues/897.