### PR TITLE
Release nats helm 1.2.9

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.2.8
+version: 1.2.9
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io


### PR DESCRIPTION
Signed-off-by: Tomasz Pietrek <tomasz@nats.io>