### PR TITLE
Update GOMEMLIMIT recommendation in readme

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -123,8 +123,8 @@ podTemplate:
 container:
   env:
     # different from k8s units, suffix must be B, KiB, MiB, GiB, or TiB
-    # should be ~90% of memory limit
-    GOMEMLIMIT: 7GiB
+    # should be ~80% of memory limit
+    GOMEMLIMIT: 6GiB
   merge:
     # recommended limit is at least 2 CPU cores and 8Gi Memory for production JetStream clusters
     resources:


### PR DESCRIPTION
https://go.dev/doc/gc-guide#:~:text=Do%20take%20advantage,is%20unaware%20of.
says:
> In this case, a good rule of thumb is to leave an additional 5-10% of headroom to account for memory sources the Go runtime is unaware of. 

We see in practice that memory can grow quickly, leading to OOMs. 

Adjust the recommendation to 80%.

Links:
A related issue in k8s on setting the value to a percentage of memlimit: https://github.com/kubernetes/kubernetes/issues/91514

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run

https://pkg.go.dev/runtime/debug#SetMemoryLimit