### PR TITLE
Add support for specifying image digest and full image name in NATS

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -138,11 +138,27 @@ container:
 
 ### Specify Image Version
 
-```yaml
-container:
-  image:
-    tag: x.y.z-alpine
-```
+The container image can now be overridden by specifying either the image tag, an image digest, or a full image name. Examples below illustrate the options:
+
+- To set the tag:
+  ```yaml
+  container:
+    image:
+      tag: x.y.z-alpine
+  ```
+- To use an image digest, which overrides the tag:
+  ```yaml
+  container:
+    image:
+      repository: nats
+      digest: sha256:abcdef1234567890...
+  ```
+- To override the registry, repository, tag, and digest all at once, specify a full image name:
+  ```yaml
+  container:
+    image:
+      fullImageName: custom-reg.io/myimage@sha256:abcdef1234567890...
+  ```
 
 ### Operator Mode with NATS Resolver
 

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -147,10 +147,18 @@ app.kubernetes.io/component: nats-box
 Print the image
 */}}
 {{- define "nats.image" }}
-{{- $image := printf "%s:%s" .repository .tag }}
+{{- $image := "" }}
+{{- if .digest }}
+{{- $image = printf "%s@%s" .repository .digest }}
+{{- else }}
+{{- $image = printf "%s:%s" .repository .tag }}
+{{- end }}
 {{- if or .registry .global.image.registry }}
 {{- $image = printf "%s/%s" (.registry | default .global.image.registry) $image }}
-{{- end -}}
+{{- end }}
+{{- if .fullImageName }}
+{{- $image = .fullImageName }}
+{{- end }}
 image: {{ $image }}
 {{- if or .pullPolicy .global.image.pullPolicy }}
 imagePullPolicy: {{ .pullPolicy | default .global.image.pullPolicy }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -315,6 +315,10 @@ container:
     tag: 2.10.25-alpine
     pullPolicy:
     registry:
+    # if digest is provided, it overrides tag (example: "sha256:abcdef1234567890")
+    digest: 
+    # if fullImageName is provided, it overrides registry, repository, tag, and digest
+    fullImageName:
 
   # container port options
   # must be enabled in the config section also
@@ -356,6 +360,8 @@ reloader:
     tag: 0.16.1
     pullPolicy:
     registry:
+    digest:
+    fullImageName:
 
   # env var map, see nats.env for an example
   env: {}
@@ -381,6 +387,8 @@ promExporter:
     tag: 0.16.0
     pullPolicy:
     registry:
+    digest:
+    fullImageName:
 
   port: 7777
   # env var map, see nats.env for an example
@@ -567,6 +575,8 @@ natsBox:
       tag: 0.16.0
       pullPolicy:
       registry:
+      digest:
+      fullImageName:
 
     # env var map, see nats.env for an example
     env: {}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -316,7 +316,7 @@ container:
     pullPolicy:
     registry:
     # if digest is provided, it overrides tag (example: "sha256:abcdef1234567890")
-    digest: 
+    digest:
     # if fullImageName is provided, it overrides registry, repository, tag, and digest
     fullImageName:
 


### PR DESCRIPTION
This PR adds two new Helm chart values: digest and fullname. The image resolution now follows this priority: tag < digest < fullname, ensuring immutable image references for improved security and compliance. 

issue: #970 