### PR TITLE
Bump NATS chart version to 1.3.0

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - nats
 - messaging
 - cncf
-version: 1.2.10
+version: 1.3.0
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io


### PR DESCRIPTION
Bump NATS chart version to 1.3.0 after following changes:

https://github.com/nats-io/k8s/pull/971