### PR TITLE
add extraVolumes and extraVolumeMounts for surveyor

### DIFF
--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -100,7 +100,6 @@ spec:
               mountPath: /etc/nats-certs/clients/
               readOnly: true
             {{- end }}
-
             {{- if .Values.config.jetstream.enabled }}
             {{- with .Values.config.jetstream.accounts }}
 
@@ -117,6 +116,10 @@ spec:
               mountPath: /jetstream
             {{- end }}
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12}}
+            {{- end }}
+            
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -153,6 +156,9 @@ spec:
           configMap:
             name: {{ include "surveyor.fullname" $ }}-accounts
         {{- end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 
       {{- with .Values.nodeSelector }}

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -100,6 +100,7 @@ spec:
               mountPath: /etc/nats-certs/clients/
               readOnly: true
             {{- end }}
+
             {{- if .Values.config.jetstream.enabled }}
             {{- with .Values.config.jetstream.accounts }}
 

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -142,13 +142,13 @@ config:
     #   password: password
 
 # Mount arbitrary volumes to surveyor pods
-extraVolumeMounts:
-  - name: ca-certs
-    mountPath: /etc/ssl/certs/ca-certificates.crt
-    readOnly: true
-
+#extraVolumeMounts:
+#  - name: ca-certs
+#    mountPath: /etc/ssl/certs/ca-certificates.crt
+#    readOnly: true
+#
 # Configure arbitrary volumes for surveyor pods
-extraVolumes:
-  - name: ca-certs
-    configMap:
-      name: ca-certs
+#extraVolumes:
+#  - name: ca-certs
+#    configMap:
+#      name: ca-certs

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -140,3 +140,15 @@ config:
     # - name: basic
     #   username: username
     #   password: password
+
+# Mount arbitrary volumes to surveyor pods
+extraVolumeMounts:
+  - name: ca-certs
+    mountPath: /etc/ssl/certs/ca-certificates.crt
+    readOnly: true
+
+# Configure arbitrary volumes for surveyor pods
+extraVolumes:
+  - name: ca-certs
+    configMap:
+      name: ca-certs


### PR DESCRIPTION
Our use case is to mount ca certs into the surveyor container, but this will enable arbitrary volume mounts which might be useful to someone. I could also write something more opinionated for the CA case if that's preferred. Is this something yall would support?