### PR TITLE
fix(charts/stan): remove -channelz, -serverz from exporter.args default

### DIFF
--- a/helm/charts/stan/Chart.yaml
+++ b/helm/charts/stan/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
 - replay
 - statefulset
 - cncf
-version: 0.13.0
+version: 0.13.1
 maintainers:
 - email: info@nats.io
   name: The NATS Authors

--- a/helm/charts/stan/templates/statefulset.yaml
+++ b/helm/charts/stan/templates/statefulset.yaml
@@ -314,8 +314,6 @@ spec:
           - -routez
           - -subz
           - -varz
-          - -channelz
-          - -serverz
           - http://localhost:8222/
           {{- end }}
           ports:


### PR DESCRIPTION
Both `GetStreamingChannelz` and `GetStreamingServerz` were removed from `NATSExporterOptions` in https://github.com/nats-io/prometheus-nats-exporter/pull/329 due to the `nats-streaming-server` deprecation.   Since `.Values.exporter.image` defaults to `latest`, new pods would enter a `CrashLoopBackOff` with the metrics container failing to start due to the undefined args.  Example errors below:

```
Defaulted container "metrics" out of: metrics, stan
flag provided but not defined: -channelz
Usage of /prometheus-nats-exporter:
…
```

```
Defaulted container "metrics" out of: metrics, stan
flag provided but not defined: -serverz
Usage of /prometheus-nats-exporter:
…
```
This PR only removes the `-channelz` and `-serverz` streaming args from the default case when the exporter is enabled and `.Values.exporter.args[]` is empty.