### PR TITLE
Fix PromExporter with TLS enabled Monitor

### DIFF
--- a/helm/charts/nats/files/stateful-set/prom-exporter-container.yaml
+++ b/helm/charts/nats/files/stateful-set/prom-exporter-container.yaml
@@ -27,4 +27,5 @@ args:
 {{- if .Values.config.gateway.enabled }}
 - -gatewayz
 {{- end }}
-- http://localhost:{{ .Values.config.monitor.port }}/
+{{- $monitorProto := ternary "https" "http" .Values.config.monitor.tls.enabled }}
+- {{ $monitorProto }}://{{ .Values.promExporter.monitorDomain }}:{{ .Values.config.monitor.port }}/

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -238,6 +238,7 @@ config:
     tls:
       # config.nats.tls must be enabled also
       # when enabled, monitoring port will use HTTPS with the options from config.nats.tls
+      # if promExporter is also enabled, consider setting promExporter.monitorDomain
       enabled: false
 
   profiling:
@@ -391,6 +392,9 @@ promExporter:
     fullImageName:
 
   port: 7777
+  # if config.monitor.tls.enabled is set to true, monitorDomain must be set to the common name
+  # or a SAN used in the tls certificate
+  monitorDomain: localhost
   # env var map, see nats.env for an example
   env: {}
 


### PR DESCRIPTION
This PR fixes an issue that occurs when TLS is enabled for the Monitor and the Prometheus Exporter is also enabled. A hardcoded `"http"` value prevents the `promExporter` container from starting up healthily.

To resolve this, the protocol used to query the Monitor (either `http` or `https`) is now selected automatically based on the TLS setting. Additionally, the domain that Prometheus Exporter queries is now configurable.

Note that the domain cannot be set to `localhost` if the TLS certificate used by the Monitor does not include `localhost` as a Subject Alternative Name (SAN). In such cases, `monitorDomain` must match a name present in the certificate.

See https://github.com/nats-io/k8s/issues/785