### PR TITLE
set   terminationGracePeriodSeconds: 60 for nats pods

### DIFF
--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -70,4 +70,6 @@ spec:
   {{- end }}
   {{- end}}
   
+  # terminationGracePeriodSeconds determines how long to wait for graceful shutdown
+  # this should be at least `lameDuckGracePeriod` + 20s shutdown overhead
   terminationGracePeriodSeconds: 60

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -69,3 +69,5 @@ spec:
   - {{ merge (dict "topologyKey" $k "labelSelector" (dict "matchLabels" (include "nats.selectorLabels" $ | fromYaml))) $v | toYaml | nindent 4 }}
   {{- end }}
   {{- end}}
+  
+  terminationGracePeriodSeconds: 60

--- a/helm/charts/nats/test/defaults_test.go
+++ b/helm/charts/nats/test/defaults_test.go
@@ -563,8 +563,9 @@ exec /entrypoint.sh "$@"
 									},
 								},
 							},
-							EnableServiceLinks:    &falseBool,
-							ShareProcessNamespace: &trueBool,
+							TerminationGracePeriodSeconds: int64Ptr(60),
+							EnableServiceLinks:            &falseBool,
+							ShareProcessNamespace:         &trueBool,
 							Volumes: []corev1.Volume{
 								{
 									Name: "config",
@@ -629,4 +630,10 @@ func TestDefaultValues(t *testing.T) {
 	test := DefaultTest()
 	expected := DefaultResources(t, test)
 	RenderAndCheck(t, test, expected)
+}
+
+func int64Ptr(i int) *int64 {
+	i64 := (int64)(i)
+
+	return &i64
 }


### PR DESCRIPTION
We used to set this value:
https://github.com/nats-io/k8s/blob/nats-0.19.17/helm/charts/nats/values.yaml#L187-L189

Let's add it back, to make sure we do not kill the pod prematurely.

Our default LameDuck perioud is 30s:
https://github.com/nats-io/k8s/blob/nats-1.3.3/helm/charts/nats/files/config/config.yaml#L5

So 60s for grace shutdown should give plenty of time.

fixes #994