### PR TITLE
adding the right podMonitor prometheus doc in values.yaml

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -410,7 +410,7 @@ promExporter:
     enabled: false
 
     # merge or patch the pod monitor
-    # https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor
+    # https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor
     merge: {}
     patch: []
     # defaults to "{{ include "nats.fullname" $ }}"


### PR DESCRIPTION
# Updated PodMonitor API reference link in values.yaml (nats chart):

Replaced:
```
# https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor
```
with:
```
# https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor
```
To reflect the correct and current API documentation.