### PR TITLE
refactor(nack): Use AppVersion to update to NACK image 0.18.2

### DIFF
--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: 0.17.2
-description: A Helm chart for NACK
 name: nack
+version: 0.29.0
+appVersion: "0.18.2"
+description: A Helm chart for NACK - NAts Controller for Kubernetes
 keywords:
 - nats
 - jetstream
 - cncf
-version: 0.28.1
 maintainers:
 - email: info@nats.io
   name: The NATS Authors

--- a/helm/charts/nack/crds/crds.yml
+++ b/helm/charts/nack/crds/crds.yml
@@ -291,6 +291,9 @@ spec:
                 description: When true, the KV Store will initiate TLS before server INFO.
                 type: boolean
                 default: false
+              jsDomain:
+                description: The JetStream domain to use for the stream.
+                type: string
           status:
             type: object
             properties:
@@ -318,7 +321,7 @@ spec:
       jsonPath: .status.conditions[?(@.type == 'Ready')].reason
     - name: Stream Name
       type: string
-      description: The name of the Jetstream Stream.
+      description: The name of the JetStream Stream.
       jsonPath: .spec.name
     - name: Subjects
       type: string
@@ -486,7 +489,7 @@ spec:
       jsonPath: .status.conditions[?(@.type == 'Ready')].reason
     - name: Stream Name
       type: string
-      description: The name of the Jetstream Stream.
+      description: The name of the JetStream Stream.
       jsonPath: .spec.name
     - name: Subjects
       type: string
@@ -678,6 +681,9 @@ spec:
                 description: When true, the KV Store will initiate TLS before server INFO.
                 type: boolean
                 default: false
+              jsDomain:
+                description: The JetStream domain to use for the consumer.
+                type: string
           status:
             type: object
             properties:
@@ -705,11 +711,11 @@ spec:
       jsonPath: .status.conditions[?(@.type == 'Ready')].reason
     - name: Stream
       type: string
-      description: The name of the Jetstream Stream.
+      description: The name of the JetStream Stream.
       jsonPath: .spec.streamName
     - name: Consumer
       type: string
-      description: The name of the Jetstream Consumer.
+      description: The name of the JetStream Consumer.
       jsonPath: .spec.durableName
     - name: Ack Policy
       type: string
@@ -829,11 +835,11 @@ spec:
       jsonPath: .status.conditions[?(@.type == 'Ready')].reason
     - name: Stream
       type: string
-      description: The name of the Jetstream Stream.
+      description: The name of the JetStream Stream.
       jsonPath: .spec.streamName
     - name: Consumer
       type: string
-      description: The name of the Jetstream Consumer.
+      description: The name of the JetStream Consumer.
       jsonPath: .spec.durableName
     - name: Ack Policy
       type: string
@@ -966,7 +972,7 @@ spec:
       jsonPath: .status.conditions[?(@.type == 'Ready')].reason
     - name: Stream Template Name
       type: string
-      description: The name of the Jetstream Stream Template.
+      description: The name of the JetStream Stream Template.
       jsonPath: .spec.name
     - name: Subjects
       type: string
@@ -1281,6 +1287,9 @@ spec:
                 description: When true, the KV Store will initiate TLS before server INFO.
                 type: boolean
                 default: false
+              jsDomain:
+                description: The JetStream domain to use for the KV store.
+                type: string
           status:
             type: object
             properties:
@@ -1419,9 +1428,12 @@ spec:
                     items:
                       type: string
               tlsFirst:
-                description: When true, the KV Store will initiate TLS before server INFO.
+                description: When true, the Object Store will initiate TLS before server INFO.
                 type: boolean
                 default: false
+              jsDomain:
+                description: The JetStream domain to use for the Object Store.
+                type: string
           status:
             type: object
             properties:

--- a/helm/charts/nack/templates/_helpers.tpl
+++ b/helm/charts/nack/templates/_helpers.tpl
@@ -37,9 +37,10 @@ Fix image keys for chart versions <= 0.17.5
 Print the image
 */}}
 {{- define "jsc.image" -}}
-{{- $image := printf "%s:%s" .repository .tag }}
-{{- if .registry }}
-{{- $image = printf "%s/%s" .registry $image }}
+{{- $imageDict := .Values.jetstream.image }}
+{{- $image := printf "%s:%s" $imageDict.repository (default .Chart.AppVersion $imageDict.tag) }}
+{{- if $imageDict.registry }}
+{{- $image = printf "%s/%s" $imageDict.registry $image }}
 {{- end }}
 {{- $image -}}
 {{- end }}

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -81,7 +81,7 @@ spec:
       {{- end }}
       containers:
         - name: jsc
-          image: {{ include "jsc.image" .Values.jetstream.image }}
+          image: {{ include "jsc.image" . }}
           imagePullPolicy: {{ .Values.jetstream.image.pullPolicy }}
           workingDir: /nack
           command:

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -7,6 +7,7 @@ jetstream:
   enabled: true
   image:
     repository: natsio/jetstream-controller
+    tag:
     pullPolicy: IfNotPresent
     # registry: docker.io
 

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -7,7 +7,6 @@ jetstream:
   enabled: true
   image:
     repository: natsio/jetstream-controller
-    tag: 0.17.2
     pullPolicy: IfNotPresent
     # registry: docker.io
 


### PR DESCRIPTION
- Updates NACK chart to NACK controller 0.18.2
- Updates CRD changes introduced in NACK 0.18.0
- Helm chart refactored to use built in `appVersion` for it's intended use
  - Still possible to override the image tag as previously