### PR TITLE
francescov1/add user password auth to surveyor

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: surveyor
 description: NATS Monitoring, Simplified.
 type: application
-version: 0.20.0
+version: 0.20.1
 appVersion: 0.9.1
 maintainers:
-- email: info@nats.io
-  name: The NATS Authors
-  url: https://github.com/nats-io
+  - email: info@nats.io
+    name: The NATS Authors
+    url: https://github.com/nats-io

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -48,14 +48,6 @@ spec:
             - --nkey=/nkey/{{ .secret.key }}
            {{- end }}
 
-           {{- with .user }}
-            - --user={{ . }}
-           {{- end }}
-
-           {{- with .password }}
-            - --password=$(NATS_ADMIN_PASSWORD)
-           {{- end }}
-
            {{- with .servers }}
             - -s={{ . }}
            {{- end }}
@@ -88,14 +80,18 @@ spec:
             - name: http
               containerPort: 7777
               protocol: TCP
-          {{- if .Values.config.password }}
           env:
-            - name: NATS_ADMIN_PASSWORD
+            {{- if .Values.config.user }}
+            - name: NATS_SURVEYOR_USER
+              value: {{ .Values.config.user }}
+            {{- end }}
+            {{- if .Values.config.password }}
+            - name: NATS_SURVEYOR_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.password.secret.name }}
                   key: {{ .Values.config.password.secret.key }}
-          {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
            {{- end }}
 
            {{- with .password }}
-            - --password=/password-auth/{{ .secret.key }}
+            - --password=$(NATS_ADMIN_PASSWORD)
            {{- end }}
 
            {{- with .servers }}
@@ -88,6 +88,14 @@ spec:
             - name: http
               containerPort: 7777
               protocol: TCP
+          {{- if .Values.config.password }}
+          env:
+            - name: NATS_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.password.secret.name }}
+                  key: {{ .Values.config.password.secret.key }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -101,11 +109,6 @@ spec:
             {{- with .Values.config.nkey }}
             - name: nkey
               mountPath: /nkey/
-              readOnly: true
-            {{- end }}
-            {{- with .Values.config.password }}
-            - name: password-auth
-              mountPath: /password-auth/
               readOnly: true
             {{- end }}
             {{- with .Values.config.tls }}
@@ -144,11 +147,6 @@ spec:
         {{- end }}
         {{- with .Values.config.nkey }}
         - name: nkey
-          secret:
-            secretName: {{ .secret.name }}
-        {{- end }}
-        {{- with .Values.config.password }}
-        - name: password-auth
           secret:
             secretName: {{ .secret.name }}
         {{- end }}

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -48,6 +48,14 @@ spec:
             - --nkey=/nkey/{{ .secret.key }}
            {{- end }}
 
+           {{- with .user }}
+            - --user={{ . }}
+           {{- end }}
+
+           {{- with .password }}
+            - --password=/password-auth/{{ .secret.key }}
+           {{- end }}
+
            {{- with .servers }}
             - -s={{ . }}
            {{- end }}
@@ -95,6 +103,11 @@ spec:
               mountPath: /nkey/
               readOnly: true
             {{- end }}
+            {{- with .Values.config.password }}
+            - name: password-auth
+              mountPath: /password-auth/
+              readOnly: true
+            {{- end }}
             {{- with .Values.config.tls }}
             - name: {{ .secret.name }}-volume
               mountPath: /etc/nats-certs/clients/
@@ -131,6 +144,11 @@ spec:
         {{- end }}
         {{- with .Values.config.nkey }}
         - name: nkey
+          secret:
+            secretName: {{ .secret.name }}
+        {{- end }}
+        {{- with .Values.config.password }}
+        - name: password-auth
           secret:
             secretName: {{ .secret.name }}
         {{- end }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -119,6 +119,16 @@ config:
   #     name: nats-sys-nkey
   #     key: sys.nkey
 
+  # User/password authentication (alternative to credentials/nkey)
+  # Username as plain text
+  # user: admin
+
+  # Password must use secret for security
+  # password:
+  #   secret:
+  #     name: nats-user-auth
+  #     key: password
+
   # Required for NATS mutual TLS
   # tls:
   #    secret:
@@ -140,7 +150,6 @@ config:
     # - name: basic
     #   username: username
     #   password: password
-
 # Mount arbitrary volumes to surveyor pods
 #extraVolumeMounts:
 #  - name: ca-certs


### PR DESCRIPTION
This PR adds support for `--user` and `--password` to the Surveyor Helm chart. It uses a secret for the password.

Addresses #905 