### PR TITLE
feat(promExporter): allow to use internal server name

### DIFF
--- a/helm/charts/nats/files/stateful-set/prom-exporter-container.yaml
+++ b/helm/charts/nats/files/stateful-set/prom-exporter-container.yaml
@@ -17,7 +17,11 @@ args:
 - -subz
 - -varz
 - -prefix=nats
+{{- if .Values.promExporter.useInternalServerName }}
+- -use_internal_server_name
+{{- else}}
 - -use_internal_server_id
+{{- end }}
 {{- if .Values.config.jetstream.enabled }}
 - -jsz=all
 {{- end }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -397,6 +397,8 @@ promExporter:
   monitorDomain: localhost
   # env var map, see nats.env for an example
   env: {}
+  # if true, use the internal server name instead of the server id
+  useInternalServerName: false
 
   # merge or patch the container
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#container-v1-core


### PR DESCRIPTION
This change allows to expose the internal server name instead of the internal server id in the prometheus exported metrics.

Thanks in advance for reviewing.