### PR TITLE
bump nats up to 0.19.0

### DIFF
--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nack
-version: 0.29.0
+version: 0.29.1
 appVersion: "0.19.0"
 description: A Helm chart for NACK - NAts Controller for Kubernetes
 keywords:


### PR DESCRIPTION
bump app version regarding to release: https://github.com/nats-io/nack/releases/tag/v0.19.0