### PR TITLE
Feature/add crd nats 0.19.0

### DIFF
--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nack
 version: 0.29.0
-appVersion: "0.18.2"
+appVersion: "0.19.0"
 description: A Helm chart for NACK - NAts Controller for Kubernetes
 keywords:
 - nats

--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nack
-version: 0.29.0
+version: 0.29.1
 appVersion: "0.19.0"
 description: A Helm chart for NACK - NAts Controller for Kubernetes
 keywords:

--- a/helm/charts/nack/crds/crds.yml
+++ b/helm/charts/nack/crds/crds.yml
@@ -232,6 +232,14 @@ spec:
                 description: When true, enables direct access to messages from the origin stream.
                 type: boolean
                 default: false
+              allowMsgTtl:
+                description: When true, allows header initiated per-message TTLs. If disabled, then the `NATS-TTL` header will be ignored.
+                type: boolean
+                default: false
+              subjectDeleteMarkerTtl:
+                description: Enables and sets a duration for adding server markers for delete, purge and max age limits.
+                type: string
+                default: ''
               consumerLimits:
                 type: object
                 properties:


### PR DESCRIPTION
We have a strange situation here.
An updated CRD for new NACK release need to copy to k8s repo...
I think we can do this better in the future, but for now I just copied new CRD from here: https://github.com/nats-io/nack/blob/main/deploy/crds.yml