### PR TITLE
make the nats format config helper for environment variable match as …

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -282,7 +282,7 @@ output: string with following format rules
 */}}
 {{- define "nats.formatConfig" -}}
   {{-
-    (regexReplaceAll "\"<<\\s+(.*)\\s+>>\""
+    (regexReplaceAll "\"<<\\s+(.*?)\\s+>>\""
       (regexReplaceAll "\".*\\$include\": \"(.*)\",?" (include "toPrettyRawJson" .) "include ${1};")
     "${1}")
   -}}


### PR DESCRIPTION
…few times as possible to allow having two env vars in same row

When using [variables](https://github.com/nats-io/k8s/pull/1034) the chart currently requires a << $name >> format as mentioned [here](https://github.com/nats-io/k8s/tree/main/helm/charts/nats#nats-config-units-and-variables).
The problem is that if you want to create a values like
```
<< $SYS_ACCOUNT_ID >>: << $SYS_ACCOUNT_JWT >>
```
the template generates
```
$SYS_ACCOUNT_ID >>": "<< $SYS_ACCOUNT_JWT
```

expected to get:
```
$SYS_ACCOUNT_ID: $SYS_ACCOUNT_JWT
```

