### PR TITLE
Add support for bearer token read from a file

### DIFF
--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -71,6 +71,12 @@ spec:
             - --tlskey=/etc/nats-certs/clients/{{ .key }}
             - --tlscert=/etc/nats-certs/clients/{{ .cert }}
            {{- end }}
+
+           {{- with .tokenFile }}
+           {{- if .enabled }}
+            - --token-file={{ .mountPath }}/{{ .filename }}
+           {{- end }}
+           {{- end }}
            {{- end }}
 
            {{- if .Values.config.jetstream.enabled }}
@@ -129,6 +135,15 @@ spec:
               mountPath: /jetstream
             {{- end }}
             {{- end }}
+
+            {{- with .Values.config.tokenFile }}
+            {{- if .enabled }}
+            - name: {{ default "nats-token" .volumeName }}
+              mountPath: {{ .mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
+
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12}}
             {{- end }}
@@ -170,6 +185,23 @@ spec:
             name: {{ include "surveyor.fullname" $ }}-accounts
         {{- end }}
         {{- end }}
+
+        {{- with .Values.config.tokenFile }}
+        {{- if .enabled }}
+        - name: {{ default "nats-token" .volumeName }}
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: {{ .filename }}
+                  {{- if .audience }}
+                  audience: {{ .audience }}
+                  {{- end }}
+                  {{- if .expirationSeconds }}
+                  expirationSeconds: {{ .expirationSeconds }}
+                  {{- end }}
+        {{- end }}
+        {{- end }}
+
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -108,6 +108,21 @@ config:
   # Enable monitoring account metrics.
   accounts: false
 
+  # stays as ENV; works with token-file + user
+  #user: "sys"
+
+  # tokenFile:
+  #   enabled: true
+    # optional: change the volume name
+    # volumeName: nats-token
+    # where to mount inside the container
+    # mountPath: /var/run/secrets/tokens
+    # filename inside the mount where kubelet writes the token
+    # filename: nats-token
+    # optional extras for projected tokens:
+    # audience: nats-auth
+    # expirationSeconds: 3600
+
   # Required if NATS auth is enabled
   # credentials:
   #   secret:


### PR DESCRIPTION
**Summary**

This PR updates the Surveyor Helm chart to support the new `--token-file` option recently added to [nats-surveyor](https://github.com/nats-io/nats-surveyor/pull/284).

It introduces new values under .Values.config to allow mounting a projected ServiceAccount token (or any other token file) and passing it to surveyor.

**Motivation**

Many Kubernetes environments rely on projected ServiceAccount tokens for authentication.

These tokens are short-lived and audience-scoped, making them more secure than static creds or passwords.

By adding this support, surveyor can be deployed in clusters that use callout-style authentication against NATS.

**Changes**

- Added `.Values.config.tokenFile` and `.Values.config.tokenVolume support`
- Deployment template mounts the projected ServiceAccount token when configured.
- Surveyor args now include **--token-file**.
- Existing authentication mechanisms (creds, nkey, user/password, etc.) remain unchanged.