### PR TITLE
Add workflow to update crds

### DIFF
--- a/.github/workflows/update-nack-crds.yaml
+++ b/.github/workflows/update-nack-crds.yaml
@@ -28,13 +28,18 @@ jobs:
 
       - name: Get latest NACK release
         id: get_release
-        # We use gh rather than curl, so that our requests can be authenticated and avoid anonymous rate limits
         run: |
-          RELEASE_TAG="$(gh release --repo nats-io/nack view --json tagName --jq .tagName)"
+          # Using curl and jq for robust JSON parsing
+          RELEASE_TAG=$(curl -s https://api.github.com/repos/nats-io/nack/releases/latest | jq -r '.tag_name')
+
+          # Fallback check if release fetch failed
+          if [[ -z "$RELEASE_TAG" ]] || [[ "$RELEASE_TAG" == "null" ]]; then
+            echo "Failed to fetch latest NACK release"
+            exit 1
+          fi
+
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "Latest NACK release: $RELEASE_TAG"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download CRDs from latest release
         id: download_crds


### PR DESCRIPTION
Automate copying over the file, as requested by a customer in:
https://github.com/nats-io/k8s/pull/1032

It is based on:
https://github.com/ConnectEverything/client-tools/blob/main/.github/workflows/version-update.yaml

@samuelattwood knows why we need a copy in this repo.

## Reproducible test plan:
Reverted to previous version
```
#  git checkout 85ea6b9 -- helm/charts/nack/crds/crds.yml helm/charts/nack/Chart.yaml
```

Then tested using act(https://github.com/nektos/act):
It did the change, but failed to create a PR(which is expected)
```
act workflow_dispatch --workflows .github/workflows/update-nack-crds.yaml -P ubuntu-latest=catthehacker/ubuntu:act-latest --container-architecture linux/amd64 --reuse
```
Tested the change is right: 
```
# docker exec -it  act-Update-NACK-CRDs-Update-NACK-CRDs-58d0c01c3a02e4abe72fee8c2eb8adf8dc1aaaa8be4ac08192e414c9f588f6d7  /bin/bash
```
And then expected contents of the container:
```
root@omenlaptop:/home/alex/code/synadia/k8s# git diff
diff --git a/helm/charts/nack/Chart.yaml b/helm/charts/nack/Chart.yaml
index 026a96d..fa20122 100755
--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nack
-version: 0.29.1
-appVersion: "0.19.0"
+version: 0.29.2
+appVersion: 0.19.2
 description: A Helm chart for NACK - NAts Controller for Kubernetes
 keywords:
 - nats
diff --git a/helm/charts/nack/crds/crds.yml b/helm/charts/nack/crds/crds.yml
index a4999b5..43036d8 100644
--- a/helm/charts/nack/crds/crds.yml
+++ b/helm/charts/nack/crds/crds.yml
@@ -232,6 +232,14 @@ spec:
                 description: When true, enables direct access to messages from the origin stream.
                 type: boolean
                 default: false
+              allowMsgTtl:
+                description: When true, allows header initiated per-message TTLs. If disabled, then the `NATS-TTL` header will be ignored.
+                type: boolean
+                default: false
+              subjectDeleteMarkerTtl:
+                description: Enables and sets a duration for adding server markers for delete, purge and max age limits.
+                type: string
+                default: ''
               consumerLimits:
```
