### PR TITLE
Add helm chart for managing NACK resources.

### DIFF
--- a/helm/charts/nack-resources/.helmignore
+++ b/helm/charts/nack-resources/.helmignore
@@ -1,0 +1,12 @@
+#  Common VCS dirs
+.git/
+.github/
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db
+
+# Archives and charts
+*.tgz
+*.tar.gz
+Chart.lock

--- a/helm/charts/nack-resources/Chart.yaml
+++ b/helm/charts/nack-resources/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: nack-resources
+version: 0.0.1
+description: A Helm chart for NACK resources - Install NATS JetStream resources (Streams, Consumers, KeyValues, ObjectStores) via NACK CRDs
+sources:
+  - https://github.com/nats-io/nack
+  - https://github.com/nats-io/k8s
+keywords:
+  - nats
+  - jetstream
+  - nack
+  - streams
+  - consumers
+  - keyvalue
+  - objectstore
+

--- a/helm/charts/nack-resources/README.md
+++ b/helm/charts/nack-resources/README.md
@@ -1,0 +1,76 @@
+# Helm chart - NATS JetStream Controller (NACK) Resources
+
+Helm chart for managing NATS JetStream resources (Streams, Consumers, KeyValues, ObjectStores) managed by the NACK controllers.
+
+You must install the [NACK controllers](https://github.com/nats-io/nack) first to let this chart renders the custom resources (CRs). 
+
+### Install
+
+Provide connection settings and one or more resources:
+
+```
+helm install my-resources ./helm/charts/nack-resources \
+  --namespace default \
+  -f values.yaml
+```
+
+Upgrade:
+
+```
+helm upgrade my-resources ./helm/charts/nack-resources -f values.yaml
+```
+
+Uninstall:
+
+```
+helm uninstall my-resources
+```
+
+### Values overview
+
+- `nats`: shared connectivity used by all resources unless overridden per-item (`connection`).
+  - `servers`, `jsDomain`, `account`, `creds`, `nkey`, `tls{}`
+- `preflight.crdChecks.enabled`: fail early if required CRDs are missing (default: `true`).
+- `streams[]`: list of Stream specs. Minimal fields: `name`, `subjects`.
+- `consumers[]`: list of Consumer specs. Minimal fields: `streamName`, `durableName`.
+- `objectStores[]`: list of Object Store specs. Minimal field: `bucket`.
+- `keyValues[]`: list of Key/Value Store specs. Minimal field: `bucket`.
+
+See `values.yaml` for all available fields and descriptions (mirrors the NACK CRD schemas).
+
+### Quick examples
+
+Minimal Stream:
+
+```
+streams:
+  - name: orders
+    subjects: ["orders.*"]
+```
+
+Pull Consumer for the stream above:
+
+```
+consumers:
+  - streamName: orders
+    durableName: orders-pull
+    ackPolicy: explicit
+```
+
+Key/Value bucket:
+
+```
+keyValues:
+  - bucket: app-config
+    history: 5
+    storage: memory
+```
+
+Object Store bucket:
+
+```
+objectStores:
+  - bucket: media
+    storage: file
+    replicas: 1
+```

--- a/helm/charts/nack-resources/templates/NOTES.txt
+++ b/helm/charts/nack-resources/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Thank you for installing the nack-resources chart.
+
+This chart renders NATS JetStream resources (Streams, Consumers, KeyValues, ObjectStores)
+managed by the NACK controllers. Ensure the NACK CRDs and controllers are installed.
+
+You can find more information about running NATS JetStream Controller on
+Kubernetes here:
+
+  https://github.com/nats-io/nack

--- a/helm/charts/nack-resources/templates/_helpers.tpl
+++ b/helm/charts/nack-resources/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "nack-resources.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "nack-resources.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "nack-resources.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "nack-resources.labels" -}}
+app.kubernetes.io/name: {{ include "nack-resources.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- if .Values.commonLabels }}
+{{- toYaml .Values.commonLabels | nindent 0 }}
+{{- end }}
+{{- end -}}
+

--- a/helm/charts/nack-resources/templates/_preflight-crds.yaml
+++ b/helm/charts/nack-resources/templates/_preflight-crds.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.preflight.crdChecks.enabled }}
+{{- $required := list "streams.jetstream.nats.io" "consumers.jetstream.nats.io" "keyvalues.jetstream.nats.io" "objectstores.jetstream.nats.io" -}}
+{{- range $crd := $required }}
+{{- if not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $crd) }}
+{{- fail (printf "Required CRD %s not found. Install NACK CRDs first (helm/charts/nack/crds)." $crd) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/charts/nack-resources/templates/consumers.yaml
+++ b/helm/charts/nack-resources/templates/consumers.yaml
@@ -1,0 +1,137 @@
+{{- $globals := .Values.nats | default dict -}}
+{{- range .Values.consumers }}
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  # include stream and durable in the resource name to avoid collisions
+  name: {{ printf "%s-%s-%s" $.Release.Name .streamName .durableName | trunc 63 | trimSuffix "-" }}
+spec:
+  streamName: {{ .streamName | quote }}
+  durableName: {{ .durableName | quote }}
+  {{- with .deliverPolicy }}
+  deliverPolicy: {{ . }}
+  {{- end }}
+  {{- with .optStartSeq }}
+  optStartSeq: {{ . }}
+  {{- end }}
+  {{- with .optStartTime }}
+  optStartTime: {{ . | quote }}
+  {{- end }}
+  {{- with .replayPolicy }}
+  replayPolicy: {{ . }}
+  {{- end }}
+  {{- with .deliverSubject }}
+  deliverSubject: {{ . | quote }}
+  {{- end }}
+  {{- with .deliverGroup }}
+  deliverGroup: {{ . | quote }}
+  {{- end }}
+  {{- with .filterSubject }}
+  filterSubject: {{ . | quote }}
+  {{- end }}
+  {{- with .filterSubjects }}
+  filterSubjects:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .ackPolicy }}
+  ackPolicy: {{ . }}
+  {{- end }}
+  {{- with .ackWait }}
+  ackWait: {{ . | quote }}
+  {{- end }}
+  {{- with .maxDeliver }}
+  maxDeliver: {{ . }}
+  {{- end }}
+  {{- with .backoff }}
+  backoff:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .maxAckPending }}
+  maxAckPending: {{ . }}
+  {{- end }}
+
+  {{- with .sampleFreq }}
+  sampleFreq: {{ . | quote }}
+  {{- end }}
+  {{- with .rateLimitBps }}
+  rateLimitBps: {{ . }}
+  {{- end }}
+  {{- with .flowControl }}
+  flowControl: {{ . }}
+  {{- end }}
+  {{- with .heartbeatInterval }}
+  heartbeatInterval: {{ . | quote }}
+  {{- end }}
+  {{- with .headersOnly }}
+  headersOnly: {{ . }}
+  {{- end }}
+
+  {{- with .maxWaiting }}
+  maxWaiting: {{ . }}
+  {{- end }}
+  {{- with .maxRequestBatch }}
+  maxRequestBatch: {{ . }}
+  {{- end }}
+  {{- with .maxRequestExpires }}
+  maxRequestExpires: {{ . | quote }}
+  {{- end }}
+  {{- with .maxRequestMaxBytes }}
+  maxRequestMaxBytes: {{ . }}
+  {{- end }}
+
+  {{- with .inactiveThreshold }}
+  inactiveThreshold: {{ . | quote }}
+  {{- end }}
+  {{- with .replicas }}
+  replicas: {{ . }}
+  {{- end }}
+  {{- with .memStorage }}
+  memStorage: {{ . }}
+  {{- end }}
+
+  {{- with .metadata }}
+  metadata:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- with $globals.account }}
+  account: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.servers }}
+  servers:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $globals.jsDomain }}
+  jsDomain: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.creds }}
+  creds: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.nkey }}
+  nkey: {{ . | quote }}
+  {{- end }}
+  {{- if $globals.tls }}
+  tls:
+      {{- with $globals.tls.clientCert }}
+    clientCert: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.clientKey }}
+    clientKey: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.rootCas }}
+    rootCas:
+{{ toYaml . | nindent 6 }}
+      {{- end }}
+  {{- end }}
+  {{- with $globals.tlsFirst }}
+  tlsFirst: {{ . }}
+  {{- end }}
+
+  {{- with .preventDelete }}
+  preventDelete: {{ . }}
+  {{- end }}
+  {{- with .preventUpdate }}
+  preventUpdate: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/nack-resources/templates/keyvalues.yaml
+++ b/helm/charts/nack-resources/templates/keyvalues.yaml
@@ -1,0 +1,98 @@
+{{- $globals := .Values.nats | default dict -}}
+{{- range .Values.keyValues }}
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: KeyValue
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name .bucket | trunc 63 | trimSuffix "-" }}
+spec:
+  bucket: {{ .bucket | quote }}
+
+  {{- with .description }}
+  description: {{ . | quote }}
+  {{- end }}
+
+  {{- with .history }}
+  history: {{ . }}
+  {{- end }}
+  {{- with .ttl }}
+  ttl: {{ . | quote }}
+  {{- end }}
+  {{- with .maxValueSize }}
+  maxValueSize: {{ . }}
+  {{- end }}
+  {{- with .maxBytes }}
+  maxBytes: {{ . }}
+  {{- end }}
+
+  {{- with .storage }}
+  storage: {{ . }}
+  {{- end }}
+  {{- with .replicas }}
+  replicas: {{ . }}
+  {{- end }}
+  {{- with .placement }}
+  placement:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .compression }}
+  compression: {{ . }}
+  {{- end }}
+
+  {{- with .mirror }}
+  mirror:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .sources }}
+  sources:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .republish }}
+  republish:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .metadata }}
+  metadata:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $globals.account }}
+  account: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.servers }}
+  servers:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $globals.jsDomain }}
+  jsDomain: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.creds }}
+  creds: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.nkey }}
+  nkey: {{ . | quote }}
+  {{- end }}
+  {{- if $globals.tls }}
+  tls:
+      {{- with $globals.tls.clientCert }}
+    clientCert: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.clientKey }}
+    clientKey: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.rootCas }}
+    rootCas:
+{{ toYaml . | nindent 6 }}
+      {{- end }}
+  {{- end }}
+  {{- with $globals.tlsFirst }}
+  tlsFirst: {{ . }}
+  {{- end }}
+
+  {{- with .preventDelete }}
+  preventDelete: {{ . }}
+  {{- end }}
+  {{- with .preventUpdate }}
+  preventUpdate: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/nack-resources/templates/objects.yaml
+++ b/helm/charts/nack-resources/templates/objects.yaml
@@ -1,0 +1,80 @@
+{{- $globals := .Values.nats | default dict -}}
+{{- range .Values.objectStores }}
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: ObjectStore
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name .bucket | trunc 63 | trimSuffix "-" }}
+spec:
+  bucket: {{ .bucket | quote }}
+
+  {{- with .description }}
+  description: {{ . | quote }}
+  {{- end }}
+
+  {{- with .ttl }}
+  ttl: {{ . | quote }}
+  {{- end }}
+  {{- with .maxBytes }}
+  maxBytes: {{ . }}
+  {{- end }}
+
+  {{- with .storage }}
+  storage: {{ . }}
+  {{- end }}
+  {{- with .replicas }}
+  replicas: {{ . }}
+  {{- end }}
+
+  {{- with .placement }}
+  placement:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .compression }}
+  compression: {{ . }}
+  {{- end }}
+
+  {{- with .metadata }}
+  metadata:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- with $globals.account }}
+  account: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.servers }}
+  servers:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $globals.jsDomain }}
+  jsDomain: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.creds }}
+  creds: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.nkey }}
+  nkey: {{ . | quote }}
+  {{- end }}
+  {{- if $globals.tls }}
+  tls:
+      {{- with $globals.tls.clientCert }}
+    clientCert: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.clientKey }}
+    clientKey: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.rootCas }}
+    rootCas:
+{{ toYaml . | nindent 6 }}
+      {{- end }}
+  {{- end }}
+  {{- with $globals.tlsFirst }}
+  tlsFirst: {{ . }}
+  {{- end }}
+
+  {{- with .preventDelete }}
+  preventDelete: {{ . }}
+  {{- end }}
+  {{- with .preventUpdate }}
+  preventUpdate: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/nack-resources/templates/streams.yaml
+++ b/helm/charts/nack-resources/templates/streams.yaml
@@ -1,0 +1,155 @@
+{{- $globals := .Values.nats | default dict -}}
+{{- range .Values.streams }}
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name .name | trunc 63 | trimSuffix "-" }}
+spec:
+  name: {{ .name | quote }}
+  subjects:
+{{ toYaml (.subjects | default (list)) | nindent 4 }}
+  {{- with .description }}
+  description: {{ . | quote }}
+  {{- end }}
+  {{- with .retention }}
+  retention: {{ . }}
+  {{- end }}
+  {{- with .maxConsumers }}
+  maxConsumers: {{ . }}
+  {{- end }}
+  {{- with .maxMsgs }}
+  maxMsgs: {{ . }}
+  {{- end }}
+  {{- with .maxBytes }}
+  maxBytes: {{ . }}
+  {{- end }}
+  {{- with .maxMsgsPerSubject }}
+  maxMsgsPerSubject: {{ . }}
+  {{- end }}
+  {{- with .maxMsgSize }}
+  maxMsgSize: {{ . }}
+  {{- end }}
+  {{- with .maxAge }}
+  maxAge: {{ . | quote }}
+  {{- end }}
+  {{- with .discard }}
+  discard: {{ . }}
+  {{- end }}
+  {{- with .discardPerSubject }}
+  discardPerSubject: {{ . }}
+  {{- end }}
+  {{- with .storage }}
+  storage: {{ . }}
+  {{- end }}
+  {{- with .replicas }}
+  replicas: {{ . }}
+  {{- end }}
+  {{- with .noAck }}
+  noAck: {{ . }}
+  {{- end }}
+  {{- with .duplicateWindow }}
+  duplicateWindow: {{ . | quote }}
+  {{- end }}
+  {{- with .placement }}
+  placement:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .mirror }}
+  mirror:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .sources }}
+  sources:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .sealed }}
+  sealed: {{ . }}
+  {{- end }}
+  {{- with .denyDelete }}
+  denyDelete: {{ . }}
+  {{- end }}
+  {{- with .denyPurge }}
+  denyPurge: {{ . }}
+  {{- end }}
+  {{- with .allowRollup }}
+  allowRollup: {{ . }}
+  {{- end }}
+  {{- with .compression }}
+  compression: {{ . | quote }}
+  {{- end }}
+  {{- with .firstSequence }}
+  firstSequence: {{ . }}
+  {{- end }}
+
+  {{- with .subjectTransform }}
+  subjectTransform:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .republish }}
+  republish:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .allowDirect }}
+  allowDirect: {{ . }}
+  {{- end }}
+  {{- with .mirrorDirect }}
+  mirrorDirect: {{ . }}
+  {{- end }}
+
+  {{- with .allowMsgTtl }}
+  allowMsgTtl: {{ . }}
+  {{- end }}
+  {{- with .subjectDeleteMarkerTtl }}
+  subjectDeleteMarkerTtl: {{ . | quote }}
+  {{- end }}
+
+  {{- with .consumerLimits }}
+  consumerLimits:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .metadata }}
+  metadata:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $globals.account }}
+  account: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.servers }}
+  servers:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $globals.jsDomain }}
+  jsDomain: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.creds }}
+  creds: {{ . | quote }}
+  {{- end }}
+  {{- with $globals.nkey }}
+  nkey: {{ . | quote }}
+  {{- end }}
+  {{- if $globals.tls }}
+  tls:
+      {{- with $globals.tls.clientCert }}
+    clientCert: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.clientKey }}
+    clientKey: {{. | quote }}
+      {{- end }}
+      {{- with $globals.tls.rootCas }}
+    rootCas:
+{{ toYaml . | nindent 6 }}
+      {{- end }}
+  {{- end }}
+  {{- with $globals.tlsFirst }}
+  tlsFirst: {{ . }}
+  {{- end }}
+
+  {{- with .preventDelete }}
+  preventDelete: {{ . }}
+  {{- end }}
+  {{- with .preventUpdate }}
+  preventUpdate: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/nack-resources/values.yaml
+++ b/helm/charts/nack-resources/values.yaml
@@ -1,0 +1,360 @@
+# Connection settings used by all Streams/Consumers/ObjectStores/KeyValues unless overridden per-item via `connection`
+nats:
+  # Name of the account to which the resource belongs.
+  account: ""
+  # A list of servers for creating stream. Example: ["nats://nats.default.svc:4222"].
+  servers: []
+  # The JetStream domain to use for the stream.
+  jsDomain: ""
+  # NATS user credentials for connecting to servers. Ensure the controller mounts the creds at this path.
+  creds: ""
+  # NATS user NKey for connecting to servers.
+  nkey: ""
+  # A client's TLS certs and keys.
+  tls:
+    # A client's cert filepath. Should be mounted.
+    clientCert: ""
+    # A client's key filepath. Should be mounted.
+    clientKey: ""
+    # A list of filepaths to CAs. Should be mounted.
+    rootCas: []
+  # When true, the KV Store will initiate TLS before server INFO.
+  tlsFirst: false
+
+# Preflight checks
+preflight:
+  crdChecks:
+    enabled: true
+
+# No streams created by default. Uncomment & edit an item below.
+streams: []
+# Example Stream item. Uncomment to use and adjust values.
+#   # A unique name for the Stream.
+#   # REQUIRED. Pattern: '^[^.*>]*$'
+# - name: mystream
+#   #
+#   # A list of subjects to consume, supports wildcards.
+#   # REQUIRED (at least one subject).
+#   subjects: ["example.>"]
+#   #
+#   # The description of the stream.
+#   description: ""
+#   #
+#   # How messages are retained in the Stream; once exceeded, old messages are removed.
+#   # One of: limits | interest | workqueue. Default: limits.
+#   retention: limits
+#   #
+#   # How many Consumers can be defined for a given Stream. -1 for unlimited.
+#   # Default: -1.
+#   maxConsumers: -1
+#   #
+#   # How many messages may be in a Stream; oldest messages are removed when exceeded.
+#   # -1 for unlimited. Default: -1.
+#   maxMsgs: -1
+#   #
+#   # How big the Stream may be; when the combined size exceeds this, old messages are removed.
+#   # -1 for unlimited. Default: -1.
+#   maxBytes: -1
+#   #
+#   # The maximum number of messages per subject. Default: 0 (unlimited).
+#   maxMsgsPerSubject: 0
+#   #
+#   # The largest message that will be accepted by the Stream. -1 for unlimited. Default: -1.
+#   maxMsgSize: -1
+#   #
+#   # Maximum age of any message in the stream, expressed in Go's time.Duration format.
+#   # Empty for unlimited. Default: "".
+#   maxAge: ""
+#   #
+#   #  When a Stream reach it's limits either old messages are deleted or new ones are denied.
+#   # One of: old | new. Default: old.
+#   discard: old
+#   #
+#   # Applies discard policy on a per-subject basis. Requires discard policy 'new' and 'maxMsgs' to be set.
+#   # Default: false.
+#   discardPerSubject: false
+#   #
+#   # The storage backend to use for the Stream. One of: file | memory. Default: memory.
+#   storage: memory
+#   #
+#   # How many replicas to keep for each message. Minimum: 1. Default: 1.
+#   replicas: 1
+#   #
+#   # Disables acknowledging messages that are received by the Stream. Default: false.
+#   noAck: false
+#   #
+#   # The duration window to track duplicate messages for. Unset by default.
+#   # duplicateWindow: ""
+#   #
+#   # A stream's placement. Unset by default.
+#   # placement: {}
+#   #
+#   # A stream mirror. Choose mirror OR sources, not both. Unset by default.
+#   #   # name: ""                    # source stream
+#   #   # optStartSeq: 0
+#   #   # optStartTime: ""           # RFC3339 timestamp
+#   #   # filterSubject: ""
+#   #   # externalApiPrefix: ""
+#   #   # externalDeliverPrefix: ""
+#   #   # subjectTransforms: []       # list of {source,dest}
+#   # mirror: {}
+#   #
+#   # A stream's sources to aggregate from. Alternative to mirror. Unset by default.
+#   #   # - name: other-stream
+#   #   #   optStartSeq: 0
+#   #   #   optStartTime: ""          # RFC3339 timestamp
+#   #   #   filterSubject: ""
+#   #   #   externalApiPrefix: ""
+#   #   #   externalDeliverPrefix: ""
+#   #   #   subjectTransforms: []     # list of {source,dest}
+#   # sources: []
+#   #
+#   # Seal an existing stream so no new messages may be added. Default: false.
+#   sealed: false
+#   #
+#   # When true, restricts the ability to delete messages from a stream via the API. Cannot be changed once true. Default: false.
+#   denyDelete: false
+#   #
+#   # When true, restricts the ability to purge a stream via the API. Cannot be changed once true. Default: false.
+#   denyPurge: false
+#   #
+#   # When true, allows the use of the Nats-Rollup header to replace contents with a single new message. Default: false.
+#   allowRollup: false
+#   #
+#   # Stream specific compression. One of: "" | s2 | none. Default: "".
+#   compression: ""
+#   #
+#   # Sequence number from which the Stream will start. Default: 0.
+#   firstSequence: 0
+#   #
+#   # SubjectTransform for applying a subject transform to matching messages when received. Unset by default.
+#   # subjectTransform: {}
+#   #
+#   # Republish configuration of the stream. Unset by default.
+#   #   # source: ""                 # Messages will be published from this subject
+#   #   # destination: ""            # Messages will be additionally published to this subject
+#   # republish: {}
+#   #
+#   # When true, allow higher performance, direct access to get individual messages. Default: false.
+#   allowDirect: false
+#   #
+#   # When true, enables direct access to messages from the origin stream. Default: false.
+#   mirrorDirect: false
+#   #
+#   # When true, allows header initiated per-message TTLs. If disabled, the `NATS-TTL` header is ignored. Default: false.
+#   allowMsgTtl: false
+#   #
+#   # Enables and sets a duration for adding server markers for delete, purge and max age limits. Default: "".
+#   subjectDeleteMarkerTtl: ""
+#   #
+#   # Default Consumer limits for this stream (e.g., inactiveThreshold, maxAckPending). Unset by default.
+#   # consumerLimits: {}
+#   #
+#   # Additional Stream metadata as key:value pairs. Default: {}.
+#   metadata: {}
+#   #
+#   # When true, the managed Stream will not be deleted when the resource is deleted. Default: false.
+#   preventDelete: false
+#   #
+#   # When true, the managed Stream will not be updated when the resource is updated. Default: false.
+#   preventUpdate: false
+
+# No consumers created by default. Uncomment & edit an item below.
+consumers: []
+# Example Consumer item. Uncomment to use and adjust values.
+#   # The name of the Consumer.
+#   # REQUIRED. Pattern: '^[^.*>]+$'
+# - durableName: myconsumer
+#   #
+#   # The name of the Stream to create the Consumer in.
+#   # REQUIRED: must match an existing Stream.
+#   streamName: mystream
+#   #
+#   # Where to start consuming from.
+#   # One of: all | last | new | byStartSequence | byStartTime. Default: all.
+#   # Requires 'optStartSeq' for byStartSequence, or 'optStartTime' for byStartTime.
+#   deliverPolicy: all
+#   #
+#   # Start at this sequence when deliverPolicy=byStartSequence. Minimum: 0.
+#   optStartSeq: 0
+#   #
+#   # Start at this time when deliverPolicy=byStartTime. Time format: RFC3339. Default: "".
+#   optStartTime: ""
+#   #
+#   # Subject to deliver observed messages to. When unset, a Pull-based Consumer is created. Default: unset.
+#   deliverSubject: ""
+#   #
+#   # How messages should be acknowledged. One of: none | all | explicit. Default: none.
+#   ackPolicy: none
+#   #
+#   # How long to allow messages to remain un-acknowledged before attempting redelivery. Default: 1ns.
+#   ackWait: 1ns
+#   #
+#   # Maximum number of redeliveries (-1 for unlimited).
+#   maxDeliver: -1
+#   #
+#   # List of durations representing a retry time scale for NaK'd or retried messages. Example: ["1s","5s","30s"].
+#   backoff: []
+#   #
+#   # Select only a specific incoming subject; supports wildcards. Default: "".
+#   filterSubject: ""
+#   #
+#   # List of incoming subjects; supports wildcards. Available since NATS 2.10. Default: [].
+#   filterSubjects: []
+#   #
+#   # How messages are sent. One of: instant | original. Default: instant.
+#   replayPolicy: instant
+#   #
+#   # What percentage of acknowledgements should be sampled for observability, e.g. "100%". Default: unset.
+#   sampleFreq: ""
+#   #
+#   # Number of outstanding pulls allowed on a Pull consumer; pulls after this are ignored. Default: 0.
+#   maxWaiting: 0
+#   #
+#   # Rate at which messages will be delivered to clients, in bits per second. Default: 0 (unlimited).
+#   rateLimitBps: 0
+#   #
+#   # Maximum pending Acks before consumers are paused. Default: 0.
+#   maxAckPending: 0
+#   #
+#   # Queue group name for push-based delivery. Default: "".
+#   deliverGroup: ""
+#   #
+#   # The description of the consumer. Default: "".
+#   description: ""
+#   #
+#   # Enables flow control for push-based consumers. Default: false.
+#   flowControl: false
+#   #
+#   # When true, only the headers of messages in the stream are delivered, not the bodies; adds Nats-Msg-Size header. Default: false.
+#   headersOnly: false
+#   #
+#   # Idle heartbeat interval for push-based consumers, Go time.Duration. Default: unset.
+#   heartbeatInterval: ""
+#   #
+#   # Largest batch property that may be specified when doing a pull. Default: 0.
+#   maxRequestBatch: 0
+#   #
+#   # Maximum expires duration that may be set when doing a pull. Default: unset.
+#   maxRequestExpires: ""
+#   #
+#   # Maximum max_bytes value that may be set when doing a pull. Default: 0.
+#   maxRequestMaxBytes: 0
+#   #
+#   # Additional Consumer metadata as key:value pairs. Default: {}.
+#   metadata: {}
+#   #
+#   # When true, the managed Consumer will not be deleted when the resource is deleted. Default: false.
+#   preventDelete: false
+#   #
+#   # When true, the managed Consumer will not be updated when the resource is updated. Default: false.
+#   preventUpdate: false
+
+# No object stores created by default. Uncomment & edit an item below.
+objectStores: []
+# Example Object Store item. Uncomment to use and adjust values.
+#   # A unique name for the Object Store bucket.
+#   # REQUIRED.
+# - bucket: myobjects
+#   #
+#   # The description of the Object Store. Default: "".
+#   description: ""
+#   #
+#   # Time-to-live for objects, Go time.Duration. Default: unset.
+#   ttl: ""
+#   #
+#   # Maximum size of the Store in bytes. 0 means unlimited.
+#   maxBytes: 0
+#   #
+#   # Storage backend to use. One of: file | memory. Default: memory.
+#   storage: memory
+#   #
+#   # Number of replicas to keep in clustered JetStream. Min: 1, Max: 5. Default: 1.
+#   replicas: 1
+#   #
+#   # Object Store placement via tags or cluster name. Unset by default.
+#   #   # cluster: ""
+#   #   # tags: []
+#   # placement: {}
+#   #
+#   # Enable compression for objects. Default: false.
+#   compression: false
+#   #
+#   # Additional Object Store metadata as key:value pairs. Default: {}.
+#   metadata: {}
+#   #
+#   # When true, the managed Object Store will not be deleted when the resource is deleted. Default: false.
+#   preventDelete: false
+#   #
+#   # When true, the managed Object Store will not be updated when the resource is updated. Default: false.
+#   preventUpdate: false
+
+# No key-value stores created by default. Uncomment & edit an item below.
+keyValues: []
+# Example KeyValue item. Uncomment to use and adjust values.
+#   # A unique name for the KV Store bucket.
+#   # REQUIRED.
+# - bucket: mykv
+#   #
+#   # The description of the KV Store. Default: "".
+#   description: ""
+#   #
+#   # Maximum size of a value in bytes. 0 means unlimited.
+#   maxValueSize: 0
+#   #
+#   # Number of historical values to keep per key. Default: 0.
+#   history: 0
+#   #
+#   # Time expiry for keys, Go time.Duration. Default: unset.
+#   ttl: ""
+#   #
+#   # Maximum size of the KV Store in bytes. 0 means unlimited.
+#   maxBytes: 0
+#   #
+#   # Storage backend to use for the KV Store. One of: file | memory. Default: memory.
+#   storage: memory
+#   #
+#   # Number of replicas to keep in clustered JetStream. Min: 1, Max: 5. Default: 1.
+#   replicas: 1
+#   #
+#   # KV Store placement via tags or cluster name. Unset by default.
+#   #   # cluster: ""
+#   #   # tags: []
+#   # placement: {}
+#   #
+#   # Republish configuration for the KV Store. Unset by default.
+#   #   # source: ""                 # Messages will be published from this subject
+#   #   # destination: ""            # Messages will be additionally published to this subject after Bucket
+#   # republish: {}
+#   #
+#   # A KV Store mirror. Unset by default.
+#   #   # name: ""
+#   #   # optStartSeq: 0
+#   #   # optStartTime: ""           # RFC3339 timestamp
+#   #   # filterSubject: ""
+#   #   # externalApiPrefix: ""
+#   #   # externalDeliverPrefix: ""
+#   #   # subjectTransforms: []       # list of {source,dest}
+#   # mirror: {}
+#   #
+#   # A KV Store's sources (aggregate from other buckets). Alternative to mirror. Unset by default.
+#   #   # - name: other-kv
+#   #   #   optStartSeq: 0
+#   #   #   optStartTime: ""          # RFC3339 timestamp
+#   #   #   filterSubject: ""
+#   #   #   externalApiPrefix: ""
+#   #   #   externalDeliverPrefix: ""
+#   #   #   subjectTransforms: []     # list of {source,dest}
+#   # sources: []
+#   #
+#   # KV Store compression. Default: false.
+#   compression: false
+#   #
+#   # Additional KV Store metadata as key:value pairs. Default: {}.
+#   metadata: {}
+#   #
+#   # When true, the managed KV Store will not be deleted when the resource is deleted. Default: false.
+#   preventDelete: false
+#   #
+#   # When true, the managed KV Store will not be updated when the resource is updated. Default: false.
+#   preventUpdate: false


### PR DESCRIPTION
### Summary

As proposed [here](https://github.com/nats-io/nack/issues/287) add a Helm chart for NACK JetStream resources that renders Kubernetes Custom Resources (CRs) for:

Stream (streams.jetstream.nats.io)

Consumer (consumers.jetstream.nats.io)

KeyValue (keyvalues.jetstream.nats.io)

ObjectStore (objectstores.jetstream.nats.io)

It separates from the NACK controller chart to keep controller lifecycle independent from application resources.

### What this PR includes

A new application chart (e.g., charts/jetstream-resources/) with:

**Templates**

- templates/streams.yaml — loops over values.streams[]

- templates/consumers.yaml — loops over values.consumers[]

- templates/keyvalues.yaml — loops over values.keyValues[]

- templates/objects.yaml — loops over values.objectStores[]

### Values schema (high-level)

```
nats:
 
streams:        #  Stream CRs
  - name: ""
    subjects: []
    # ...optional Stream fields (retention, limits, storage, replicas, placement, mirror/sources, etc.)
    # connection: {}       # optional per-stream overrides

consumers:      #  Consumer CRs
  - streamName: ""
    durableName: ""

keyValues:      # -> KeyValue CRs (buckets)
  - bucket: ""

objectStores:   # -> ObjectStore CRs (buckets)
  - bucket: ""

```

### Example Usage

```

streams:
  - name: orders
    subjects: ["orders.*"]
    storage: file
    replicas: 1
    maxAge: 72h

consumers:
  - streamName: orders
    durableName: orders-worker
    ackPolicy: explicit
    deliverPolicy: all
    ackWait: 30s

keyValues:
  - bucket: app-kv
    history: 3
    ttl: 24h
    storage: file
    replicas: 1

objectStores:
  - bucket: assets
    ttl: 168h
    storage: file
    replicas: 1

```