### PR TITLE
Bump NATS Server to 2.12.1

### DIFF
--- a/helm/charts/nats/Chart.yaml
+++ b/helm/charts/nats/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: 2.11.10
+appVersion: 2.12.1
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications Technology.
 name: nats
 keywords:
 - nats
 - messaging
 - cncf
-version: 1.3.16
+version: 2.12.1
 home: http://github.com/nats-io/k8s
 maintainers:
 - email: info@nats.io

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -313,7 +313,7 @@ config:
 container:
   image:
     repository: nats
-    tag: 2.11.10-alpine
+    tag: 2.12.1-alpine
     pullPolicy:
     registry:
     # if digest is provided, it overrides tag (example: "sha256:abcdef1234567890")


### PR DESCRIPTION
First release in the NATS Server `2.12` line. `2.11` releases will remain on the `1.3` chart versions for consistency, but going forward we will align `major.minor` with the app version to allow better clarity with multiple supported minor versions.

For example:
`helm upgrade -i nats nats/nats --version "~2.12"`