### PR TITLE
feat: Add ability to add annotations to nack deployment

### DIFF
--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -5,6 +5,10 @@ kind: Deployment
 metadata:
   name: {{ template "jsc.name" . }}
   namespace: {{ include "jsc.namespace" . }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ template "jsc.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -117,6 +117,10 @@ rbacRules: |
     - update
     - delete
 
+# Annotations to add to the deployment
+deploymentAnnotations: {}
+
+# Annotations to add to pods managed by the deployment
 podAnnotations: {}
 
 # Toggle whether to use setup a Pod Security Context


### PR DESCRIPTION
Like the commit message says, adds values to be able to add annotations to the NACK deployment. For things like https://github.com/stakater/Reloader when using a [cert-manager](https://cert-manager.io/) cert for authorization to NATS server.