### PR TITLE
Ensure namespace is emitted into metadata.

### DIFF
--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -41,9 +41,7 @@ Print the namespace
 Print the namespace for the metadata section
 */}}
 {{- define "nats.metadataNamespace" -}}
-{{- with .Values.namespaceOverride }}
-namespace: {{ . | quote }}
-{{- end }}
+namespace: {{ include "nats.namespace" . | quote }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This attempts to resolve #1082  by changing the logic for `nats.metadataNamespace` to use the `nats.namespace` template rather than using it's own seperate logic which doesn't include `.Release.Namespace`