### PR TITLE
feat(surveyor): Add extraEnv and extraArgs to Surveyor pod

### DIFF
--- a/helm/charts/surveyor/Chart.yaml
+++ b/helm/charts/surveyor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: surveyor
 description: NATS Monitoring, Simplified.
 type: application
-version: 0.20.5
+version: 0.20.6
 appVersion: 0.9.5
 maintainers:
   - email: info@nats.io

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
            {{- if .Values.config.jetstream.enabled }}
             - --jetstream=/jetstream
            {{- end }}
+
+           {{- with .Values.extraArgs }}
+           {{- toYaml . | nindent 12 }}
+           {{- end }}
           ports:
             - name: http
               containerPort: 7777
@@ -105,6 +109,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.config.password.secret.name }}
                   key: {{ .Values.config.password.secret.key }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -178,3 +178,13 @@ config:
 #  - name: ca-certs
 #    configMap:
 #      name: ca-certs
+
+# Attach arbitrary environment variables to the surveyor pod
+# extraEnv:
+# - name: MY_ENV_VAR
+#   value: my_value
+
+# Add arbitrary arguments to the surveyor pod
+# extraArgs:
+# - --arg1
+# - --arg2


### PR DESCRIPTION
To help future proof the Surveyor Helm chart, support `extraEnv` and `extraArgs` Helm values. These values allow users to supply any extra, arbitrary environment variables and command line arguments, respectively.