### PR TITLE
FIXED Add missing lastPerSubject deliverPolicy option for Consumer CRD

### DIFF
--- a/helm/charts/nack/crds/crds.yml
+++ b/helm/charts/nack/crds/crds.yml
@@ -557,6 +557,7 @@ spec:
                 enum:
                 - all
                 - last
+                - lastPerSubject
                 - new
                 # Requires optStartSeq
                 - byStartSequence


### PR DESCRIPTION
This PR adds support for the 'lastPerSubject' option for DeliverPolicy when creating a consumer as documented in [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy) documentation. This option was missing from the current v1beta2 CRD schema, causing validation errors when trying to use this feature:

```
spec.deliverPolicy: Unsupported value: "lastPerSubject": supported values: "all", "last", "new", "byStartSequence", "byStartTime"
```

This option is named differently than in the NATS documentation, where it is called `DeliverLastPerSubject`, or in the `nats consumer info -j` output, where it is `last_per_subject`. The camel-case naming is based on the NACK implementation in `consumerSpecToOpts()` in the natsio/nack repo file `controllers/jetstream/consumer.go` which processes `deliverPolicy` values.

As this is a new enum value, this is expected to be a **non-breaking change** for all users of the chart. Also, while the change is minor, I have _not actually_ tested it.

NACK reference:

- https://github.com/nats-io/nack/blob/0621c29652f2cedd7f74d319a3156763422ce721/controllers/jetstream/consumer.go#L233-L237

_This contribution is my original work and that I license the work to the project under the project’s open source license._
