### PR TITLE
fix: add api version kind to statefulset pvc

### DIFF
--- a/helm/charts/nats/files/stateful-set/jetstream-pvc.yaml
+++ b/helm/charts/nats/files/stateful-set/jetstream-pvc.yaml
@@ -1,4 +1,6 @@
 {{- with .Values.config.jetstream.fileStore.pvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: {{ .name }}
 spec:

--- a/helm/charts/nats/files/stateful-set/resolver-pvc.yaml
+++ b/helm/charts/nats/files/stateful-set/resolver-pvc.yaml
@@ -1,4 +1,6 @@
 {{- with .Values.config.resolver.pvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: {{ .name }}
 spec:

--- a/helm/charts/nats/test/config_test.go
+++ b/helm/charts/nats/test/config_test.go
@@ -73,6 +73,10 @@ config:
 	resource10Gi, _ := resource.ParseQuantity("10Gi")
 	expected.StatefulSet.Value.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 		{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: test.FullName + "-js",
 			},
@@ -191,6 +195,10 @@ config:
 	storageClassGp3 := "gp3"
 	expected.StatefulSet.Value.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 		{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: test.FullName + "-js",
 			},
@@ -207,6 +215,10 @@ config:
 			},
 		},
 		{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: test.FullName + "-resolver",
 			},
@@ -401,6 +413,10 @@ config:
 	storageClassGp3 := "gp3"
 	expected.StatefulSet.Value.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 		{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: test.FullName + "-js",
 			},
@@ -418,6 +434,10 @@ config:
 			},
 		},
 		{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: test.FullName + "-resolver",
 			},
@@ -600,6 +620,10 @@ max_outstanding_catchup: 64MB
 	resource10Gi, _ := resource.ParseQuantity("10Gi")
 	expected.StatefulSet.Value.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 		{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: test.FullName + "-js",
 			},

--- a/helm/charts/nats/test/resources_test.go
+++ b/helm/charts/nats/test/resources_test.go
@@ -310,6 +310,10 @@ natsBox:
 	resource10Gi, _ := resource.ParseQuantity("10Gi")
 	expected.StatefulSet.Value.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 		{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: test.FullName + "-js",
 			},


### PR DESCRIPTION
this fixes #1103 

*Problem*: When using ArgoCD, the NATS StatefulSet always shows a "diff" for `volumeClaimTemplates`. This is because the chart omits `apiVersion` and `kind`, which the Kubernetes API server then automatically adds to the live resource. ArgoCD interprets this as a drift from the desired state.

*Solution*: Explicitly add `apiVersion: v1` and `kind: PersistentVolumeClaim` to the `jetstream-pvc.yaml` and `resolver-pvc.yaml` files.

*Impact*: This is a non-breaking change that ensures the rendered Helm output matches the live cluster state, resulting in a "Healthy/Synced" status in GitOps controllers. 
*CAVEAT*: This may result in a sync error for existing deployments since `volumeClaimTemplates` is immutable, but a delete & recreate of the `StatefulSet` can remedy this.