### PR TITLE
Add initcontainer to test if the service is listening

### DIFF
--- a/helm/charts/nats/templates/tests/request-reply.yaml
+++ b/helm/charts/nats/templates/tests/request-reply.yaml
@@ -28,6 +28,14 @@ kind: Pod
   )
   "spec" (dict
     "restartPolicy" "Never"
+    "initContainers" (list
+      (dict
+        "name" "wait-for-nats"
+        "image" "busybox:1.36"
+        "command" (list "sh" "-c")
+        "args" (list (printf "echo 'Waiting for NATS service'; until nc -z -v -w5 %s 4222; do echo 'NATS not ready yet'; sleep 2; done; echo 'NATS service ready'" $.Values.service.name))
+      )
+    )
   )
 ) }}
 {{- $_ := set . "patch" list }}


### PR DESCRIPTION
When starting nats, the `nats-test-request-reply` test always seems to fail. If I delete the `nats-test-request-reply` pod and recreate it, the test completes. I think this might be because the Service isn't ready yet. This means the test always errors with this on first try:

```
nats: error: dial tcp 10.43.184.145:4222
```

I added an initContainer that checks to see if the service is accessible before the nats request test happens. This has made the task complete each time. 