### PR TITLE
feat(nack): Add global.labels and control loop mode switch

### DIFF
--- a/helm/charts/nack/Chart.yaml
+++ b/helm/charts/nack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nack
-version: 0.31.1
+version: 0.32.0
 appVersion: 0.21.1
 description: A Helm chart for NACK - NAts Controller for Kubernetes
 keywords:

--- a/helm/charts/nack/templates/_helpers.tpl
+++ b/helm/charts/nack/templates/_helpers.tpl
@@ -31,6 +31,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+{{- with ((.Values.global).labels) }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -22,7 +22,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "jsc.selectorLabels" . | nindent 8 }}
+        {{- include "jsc.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -114,6 +114,12 @@ spec:
           {{- if .Values.jetstream.tls.tlsFirst }}
           - --tlsfirst={{ .Values.jetstream.tls.tlsFirst }}
           {{- end }}
+          {{- if or .Values.jetstream.controlLoop (has "--control-loop" .Values.jetstream.additionalArgs) }}
+          - --health-probe-bind-address=:8081
+          {{- if not (has "--control-loop" .Values.jetstream.additionalArgs) }} # Do not duplicate the flag for upgrading users
+          - --control-loop
+          {{- end }}
+          {{- end }}
           {{- with .Values.jetstream.additionalArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -129,6 +135,20 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if or .Values.jetstream.controlLoop (has "--control-loop" .Values.jetstream.additionalArgs) }}
+          livenessProbe:
+            httpGet:
+                path: /healthz
+                port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+                path: /readyz
+                port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nack/templates/rbac-jetstream-controller.yml
+++ b/helm/charts/nack/templates/rbac-jetstream-controller.yml
@@ -7,12 +7,16 @@ kind: ServiceAccount
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}
   namespace: {{ include "jsc.namespace" . }}
+  labels:
+    {{- include "jsc.labels" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $kind }}
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-{{ $kindSuffix }}
   namespace: {{ include "jsc.namespace" . }}
+  labels:
+    {{- include "jsc.labels" . | nindent 4 }}
 {{ tpl .Values.rbacRules . }}
 
 ---
@@ -21,6 +25,8 @@ kind: {{ printf "%sBinding" $kind}}
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-{{ $kindSuffix }}-binding
   namespace: {{ include "jsc.namespace" . }}
+  labels:
+    {{- include "jsc.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "jsc.serviceAccountName" . }}

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -3,6 +3,11 @@
 #  NACK JetStream Controller  #
 #                             #
 ###############################
+
+global:
+  # global labels will be applied to all resources deployed by the chart
+  labels: {}
+
 jetstream:
   enabled: true
   image:
@@ -47,10 +52,11 @@ jetstream:
       timeout: 3
 
   # Additional arguments to pass to the controller process
-  # Enable controller-runtime backend
-  # additionalArgs:
-  # - --control-loop
   additionalArgs: []
+
+  # Enable controller-runtime backend
+  # See https://github.com/nats-io/nack/blob/50d1f5/README.md#controller-modes
+  controlLoop: false
 
 # restrict the controller to only watch resources in it's current namespace
 namespaced: false


### PR DESCRIPTION
* Adds `.Values.global.labels`, [aligned](https://github.com/nats-io/k8s/blob/56223ee0c8a14200008e255de5a9fe5bdde407c8/helm/charts/nats/values.yaml#L17-L18) to the same val in the `nats` chart.
* Normalizes labels across all resources
* Add a first-party `--control-loop` mode switch. Backward compatible with upgrading users who enable this mode via `additionalArgs`. 
* In the `--control-loop` mode, `/healthz` and `/readyz` probe endpoints are [available](https://github.com/nats-io/nack/blob/50d1f5dded27c8b1836bc38f659f5795d93d2813/cmd/jetstream-controller/main.go#L218-L223) and set in the chart.