### PR TITLE
feat(surveyor) Add global.labels & normalize serviceMonitor meta

### DIFF
--- a/helm/charts/surveyor/templates/_helpers.tpl
+++ b/helm/charts/surveyor/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "surveyor.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with ((.Values.global).labels) }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "surveyor.selectorLabels" . | nindent 8 }}
+        {{- include "surveyor.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -111,6 +111,10 @@ spec:
                   key: {{ .Values.config.password.secret.key }}
             {{- end }}
           livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
             httpGet:
               path: /healthz
               port: http

--- a/helm/charts/surveyor/templates/serviceMonitor.yaml
+++ b/helm/charts/surveyor/templates/serviceMonitor.yaml
@@ -3,13 +3,14 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "surveyor.fullname" . }}
-  {{- if .Values.serviceMonitor.labels }}
   labels:
-    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
-  {{- end }}
-  {{- if .Values.serviceMonitor.annotations }}
+    {{- include "surveyor.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
   annotations:
-    {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   endpoints:

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # global labels will be applied to all resources deployed by the chart
+  labels: {}
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
* Adds `.Values.global.labels`, [aligned](https://github.com/nats-io/k8s/blob/56223ee0c8a14200008e255de5a9fe5bdde407c8/helm/charts/nats/values.yaml#L17-L18) to the same val in the `nats` chart.
* Normalizes labels and annotations in `ServiceMonitor`
* nit: reuse health endpoint for readinessProbe