### PR TITLE
adding nodeSelector and tolerations to nats helm-chart

### DIFF
--- a/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
+++ b/helm/charts/nats/files/nats-box/deployment/pod-template.yaml
@@ -2,6 +2,15 @@ metadata:
   labels:
     {{- include "natsBox.labels" $ | nindent 4 }}
 spec:
+  {{- with .Values.natsBox.podTemplate.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.natsBox.podTemplate.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
   {{- with .Values.natsBox.container }}
   - {{ include "nats.loadMergePatch" (merge (dict "file" "nats-box/deployment/container.yaml" "ctx" $) .) | nindent 4 }}

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -7,6 +7,15 @@ metadata:
     checksum/config: {{ sha256sum $configMap }}
     {{- end }}
 spec:
+  {{- with .Values.podTemplate.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.podTemplate.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
   # nats
   {{- $nats := dict }}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -494,6 +494,14 @@ podTemplate:
   #
   topologySpreadConstraints: {}
 
+  # node selection for NATS StatefulSet pods
+  # if empty, Kubernetes will schedule on any node
+  nodeSelector: {}
+
+  # tolerations for NATS StatefulSet pods
+  # if empty, no tolerations are applied
+  tolerations: []
+
   # merge or patch the pod template
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pod-v1-core
   merge: {}
@@ -619,6 +627,14 @@ natsBox:
 
   # deployment -> pod template
   podTemplate:
+    # node selection for nats-box pods
+    # if empty, Kubernetes will schedule on any node
+    nodeSelector: {}
+
+    # tolerations for nats-box pods
+    # if empty, no tolerations are applied
+    tolerations: []
+    
     # merge or patch the pod template
     # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pod-v1-core
     merge: {}


### PR DESCRIPTION
What motivated this proposal?
I would like to deploy NATS on AWS Graviton (arm64) node pools. Both the NATS and prometheus-nats-exporter images provide multi‑arch support (amd64 and arm64), so the chart is already compatible with this architecture.

What is the proposed change?
Add nodeSelector and tolerations configuration to the NATS Helm chart templates and values.yaml, so users can explicitly target particular node pools and architectures for the NATS and exporter pods.

Who benefits from this change?
Users running heterogeneous clusters (for example, mixed amd64 and arm64 pools) can more easily schedule NATS onto cost‑efficient node pools such as AWS Graviton, without having to maintain custom chart forks or extensive overrides.