### PR TITLE
helm/nack: add env support for jetstream-controller

### DIFF
--- a/helm/charts/nack/templates/_helpers.tpl
+++ b/helm/charts/nack/templates/_helpers.tpl
@@ -87,3 +87,20 @@ Print the image
 {{- end }}
 {{- $image -}}
 {{- end }}
+
+{{/*
+Render environment variables from a map.
+Supports both simple string values and complex valueFrom references.
+*/}}
+{{- define "jsc.env" -}}
+{{- range $k, $v := . }}
+{{- if kindIs "string" $v }}
+- name: {{ $k | quote }}
+  value: {{ $v | quote }}
+{{- else if kindIs "map" $v }}
+- {{ merge (dict "name" $k) $v | toYaml | nindent 2 }}
+{{- else }}
+{{- fail (cat "env var" $k "must be string or map, got" (kindOf $v)) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/charts/nack/templates/deployment-jetstream-controller.yml
+++ b/helm/charts/nack/templates/deployment-jetstream-controller.yml
@@ -135,6 +135,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- with .Values.jetstream.env }}
+          {{- include "jsc.env" . | nindent 10 }}
+          {{- end }}
           {{- if or .Values.jetstream.controlLoop (has "--control-loop" .Values.jetstream.additionalArgs) }}
           livenessProbe:
             httpGet:

--- a/helm/charts/nack/values.yaml
+++ b/helm/charts/nack/values.yaml
@@ -51,6 +51,18 @@ jetstream:
       client_ca: "/etc/nats/certs/ca.crt"
       timeout: 3
 
+  # Environment variables to add to the controller container
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+  #
+  # env:
+  #   GOMEMLIMIT: 7GiB
+  #   MY_SECRET:
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: my-secret
+  #         key: token
+  env: {}
+
   # Additional arguments to pass to the controller process
   additionalArgs: []
 


### PR DESCRIPTION
## Summary

- Adds `jetstream.env` to the NACK Helm chart values, allowing users to configure environment variables on the jetstream-controller container
- Follows the same pattern as the NATS chart's `container.env` — supports both simple string values (`GOMEMLIMIT: 7GiB`) and complex `valueFrom` references (secrets, configmaps, field refs)
- Addresses OOMKill crashes by enabling `GOMEMLIMIT` configuration without manual deployment patching

Closes nats-io/nack#341