### PR TITLE
Fix README typo and broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 In this repository you can find several examples of how to deploy NATS, NATS Streaming 
 and other tools from the NATS ecosystem on Kubernetes.
 
-- [NATS Helm Chart](https://github.com/nats-io/k8s/tree/main/helm/charts/nats#jetstream)
+- [NATS Helm Chart](https://github.com/nats-io/k8s/tree/main/helm/charts/nats)
 - [NATS Surveyor Chart](https://github.com/nats-io/k8s/tree/main/helm/charts/surveyor)
 - [NATS JetStream Controller Chart](https://github.com/nats-io/k8s/tree/main/helm/charts/nack)
 

--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -12,7 +12,7 @@ helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm upgrade --install nats nats/nats
 ```
 
-## Upgrade Nodes
+## Upgrade Notes
 
 - **Upgrading from 0.x**: The `values.yaml` schema changed significantly from 0.x to 1.x.  Read [UPGRADING.md](UPGRADING.md) for instructions on upgrading a 0.x release to 1.x.
 


### PR DESCRIPTION
- Fix "Upgrade Nodes" → "Upgrade Notes" typo in nats chart README heading
- Remove broken `#jetstream` anchor fragment from NATS chart link in root README