### PR TITLE
Update EOL tool versions in CI workflows

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 18
+          node-version: 22
       
       - name: Install semver
         run: |-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,14 +29,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.11.2
+          version: v3.20.0
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0


### PR DESCRIPTION
Update EOL tool versions: Python 3.9 → 3.12, Helm v3.11.2 → v3.20.0, Node 18 → 22.