### PR TITLE
fix: omit namespace in ClusterRole(Binding)

### DIFF
--- a/helm/charts/nack/templates/rbac-jetstream-controller.yml
+++ b/helm/charts/nack/templates/rbac-jetstream-controller.yml
@@ -14,7 +14,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $kind }}
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-{{ $kindSuffix }}
+  {{- if .Values.namespaced }}
   namespace: {{ include "jsc.namespace" . }}
+  {{- end }}
   labels:
     {{- include "jsc.labels" . | nindent 4 }}
 {{ tpl .Values.rbacRules . }}
@@ -24,7 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ printf "%sBinding" $kind}}
 metadata:
   name: {{ template "jsc.serviceAccountName" . }}-{{ $kindSuffix }}-binding
+  {{- if .Values.namespaced }}
   namespace: {{ include "jsc.namespace" . }}
+  {{- end }}
   labels:
     {{- include "jsc.labels" . | nindent 4 }}
 subjects:


### PR DESCRIPTION
Previously the `namespace` field was always set, even if namespaced mode was not enabled. The `namespace` field is not valid on cluster-scoped resources like `ClusterRole(Binding)`s and leads to weird diff results in some gitops tools.