### PR TITLE
feat(surveyor): emit metadata.namespace on all rendered resources

### DIFF
--- a/helm/charts/surveyor/templates/_helpers.tpl
+++ b/helm/charts/surveyor/templates/_helpers.tpl
@@ -54,6 +54,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Define the namespace where the content of the chart will be deployed.
+Defaults to .Release.Namespace; can be overridden via .Values.namespaceOverride.
+*/}}
+{{- define "surveyor.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "surveyor.serviceAccountName" -}}

--- a/helm/charts/surveyor/templates/configmap.yaml
+++ b/helm/charts/surveyor/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "surveyor.fullname" . }}-accounts
+  namespace: {{ include "surveyor.namespace" . }}
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
 data:

--- a/helm/charts/surveyor/templates/deployment.yaml
+++ b/helm/charts/surveyor/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "surveyor.fullname" . }}
+  namespace: {{ include "surveyor.namespace" . }}
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/surveyor/templates/hpa.yaml
+++ b/helm/charts/surveyor/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "surveyor.fullname" . }}
+  namespace: {{ include "surveyor.namespace" . }}
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/surveyor/templates/ingress.yaml
+++ b/helm/charts/surveyor/templates/ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "surveyor.namespace" . }}
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/helm/charts/surveyor/templates/service.yaml
+++ b/helm/charts/surveyor/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "surveyor.fullname" . }}
+  namespace: {{ include "surveyor.namespace" . }}
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/surveyor/templates/serviceAccount.yaml
+++ b/helm/charts/surveyor/templates/serviceAccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "surveyor.serviceAccountName" . }}
+  namespace: {{ include "surveyor.namespace" . }}
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/charts/surveyor/templates/serviceMonitor.yaml
+++ b/helm/charts/surveyor/templates/serviceMonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "surveyor.fullname" . }}
+  namespace: {{ include "surveyor.namespace" . }}
   labels:
     {{- include "surveyor.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}

--- a/helm/charts/surveyor/values.yaml
+++ b/helm/charts/surveyor/values.yaml
@@ -17,6 +17,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 podAnnotations: {}
 


### PR DESCRIPTION
## Summary

The surveyor chart never populated `metadata.namespace` in its rendered output, relying on `helm install -n <ns>` to apply the namespace via the Kubernetes API instead. This works fine for direct-install flows but breaks any workflow that renders templates statically and applies them later (`helm template -n <ns> | kubectl apply -f -`, kustomize+helm, ArgoCD/Flux): the manifest carries no namespace field, so resources land in the kubectl client's current context (typically `default`) instead of the namespace passed to `helm template`.

This PR adds a `surveyor.namespace` helper following the same `jsc.namespace` pattern used by the [nack chart](../charts/nack/templates/_helpers.tpl) in this repo, and emits `namespace:` in every template's metadata block (Service, ServiceAccount, Deployment, ConfigMap, HPA, Ingress, ServiceMonitor). It defaults to `.Release.Namespace` and can be overridden via `.Values.namespaceOverride`.

This was discovered while migrating to Pulumi's `pulumi-kubernetes` v4.30, which bundles `kustomize/api` v0.21 — that release [intentionally changed](https://github.com/kubernetes-sigs/kustomize/issues/5566) the namespace transformer so the kustomization-level `namespace:` directive no longer post-injects `metadata.namespace` into helm output. Charts that don't emit the field themselves end up namespace-less.

## Behaviour change matrix

| Workflow | Before | After |
|---|---|---|
| `helm install -n my-ns` | works | works (no diff) |
| `helm template -n my-ns \| kubectl apply -f -` | **silently** lands in kubectl's current ns | lands in `my-ns` |
| `helm template -n my-ns \| kubectl apply -n my-ns -f -` | works | works (the `-n` flag is now redundant but harmless) |
| `helm template \| kubectl apply -n target-ns -f -` | works (no manifest ns, kubectl `-n` wins) | resources land in `default` because manifest ns now wins |

The last row is the only true breaking change. It's an antipattern (the right form is `helm template -n target-ns`), but worth calling out.