### PR TITLE
Expose graceful shutdown and health probe settings as chart values

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -145,6 +145,29 @@ container:
         memory: 8Gi
 ```
 
+### Graceful Shutdown and Health Probes
+
+On pod shutdown, a `preStop` hook puts the NATS Server into [lame duck mode](https://docs.nats.io/running-a-nats-service/nats_admin/lame_duck_mode).
+The server waits `config.lameDuckGracePeriod` before it begins evicting clients, then spreads client evictions over `config.lameDuckDuration`.
+`podTemplate.terminationGracePeriodSeconds` should allow time for both, plus roughly 20s of shutdown overhead.
+
+The nats container's `startupProbe`, `readinessProbe`, and `livenessProbe` are applied whenever `config.monitor` is enabled (the default), and their defaults follow the recommended [NATS health check configuration](https://docs.nats.io/running-a-nats-service/nats_admin/monitoring#health-healthz).
+`scheme: HTTPS` is added automatically when `config.monitor.tls` is enabled.
+Probe fields set in your values are deep-merged over the chart defaults.
+Example - extend the lame duck window and relax the liveness probe:
+
+```yaml
+config:
+  lameDuckGracePeriod: 10s
+  lameDuckDuration: 2m
+container:
+  livenessProbe:
+    periodSeconds: 60
+podTemplate:
+  # 10s grace period + 2m duration + 20s overhead
+  terminationGracePeriodSeconds: 150
+```
+
 ### Specify Image Version
 
 The container image can now be overridden by specifying either the image tag, an image digest, or a full image name. Examples below illustrate the options:

--- a/helm/charts/nats/files/config/config.yaml
+++ b/helm/charts/nats/files/config/config.yaml
@@ -1,8 +1,8 @@
 {{- with .Values.config }}
 
 server_name: << $SERVER_NAME >>
-lame_duck_grace_period: 10s
-lame_duck_duration: 30s
+lame_duck_grace_period: {{ .lameDuckGracePeriod | quote }}
+lame_duck_duration: {{ .lameDuckDuration | quote }}
 pid_file: /var/run/nats/nats.pid
 
 ########################################

--- a/helm/charts/nats/files/stateful-set/nats-container.yaml
+++ b/helm/charts/nats/files/stateful-set/nats-container.yaml
@@ -35,42 +35,16 @@ lifecycle:
 
 {{- with .Values.config.monitor }}
 {{- if .enabled }}
+{{- $tlsPatch := dict }}
+{{- if .tls.enabled }}
+{{- $tlsPatch = dict "httpGet" (dict "scheme" "HTTPS") }}
+{{- end }}
 startupProbe:
-  httpGet:
-    path: /healthz
-    port: monitor
-    {{- if .tls.enabled }}
-    scheme: HTTPS
-    {{- end}}
-  initialDelaySeconds: 10
-  timeoutSeconds: 5
-  periodSeconds: 10
-  successThreshold: 1
-  failureThreshold: 90
+  {{- mergeOverwrite (deepCopy $.Values.container.startupProbe) $tlsPatch | toYaml | nindent 2 }}
 readinessProbe:
-  httpGet:
-    path: /healthz?js-server-only=true
-    port: monitor
-    {{- if .tls.enabled }}
-    scheme: HTTPS
-    {{- end}}
-  initialDelaySeconds: 10
-  timeoutSeconds: 5
-  periodSeconds: 10
-  successThreshold: 1
-  failureThreshold: 3
+  {{- mergeOverwrite (deepCopy $.Values.container.readinessProbe) $tlsPatch | toYaml | nindent 2 }}
 livenessProbe:
-  httpGet:
-    path: /healthz?js-enabled-only=true
-    port: monitor
-    {{- if .tls.enabled }}
-    scheme: HTTPS
-    {{- end}}
-  initialDelaySeconds: 10
-  timeoutSeconds: 5
-  periodSeconds: 30
-  successThreshold: 1
-  failureThreshold: 3
+  {{- mergeOverwrite (deepCopy $.Values.container.livenessProbe) $tlsPatch | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/helm/charts/nats/files/stateful-set/pod-template.yaml
+++ b/helm/charts/nats/files/stateful-set/pod-template.yaml
@@ -71,5 +71,6 @@ spec:
   {{- end}}
   
   # terminationGracePeriodSeconds determines how long to wait for graceful shutdown
-  # this should be at least `lameDuckGracePeriod` + 20s shutdown overhead
-  terminationGracePeriodSeconds: 60
+  # this should be at least config.lameDuckGracePeriod + config.lameDuckDuration
+  # + 20s shutdown overhead
+  terminationGracePeriodSeconds: {{ .Values.podTemplate.terminationGracePeriodSeconds }}

--- a/helm/charts/nats/test/resources_test.go
+++ b/helm/charts/nats/test/resources_test.go
@@ -662,3 +662,36 @@ natsBox:
 
 	RenderAndCheck(t, test, expected)
 }
+
+func TestGracefulShutdownAndProbeOptions(t *testing.T) {
+	t.Parallel()
+	test := DefaultTest()
+	test.Values = `
+config:
+  lameDuckGracePeriod: 5s
+  lameDuckDuration: 2m
+container:
+  startupProbe:
+    failureThreshold: 120
+  readinessProbe:
+    httpGet:
+      path: /healthz
+  livenessProbe:
+    periodSeconds: 60
+podTemplate:
+  terminationGracePeriodSeconds: 150
+`
+	expected := DefaultResources(t, test)
+
+	expected.Conf.Value["lame_duck_grace_period"] = "5s"
+	expected.Conf.Value["lame_duck_duration"] = "2m"
+
+	ctr := &expected.StatefulSet.Value.Spec.Template.Spec.Containers[0]
+	ctr.StartupProbe.FailureThreshold = 120
+	ctr.ReadinessProbe.HTTPGet.Path = "/healthz"
+	ctr.LivenessProbe.PeriodSeconds = 60
+
+	expected.StatefulSet.Value.Spec.Template.Spec.TerminationGracePeriodSeconds = int64Ptr(150)
+
+	RenderAndCheck(t, test, expected)
+}

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -274,6 +274,15 @@ config:
     merge: {}
     patch: []
 
+  # period the server waits after entering lame duck mode before starting
+  # to evict clients
+  lameDuckGracePeriod: 10s
+  # period over which the server evicts all clients after the grace period
+  # https://docs.nats.io/running-a-nats-service/nats_admin/lame_duck_mode
+  # note: podTemplate.terminationGracePeriodSeconds should be at least
+  # lameDuckGracePeriod + lameDuckDuration + 20s shutdown overhead
+  lameDuckDuration: 30s
+
   # adds a prefix to the server name, which defaults to the pod name
   # helpful for ensuring server name is unique in a super cluster
   serverNamePrefix: ""
@@ -350,6 +359,37 @@ container:
   #           name: nats-auth
   #           key: token
   env: {}
+
+  # probes are only applied when config.monitor is enabled
+  # scheme is set to HTTPS automatically when config.monitor.tls is enabled
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: monitor
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 90
+  readinessProbe:
+    httpGet:
+      path: /healthz?js-server-only=true
+      port: monitor
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+  livenessProbe:
+    httpGet:
+      path: /healthz?js-enabled-only=true
+      port: monitor
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 3
 
   # merge or patch the container
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#container-v1-core
@@ -484,6 +524,11 @@ podTemplate:
   # this will cause the StatefulSet to roll when the ConfigMap is updated
   # set to true to force pod rollouts on config changes instead of using the reloader for hot updates
   configChecksumAnnotation: false
+
+  # how long to wait for graceful shutdown
+  # should be at least config.lameDuckGracePeriod + config.lameDuckDuration
+  # + 20s shutdown overhead
+  terminationGracePeriodSeconds: 60
 
   # map of topologyKey: topologySpreadConstraint
   # labelSelector will be added to match StatefulSet pods


### PR DESCRIPTION
## Motivation

The chart already ships well-chosen defaults for graceful shutdown and health checking, but they are hardcoded inside the `files/` templates and never appear in `values.yaml`. Users cannot discover them, and tuning them requires knowing the generic `merge`/`patch` mechanism and the exact template internals. In practice this leads to misconfigured shutdowns (a JetStream data risk when the lame duck window exceeds the termination grace period) and copy-pasted probe overrides. This PR promotes those settings to first-class, documented values while keeping the rendered defaults byte-identical to the current release.

## What changed

- `config.lameDuckGracePeriod` (default `10s`) and `config.lameDuckDuration` (default `30s`) now drive `lame_duck_grace_period` and `lame_duck_duration` in the generated config, with comments documenting the relationship to the termination grace period.
- `container.startupProbe`, `container.readinessProbe`, and `container.livenessProbe` are now full probe objects in values, copied verbatim from the previously hardcoded blocks. User values deep-merge over the defaults, so setting a single field (for example `livenessProbe.periodSeconds`) keeps every other default. Probes remain applied only when `config.monitor` is enabled, and `scheme: HTTPS` is still added automatically when `config.monitor.tls` is enabled.
- `podTemplate.terminationGracePeriodSeconds` (default `60`) replaces the hardcoded value, and the adjacent comment now states the correct arithmetic (`lameDuckGracePeriod + lameDuckDuration + ~20s` overhead).
- New test `TestGracefulShutdownAndProbeOptions` covers overrides of all of the above, including partial probe overrides.
- New README section "Graceful Shutdown and Health Probes" documents the shutdown flow, the grace period arithmetic, probe gating, and an override example.

## Backwards compatibility

Rendered defaults are byte-identical to `main`. The new values render in the same first pass that previously emitted the hardcoded blocks, before `nats.loadMergePatch` applies user `merge`/`patch` input, so every existing override via `config.merge`, `container.merge`, `container.patch`, or `podTemplate.merge` produces exactly the same output as before. The existing golden assertions in `defaults_test.go` continue to lock in every default value.

## What was tested

- `go test` in `helm/charts/nats/test` passes, including the new `TestGracefulShutdownAndProbeOptions`.
- `helm lint` is clean and the repository nindent CI check was replicated locally.
- Byte-identical render verification: `helm template` output with default values diffed against the pre-change base, both with defaults and with monitor TLS enabled (exercising the automatic `scheme: HTTPS` merge path); both diffs were empty.
- Override smoke test: `--set config.lameDuckDuration=2m --set podTemplate.terminationGracePeriodSeconds=150 --set container.livenessProbe.periodSeconds=60` rendered the overrides with all untouched defaults preserved.
- Live cluster verification on a 3-node bare-metal Talos cluster running Kubernetes v1.35.0, with a 3-replica JetStream-enabled deployment: a default install came up healthy with probes, termination grace period, and lame duck settings identical to the previously hardcoded values; an upgrade with overrides (`lameDuckGracePeriod: 5s`, `lameDuckDuration: 1m`, `terminationGracePeriodSeconds: 90`, plus partial probe overrides) propagated to the live StatefulSet and ConfigMap with untouched probe fields preserved, confirming the deep-merge behavior live.
- Live graceful shutdown test: deleting a pod with a connected client showed the full flow in the server logs, with the preStop hook entering lame duck mode, JetStream shutting down, the overridden 5s grace period honored, the client evicted and reconnecting to another server, and a clean server exit in about 7 seconds, well inside the termination grace period; the pod then rejoined the cluster.
- Live HTTPS probe path verification on the same cluster, following the optional step 8 in How To Test: with a self-signed certificate and `config.nats.tls` plus `config.monitor.tls` enabled, all three probes switched to `scheme: HTTPS` while a deliberate `livenessProbe.periodSeconds` override was preserved (the automatic TLS patch composes with user overrides), the generated config switched to `https_port`, healthz answered `{"status":"ok"}` over HTTPS, and the rollout completed with the kubelet successfully probing over HTTPS.

## Not covered

- `ct lint` and `ct install` were not run locally; CI runs them against Kubernetes 1.30-1.32.
- No `Chart.yaml` version bump is included, following the repository convention that chart-only changes ship with the next release.

## How To Test

Prerequisites: a Kubernetes cluster with a default StorageClass (for the JetStream PVC), plus `kubectl`, `helm`, `git`, `jq`, and Go 1.24+ on your workstation. All commands run from the repository root with this branch checked out. The walkthrough creates everything in a throwaway `nats-test` namespace and removes it at the end.

### 1. Read the diff

Run `git diff main...HEAD` and focus on the pairing between new values and the templates that consume them: 
* the three probe objects and the two lame duck keys in `helm/charts/nats/values.yaml`
* the `mergeOverwrite` probe rendering in `helm/charts/nats/files/stateful-set/nats-container.yaml`
* the templated lame duck lines in `helm/charts/nats/files/config/config.yaml`
* the templated grace period in `helm/charts/nats/files/stateful-set/pod-template.yaml`. 
 
The claim to verify throughout: the defaults in values are verbatim copies of the blocks that were deleted from the templates.

### 2. Run the unit tests

```
cd helm/charts/nats/test && go test && cd -
```

All tests should pass, including the new `TestGracefulShutdownAndProbeOptions`.

### 3. Prove the rendered defaults are unchanged

This is the core backwards-compatibility claim. Render the chart from `main` and from this branch and diff the output, first with default values, then with monitor TLS enabled to exercise the automatic `scheme: HTTPS` path:

```
tmp=$(mktemp -d)
git archive main helm/charts/nats | tar -x -C "$tmp"
diff <(helm template my-nats "$tmp/helm/charts/nats") <(helm template my-nats helm/charts/nats)
diff <(helm template my-nats "$tmp/helm/charts/nats" --set config.nats.tls.enabled=true --set config.nats.tls.secretName=nats-tls --set config.monitor.tls.enabled=true) \
     <(helm template my-nats helm/charts/nats --set config.nats.tls.enabled=true --set config.nats.tls.secretName=nats-tls --set config.monitor.tls.enabled=true)
```

With the exception of newer version numbers, both diffs must be empty. In the TLS render, confirm the probes carry `scheme: HTTPS` (`helm template ... | grep -B1 HTTPS`).

### 4. Install with defaults

```
cat > /tmp/values-defaults.yaml <<'EOF'
config:
  cluster:
    enabled: true
    replicas: 3
  jetstream:
    enabled: true
    fileStore:
      pvc:
        size: 1Gi
EOF
helm install nats helm/charts/nats -n nats-test --create-namespace -f /tmp/values-defaults.yaml
kubectl rollout status statefulset/nats -n nats-test --timeout=180s
```

All pods reaching Ready is itself a probe test: readiness now comes from the values-driven probe definitions.

### 5. Verify the live defaults match the previously hardcoded values

```
kubectl get statefulset nats -n nats-test -o jsonpath='{.spec.template.spec.terminationGracePeriodSeconds}{"\n"}'
kubectl get statefulset nats -n nats-test -o json | jq '.spec.template.spec.containers[] | select(.name=="nats") | {startupProbe, readinessProbe, livenessProbe}'
kubectl get configmap nats-config -n nats-test -o jsonpath='{.data.nats\.conf}' | grep lame_duck
```

Expect: 
* grace period `60`
* startup probe `/healthz` with failureThreshold 90
* readiness probe `/healthz?js-server-only=true`
* liveness probe `/healthz?js-enabled-only=true` with periodSeconds 30
* all probes with initialDelaySeconds 10 and timeoutSeconds 5
* `lame_duck_grace_period: "10s"` and `lame_duck_duration: "30s"`. 

These are exactly the values hardcoded on `main`.

### 6. Upgrade with overrides and verify deep-merge

The partial probe overrides are the interesting part: each one changes a single field, and every field you did not set must keep its default.

```
cat > /tmp/values-overrides.yaml <<'EOF'
config:
  cluster:
    enabled: true
    replicas: 3
  jetstream:
    enabled: true
    fileStore:
      pvc:
        size: 1Gi
  lameDuckGracePeriod: 5s
  lameDuckDuration: 1m
container:
  startupProbe:
    failureThreshold: 120
  readinessProbe:
    httpGet:
      path: /healthz
  livenessProbe:
    periodSeconds: 60
podTemplate:
  terminationGracePeriodSeconds: 90
EOF
helm upgrade nats helm/charts/nats -n nats-test -f /tmp/values-overrides.yaml
kubectl rollout status statefulset/nats -n nats-test --timeout=300s
```

Re-run the step 5 commands. Expect the overridden fields:
* `terminationGracePeriodSeconds: 90`
* startup failureThreshold 120, 
* readiness path `/healthz`
* liveness periodSeconds 60
* lame duck `5s`/`1m`

alongside untouched defaults
* startup initialDelaySeconds still 10
* readiness failureThreshold still 3
* liveness path still `/healthz?js-enabled-only=true`

If those defaults survived, the deep-merge works.

### 7. Watch a graceful shutdown honor the overridden lame duck settings

Open three terminals. In the first, attach a client directly to one pod; in the second, follow that pod's logs; in the third, delete the pod and time it:

```
kubectl exec -it -n nats-test deploy/nats-box -- nats sub 'test.>' -s nats://nats-1.nats-headless:4222
kubectl logs -f nats-1 -c nats -n nats-test --timestamps
time kubectl delete pod nats-1 -n nats-test
```

Expect, in order: 
* the log line `Entering lame duck mode, stop accepting new clients` immediately after the delete (the preStop hook)
*  `Initiating JetStream Shutdown`
* then roughly 5 seconds later (the overridden `lameDuckGracePeriod`) `Initiating Shutdown...` and `Server Exiting`
* the subscriber prints `Disconnected due to: EOF, will attempt reconnect`
* the delete returns in well under the 90 second grace period (about 7 seconds with a single client, since eviction spreading over `lameDuckDuration` only matters with many clients). 
 
Afterwards `kubectl get pods -n nats-test` should show the pod recreated and back to 2/2 Ready.

### 8. Optional: exercise the HTTPS probe path live

This works on any cluster; cert-manager is not required. Two facts make it cheap: kubelet does not verify certificates on `httpGet` probes with `scheme: HTTPS`, so a self-signed certificate is sufficient, and per the chart the monitor port reuses the certificate from `config.nats.tls`, which must also be enabled (see the comment in `values.yaml` under `config.monitor.tls`). Because that also enables TLS on the client port 4222, the plain nats-box subscriber from step 7 would fail certificate verification against a self-signed cert, so run this step last (or pass the CA to the CLI with `--tlsca`). Like every step, run the commands from the repository root: helm otherwise reinterprets the relative chart path `helm/charts/nats` as a `<repository>/<chart>` reference and fails with `Error: repo helm not found`. This step also works standalone: if the `nats-test` namespace from step 4 no longer exists, create it first with `kubectl create namespace nats-test` (the TLS secret must land in an existing namespace), and the `--install` flag below handles the missing release.

```
openssl req -x509 -newkey rsa:2048 -nodes -keyout /tmp/tls.key -out /tmp/tls.crt -days 7 \
  -subj "/CN=nats" -addext "subjectAltName=DNS:nats,DNS:nats.nats-test.svc,DNS:*.nats-headless.nats-test.svc.cluster.local"
kubectl create secret tls nats-tls -n nats-test --cert=/tmp/tls.crt --key=/tmp/tls.key
cat > /tmp/values-tls.yaml <<'EOF'
config:
  cluster:
    enabled: true
    replicas: 3
  jetstream:
    enabled: true
    fileStore:
      pvc:
        size: 1Gi
  nats:
    tls:
      enabled: true
      secretName: nats-tls
  monitor:
    tls:
      enabled: true
container:
  livenessProbe:
    periodSeconds: 60
EOF
helm upgrade --install nats helm/charts/nats -n nats-test -f /tmp/values-tls.yaml
kubectl rollout status statefulset/nats -n nats-test --timeout=300s
```

The single probe override is kept on purpose: it shows the automatic TLS patch composing with a user override rather than clobbering it. Verify:

```
kubectl get statefulset nats -n nats-test -o json | jq '.spec.template.spec.containers[] | select(.name=="nats") | {startup: .startupProbe.httpGet.scheme, ready: .readinessProbe.httpGet.scheme, live: .livenessProbe.httpGet.scheme, livePeriod: .livenessProbe.periodSeconds}'
kubectl get configmap nats-config -n nats-test -o jsonpath='{.data.nats\.conf}' | grep https_port
kubectl port-forward -n nats-test nats-0 8222:8222 &
curl -ks https://localhost:8222/healthz
kill %1
```

Expect all three probe schemes
* to be `HTTPS` with `livePeriod` still 60
* `https_port: 8222` in the generated config
* `{"status":"ok"}` from healthz over HTTPS. 

The strongest signal is the rollout itself completing: pods only reach Ready if the kubelet is successfully probing `/healthz` over HTTPS.

### 9. Clean up

```
helm uninstall nats -n nats-test
kubectl delete namespace nats-test
rm /tmp/tls.key /tmp/tls.crt /tmp/values-*.yaml
```

The namespace deletion removes the JetStream PVCs created by the StatefulSet and the TLS secret.
