### PR TITLE
Address review feedback on leafnode remotesHelm chart values

### DIFF
--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -215,7 +215,7 @@ config:
 ### Leafnode Remotes and Synadia Cloud (NGS)
 
 `config.leafnodes.remotes` solicits [leafnode](https://docs.nats.io/running-a-nats-service/configuration/leafnodes) connections to remote NATS servers, with credentials mounted from an existing Kubernetes Secret.
-The config reloader watches the mounted credentials and certificate files, so rotating the Secret hot-reloads the server.
+Rotating a mounted credentials or certificate Secret takes effect on the next connection attempt to the remote, not on established connections: the server reads the credentials file fresh on every attempt, and the config reloader re-applies changed certificate files for future attempts.
 
 Example - connect to [Synadia Cloud](https://docs.synadia.com/cloud) (NGS):
 
@@ -233,9 +233,28 @@ config:
         secretName: ngs-creds
 ```
 
-Each remote must set `url` or `urls`.
-`account` binds the remote to a local account, and a per-remote `tls` block mounts client certificates from a Secret; `tls://` URLs use TLS with system CAs without needing a `tls` block.
+Each remote must set `url` or `urls`; if both are set, they are combined.
+`account` binds the remote to a local account.
+The per-remote `tls` block must be enabled like the other `tls` blocks in the chart: enabling it forces a TLS connection to the remote, mounts client certificates from a Secret when `secretName` is set, and applies the global `tlsCA` as `ca_file`, which replaces the system CAs.
+`tls://` URLs use TLS with system CAs without needing a `tls` block, so leave it disabled for remotes with publicly trusted certificates such as NGS.
 Note that enabling leafnodes also opens the leafnode accept port (7422 by default) on this server.
+
+Example - connect to a hub that uses certificates from a private CA:
+
+```yaml
+tlsCA:
+  enabled: true
+  configMapName: private-ca
+config:
+  leafnodes:
+    enabled: true
+    remotes:
+    - url: tls://hub.example.com:7422
+      credentials:
+        secretName: hub-creds
+      tls:
+        enabled: true
+```
 
 Other remote options remain available through the leafnodes `patch` (note that setting `remotes` inside `config.leafnodes.merge` would replace the whole generated list):
 
@@ -249,7 +268,6 @@ config:
         secretName: hub-creds
     patch: [{op: add, path: /remotes/0/hub, value: true}]
 ```
-
 
 ## Accessing NATS
 

--- a/helm/charts/nats/README.md
+++ b/helm/charts/nats/README.md
@@ -212,6 +212,44 @@ config:
       SYS_ACCOUNT_ID: SYS_ACCOUNT_JWT
 ```
 
+### Leafnode Remotes and Synadia Cloud (NGS)
+
+`config.leafnodes.remotes` solicits [leafnode](https://docs.nats.io/running-a-nats-service/configuration/leafnodes) connections to remote NATS servers, with credentials mounted from an existing Kubernetes Secret.
+The config reloader watches the mounted credentials and certificate files, so rotating the Secret hot-reloads the server.
+
+Example - connect to [Synadia Cloud](https://docs.synadia.com/cloud) (NGS):
+
+```shell
+kubectl create secret generic ngs-creds --from-file=nats.creds=/path/to/ngs.creds
+```
+
+```yaml
+config:
+  leafnodes:
+    enabled: true
+    remotes:
+    - url: tls://connect.ngs.global:7422
+      credentials:
+        secretName: ngs-creds
+```
+
+Each remote must set `url` or `urls`.
+`account` binds the remote to a local account, and a per-remote `tls` block mounts client certificates from a Secret; `tls://` URLs use TLS with system CAs without needing a `tls` block.
+Note that enabling leafnodes also opens the leafnode accept port (7422 by default) on this server.
+
+Other remote options remain available through the leafnodes `patch` (note that setting `remotes` inside `config.leafnodes.merge` would replace the whole generated list):
+
+```yaml
+config:
+  leafnodes:
+    enabled: true
+    remotes:
+    - url: tls://hub.example.com:7422
+      credentials:
+        secretName: hub-creds
+    patch: [{op: add, path: /remotes/0/hub, value: true}]
+```
+
 
 ## Accessing NATS
 

--- a/helm/charts/nats/files/config/leafnodes.yaml
+++ b/helm/charts/nats/files/config/leafnodes.yaml
@@ -2,6 +2,34 @@
 port: {{ .port }}
 no_advertise: true
 
+{{- with .remotes }}
+remotes:
+{{- range $remote := . }}
+{{- if not (or $remote.url $remote.urls) }}
+{{- fail "config.leafnodes.remotes entries must set url or urls" }}
+{{- end }}
+- urls:
+  {{- with $remote.url }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- range $remote.urls }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- with $remote.account }}
+  account: {{ . | quote }}
+  {{- end }}
+  {{- with $remote.credentials }}
+  {{- if .secretName }}
+  credentials: {{ printf "%s/%s" (trimSuffix "/" .dir) .key | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with $remote.tls }}
+  tls:
+    {{- include "nats.loadMergePatch" (merge (dict "file" "config/tls.yaml" "ctx" (merge (dict "tls" .) $)) .) | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- with .tls }}
 {{- if .enabled }}
 tls:

--- a/helm/charts/nats/files/config/leafnodes.yaml
+++ b/helm/charts/nats/files/config/leafnodes.yaml
@@ -19,13 +19,16 @@ remotes:
   account: {{ . | quote }}
   {{- end }}
   {{- with $remote.credentials }}
-  {{- if .secretName }}
+  {{- if not .secretName }}
+  {{- fail "config.leafnodes.remotes credentials must set secretName" }}
+  {{- end }}
   credentials: {{ printf "%s/%s" (trimSuffix "/" .dir) .key | quote }}
   {{- end }}
-  {{- end }}
   {{- with $remote.tls }}
+  {{- if .enabled }}
   tls:
     {{- include "nats.loadMergePatch" (merge (dict "file" "config/tls.yaml" "ctx" (merge (dict "tls" .) $)) .) | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -86,6 +86,16 @@ Set default values.
   {{- end }}
   {{- $_ := set $ "hasContentsSecret" $hasContentsSecret }}
 
+  {{- range $i, $remote := .Values.config.leafnodes.remotes }}
+    {{- with $remote.credentials }}
+      {{- $_ := set . "dir" (.dir | default (printf "/etc/nats-creds/leafnodes-remote-%d" $i)) }}
+      {{- $_ := set . "key" (.key | default "nats.creds") }}
+    {{- end }}
+    {{- with $remote.tls }}
+      {{- $_ := set . "dir" (.dir | default (printf "/etc/nats-certs/leafnodes-remote-%d" $i)) }}
+    {{- end }}
+  {{- end }}
+
   {{- with .Values.config }}
   {{- $config := include "nats.loadMergePatch" (merge (dict "file" "config/config.yaml" "ctx" $) .) | fromYaml }}
   {{- $_ := set $ "config" $config }}
@@ -173,6 +183,20 @@ imagePullPolicy: {{ .pullPolicy | default .global.image.pullPolicy }}
     {{- $secrets = append $secrets (merge (dict "name" (printf "%s-tls" $protocol)) $configProtocol.tls) }}
   {{- end }}
 {{- end }}
+{{- if .Values.config.leafnodes.enabled }}
+  {{- range $i, $remote := .Values.config.leafnodes.remotes }}
+    {{- with $remote.credentials }}
+      {{- if .secretName }}
+        {{- $secrets = append $secrets (dict "name" (printf "leafnodes-remote-%d-creds" $i) "secretName" .secretName "dir" .dir) }}
+      {{- end }}
+    {{- end }}
+    {{- with $remote.tls }}
+      {{- if .secretName }}
+        {{- $secrets = append $secrets (dict "name" (printf "leafnodes-remote-%d-tls" $i) "secretName" .secretName "dir" .dir) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- toJson (dict "secretNames" $secrets) }}
 {{- end }}
 
@@ -258,7 +282,7 @@ output: YAML list of reloader config files
   {{- with .config -}}
   {{- if kindIs "map" . -}}
     {{- range $k, $v := . -}}
-      {{- if or (eq $k "cert_file") (eq $k "key_file") (eq $k "ca_file") }}
+      {{- if or (eq $k "cert_file") (eq $k "key_file") (eq $k "ca_file") (eq $k "credentials") }}
 - -config
 - {{ $v }}
       {{- else if hasSuffix "$include" $k }}
@@ -267,6 +291,10 @@ output: YAML list of reloader config files
       {{- else }}
         {{- include "nats.reloaderConfig" (dict "config" $v "dir" $dir) }}
       {{- end -}}
+    {{- end -}}
+  {{- else if kindIs "slice" . -}}
+    {{- range . -}}
+      {{- include "nats.reloaderConfig" (dict "config" . "dir" $dir) -}}
     {{- end -}}
   {{- end -}}
   {{- end -}}

--- a/helm/charts/nats/templates/_helpers.tpl
+++ b/helm/charts/nats/templates/_helpers.tpl
@@ -191,7 +191,7 @@ imagePullPolicy: {{ .pullPolicy | default .global.image.pullPolicy }}
       {{- end }}
     {{- end }}
     {{- with $remote.tls }}
-      {{- if .secretName }}
+      {{- if and .enabled .secretName }}
         {{- $secrets = append $secrets (dict "name" (printf "leafnodes-remote-%d-tls" $i) "secretName" .secretName "dir" .dir) }}
       {{- end }}
     {{- end }}
@@ -282,7 +282,7 @@ output: YAML list of reloader config files
   {{- with .config -}}
   {{- if kindIs "map" . -}}
     {{- range $k, $v := . -}}
-      {{- if or (eq $k "cert_file") (eq $k "key_file") (eq $k "ca_file") (eq $k "credentials") }}
+      {{- if or (eq $k "cert_file") (eq $k "key_file") (eq $k "ca_file") }}
 - -config
 - {{ $v }}
       {{- else if hasSuffix "$include" $k }}

--- a/helm/charts/nats/test/chart_test.go
+++ b/helm/charts/nats/test/chart_test.go
@@ -153,7 +153,7 @@ func DefaultTest() *Test {
 	}
 }
 
-func HelmRender(t *testing.T, test *Test) *Resources {
+func helmRenderOptions(t *testing.T, test *Test) (string, *helm.Options) {
 	t.Helper()
 
 	helmChartPath, err := filepath.Abs("..")
@@ -161,19 +161,22 @@ func HelmRender(t *testing.T, test *Test) *Resources {
 
 	tmpFile, err := os.CreateTemp("", "values.*.yaml")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
 
-	if _, err := tmpFile.Write([]byte(test.Values)); err != nil {
-		tmpFile.Close()
-		require.NoError(t, err)
-	}
-	err = tmpFile.Close()
+	_, err = tmpFile.Write([]byte(test.Values))
 	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
 
-	options := &helm.Options{
+	return helmChartPath, &helm.Options{
 		ValuesFiles:    []string{tmpFile.Name()},
 		KubectlOptions: k8s.NewKubectlOptions("", "", test.Namespace),
 	}
+}
+
+func HelmRender(t *testing.T, test *Test) *Resources {
+	t.Helper()
+
+	helmChartPath, options := helmRenderOptions(t, test)
 	output := helm.RenderTemplate(t, options, helmChartPath, test.ReleaseName, nil)
 	outputs := strings.Split(output, "---")
 
@@ -213,6 +216,15 @@ func HelmRender(t *testing.T, test *Test) *Resources {
 	resources.Conf.HasValue = true
 
 	return resources
+}
+
+func HelmRenderError(t *testing.T, test *Test, wantSubstr string) {
+	t.Helper()
+
+	helmChartPath, options := helmRenderOptions(t, test)
+	_, err := helm.RenderTemplateE(t, options, helmChartPath, test.ReleaseName, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), wantSubstr)
 }
 
 func RenderAndCheck(t *testing.T, test *Test, expected *Resources) {

--- a/helm/charts/nats/test/config_test.go
+++ b/helm/charts/nats/test/config_test.go
@@ -619,6 +619,140 @@ max_outstanding_catchup: 64MB
 	RenderAndCheck(t, test, expected)
 }
 
+func TestConfigLeafnodeRemotes(t *testing.T) {
+	t.Parallel()
+	test := DefaultTest()
+	test.Values = `
+config:
+  leafnodes:
+    enabled: true
+    remotes:
+    - url: tls://connect.ngs.global:7422
+      account: A
+      credentials:
+        secretName: ngs-creds
+    - urls:
+      - tls://hub-1.example.com:7422
+      - tls://hub-2.example.com:7422
+      tls:
+        secretName: hub-tls
+`
+	expected := DefaultResources(t, test)
+
+	expected.Conf.Value["leafnodes"] = map[string]any{
+		"port":         int64(7422),
+		"no_advertise": true,
+		"remotes": []any{
+			map[string]any{
+				"account":     "A",
+				"credentials": "/etc/nats-creds/leafnodes-remote-0/nats.creds",
+				"urls":        []any{"tls://connect.ngs.global:7422"},
+			},
+			map[string]any{
+				"tls": map[string]any{
+					"cert_file": "/etc/nats-certs/leafnodes-remote-1/tls.crt",
+					"key_file":  "/etc/nats-certs/leafnodes-remote-1/tls.key",
+				},
+				"urls": []any{
+					"tls://hub-1.example.com:7422",
+					"tls://hub-2.example.com:7422",
+				},
+			},
+		},
+	}
+
+	volumes := expected.StatefulSet.Value.Spec.Template.Spec.Volumes
+	volumes = append(volumes, corev1.Volume{
+		Name: "leafnodes-remote-0-creds",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "ngs-creds",
+			},
+		},
+	}, corev1.Volume{
+		Name: "leafnodes-remote-1-tls",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "hub-tls",
+			},
+		},
+	})
+	expected.StatefulSet.Value.Spec.Template.Spec.Volumes = volumes
+
+	credsVm := corev1.VolumeMount{
+		MountPath: "/etc/nats-creds/leafnodes-remote-0",
+		Name:      "leafnodes-remote-0-creds",
+	}
+	tlsVm := corev1.VolumeMount{
+		MountPath: "/etc/nats-certs/leafnodes-remote-1",
+		Name:      "leafnodes-remote-1-tls",
+	}
+	natsVm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts = append(natsVm, credsVm, tlsVm)
+	reloaderVm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].VolumeMounts
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].VolumeMounts = append(reloaderVm, credsVm, tlsVm)
+
+	reloaderArgs := expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args
+	reloaderArgs = append(reloaderArgs,
+		"-config", "/etc/nats-creds/leafnodes-remote-0/nats.creds",
+		"-config", "/etc/nats-certs/leafnodes-remote-1/tls.crt",
+		"-config", "/etc/nats-certs/leafnodes-remote-1/tls.key")
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args = reloaderArgs
+
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{
+			Name:          "nats",
+			ContainerPort: 4222,
+		},
+		{
+			Name:          "leafnodes",
+			ContainerPort: 7422,
+		},
+		{
+			Name:          "monitor",
+			ContainerPort: 8222,
+		},
+	}
+
+	expected.HeadlessService.Value.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:        "nats",
+			Port:        4222,
+			TargetPort:  intstr.FromString("nats"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "leafnodes",
+			Port:        7422,
+			TargetPort:  intstr.FromString("leafnodes"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "monitor",
+			Port:        8222,
+			TargetPort:  intstr.FromString("monitor"),
+			AppProtocol: &appProtocolHTTP,
+		},
+	}
+
+	expected.Service.Value.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:        "nats",
+			Port:        4222,
+			TargetPort:  intstr.FromString("nats"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "leafnodes",
+			Port:        7422,
+			TargetPort:  intstr.FromString("leafnodes"),
+			AppProtocol: &appProtocolTCP,
+		},
+	}
+
+	RenderAndCheck(t, test, expected)
+}
+
 func TestExtraResources(t *testing.T) {
 	t.Parallel()
 	test := DefaultTest()

--- a/helm/charts/nats/test/config_test.go
+++ b/helm/charts/nats/test/config_test.go
@@ -635,6 +635,7 @@ config:
       - tls://hub-1.example.com:7422
       - tls://hub-2.example.com:7422
       tls:
+        enabled: true
         secretName: hub-tls
 `
 	expected := DefaultResources(t, test)
@@ -694,7 +695,6 @@ config:
 
 	reloaderArgs := expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args
 	reloaderArgs = append(reloaderArgs,
-		"-config", "/etc/nats-creds/leafnodes-remote-0/nats.creds",
 		"-config", "/etc/nats-certs/leafnodes-remote-1/tls.crt",
 		"-config", "/etc/nats-certs/leafnodes-remote-1/tls.key")
 	expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args = reloaderArgs
@@ -747,6 +747,253 @@ config:
 			Port:        7422,
 			TargetPort:  intstr.FromString("leafnodes"),
 			AppProtocol: &appProtocolTCP,
+		},
+	}
+
+	RenderAndCheck(t, test, expected)
+}
+
+func TestConfigLeafnodeRemoteTlsCA(t *testing.T) {
+	t.Parallel()
+	test := DefaultTest()
+	test.Values = `
+config:
+  leafnodes:
+    enabled: true
+    remotes:
+    - url: tls://hub.example.com:7422
+      credentials:
+        secretName: hub-creds
+      tls:
+        enabled: true
+tlsCA:
+  enabled: true
+  configMapName: nats-ca
+`
+	expected := DefaultResources(t, test)
+
+	expected.Conf.Value["leafnodes"] = map[string]any{
+		"port":         int64(7422),
+		"no_advertise": true,
+		"remotes": []any{
+			map[string]any{
+				"credentials": "/etc/nats-creds/leafnodes-remote-0/nats.creds",
+				"tls": map[string]any{
+					"ca_file": "/etc/nats-ca-cert/ca.crt",
+				},
+				"urls": []any{"tls://hub.example.com:7422"},
+			},
+		},
+	}
+
+	tlsCAVol := corev1.Volume{
+		Name: "tls-ca",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "nats-ca",
+				},
+			},
+		},
+	}
+	credsVol := corev1.Volume{
+		Name: "leafnodes-remote-0-creds",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "hub-creds",
+			},
+		},
+	}
+	stsVols := expected.StatefulSet.Value.Spec.Template.Spec.Volumes
+	expected.StatefulSet.Value.Spec.Template.Spec.Volumes = append(stsVols, tlsCAVol, credsVol)
+
+	tlsCAVm := corev1.VolumeMount{
+		Name:      "tls-ca",
+		MountPath: "/etc/nats-ca-cert",
+	}
+	credsVm := corev1.VolumeMount{
+		MountPath: "/etc/nats-creds/leafnodes-remote-0",
+		Name:      "leafnodes-remote-0-creds",
+	}
+	natsVm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].VolumeMounts = append(natsVm, tlsCAVm, credsVm)
+	reloaderVm := expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].VolumeMounts
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].VolumeMounts = append(reloaderVm, tlsCAVm, credsVm)
+
+	natsBoxVols := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Volumes
+	expected.NatsBoxDeployment.Value.Spec.Template.Spec.Volumes = append(natsBoxVols, tlsCAVol)
+	natsBoxVms := expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0].VolumeMounts
+	expected.NatsBoxDeployment.Value.Spec.Template.Spec.Containers[0].VolumeMounts = append(natsBoxVms, tlsCAVm)
+
+	reloaderArgs := expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args
+	reloaderArgs = append(reloaderArgs, "-config", "/etc/nats-ca-cert/ca.crt")
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args = reloaderArgs
+
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{
+			Name:          "nats",
+			ContainerPort: 4222,
+		},
+		{
+			Name:          "leafnodes",
+			ContainerPort: 7422,
+		},
+		{
+			Name:          "monitor",
+			ContainerPort: 8222,
+		},
+	}
+
+	expected.HeadlessService.Value.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:        "nats",
+			Port:        4222,
+			TargetPort:  intstr.FromString("nats"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "leafnodes",
+			Port:        7422,
+			TargetPort:  intstr.FromString("leafnodes"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "monitor",
+			Port:        8222,
+			TargetPort:  intstr.FromString("monitor"),
+			AppProtocol: &appProtocolHTTP,
+		},
+	}
+
+	expected.Service.Value.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:        "nats",
+			Port:        4222,
+			TargetPort:  intstr.FromString("nats"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "leafnodes",
+			Port:        7422,
+			TargetPort:  intstr.FromString("leafnodes"),
+			AppProtocol: &appProtocolTCP,
+		},
+	}
+
+	RenderAndCheck(t, test, expected)
+}
+
+func TestConfigLeafnodeRemotesRenderFail(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		values  string
+		wantErr string
+	}{
+		{
+			name: "MissingUrl",
+			values: `
+config:
+  leafnodes:
+    enabled: true
+    remotes:
+    - account: A
+`,
+			wantErr: "config.leafnodes.remotes entries must set url or urls",
+		},
+		{
+			name: "CredentialsMissingSecretName",
+			values: `
+config:
+  leafnodes:
+    enabled: true
+    remotes:
+    - url: tls://connect.ngs.global:7422
+      credentials:
+        key: my.creds
+`,
+			wantErr: "config.leafnodes.remotes credentials must set secretName",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := DefaultTest()
+			test.Values = tt.values
+			HelmRenderError(t, test, tt.wantErr)
+		})
+	}
+}
+
+func TestReloaderTlsInConfigList(t *testing.T) {
+	t.Parallel()
+	test := DefaultTest()
+	test.Values = `
+config:
+  gateway:
+    enabled: true
+    merge:
+      gateways:
+      - name: hub
+        url: nats://gw.example.com:7222
+        tls:
+          cert_file: /etc/nats-certs/gw/tls.crt
+          key_file: /etc/nats-certs/gw/tls.key
+`
+	expected := DefaultResources(t, test)
+
+	expected.Conf.Value["gateway"] = map[string]any{
+		"name": "nats",
+		"port": int64(7222),
+		"gateways": []any{
+			map[string]any{
+				"name": "hub",
+				"url":  "nats://gw.example.com:7222",
+				"tls": map[string]any{
+					"cert_file": "/etc/nats-certs/gw/tls.crt",
+					"key_file":  "/etc/nats-certs/gw/tls.key",
+				},
+			},
+		},
+	}
+
+	reloaderArgs := expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args
+	reloaderArgs = append(reloaderArgs,
+		"-config", "/etc/nats-certs/gw/tls.crt",
+		"-config", "/etc/nats-certs/gw/tls.key")
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[1].Args = reloaderArgs
+
+	expected.StatefulSet.Value.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{
+			Name:          "nats",
+			ContainerPort: 4222,
+		},
+		{
+			Name:          "gateway",
+			ContainerPort: 7222,
+		},
+		{
+			Name:          "monitor",
+			ContainerPort: 8222,
+		},
+	}
+
+	expected.HeadlessService.Value.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:        "nats",
+			Port:        4222,
+			TargetPort:  intstr.FromString("nats"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "gateway",
+			Port:        7222,
+			TargetPort:  intstr.FromString("gateway"),
+			AppProtocol: &appProtocolTCP,
+		},
+		{
+			Name:        "monitor",
+			Port:        8222,
+			TargetPort:  intstr.FromString("monitor"),
+			AppProtocol: &appProtocolHTTP,
 		},
 	}
 

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -141,7 +141,7 @@ config:
 
     # solicit connections to remote NATS servers as a leafnode
     # https://docs.nats.io/running-a-nats-service/configuration/leafnodes/leafnode_conf
-    # each remote must set url or urls
+    # each remote must set url or urls; if both are set, they are combined
     # other remote options (hub, deny_imports, etc.) can be added with the leafnodes patch
     # example - connect to Synadia Cloud:
     #
@@ -157,16 +157,20 @@ config:
     #   # local account to bind to this remote
     #   account:
     #   # mount an existing secret containing a credentials file
+    #   # secretName is required when credentials is set
     #   credentials:
     #     secretName:
     #     # key in the secret that contains the credentials file
     #     key: nats.creds
     #     # defaults to /etc/nats-creds/leafnodes-remote-<index>
     #     dir:
-    #   # client certificates for this remote
+    #   # tls options for this remote, must be enabled like the other tls blocks in the chart
+    #   # enabling forces a TLS connection to this remote and applies the global tlsCA as
+    #   # ca_file, which replaces the system CAs
     #   # note: tls:// urls use TLS with system CAs without needing this block
     #   tls:
-    #     # set secretName in order to mount an existing secret to dir
+    #     enabled: false
+    #     # set secretName in order to mount an existing secret with client certificates to dir
     #     secretName:
     #     # defaults to /etc/nats-certs/leafnodes-remote-<index>
     #     dir:

--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -138,6 +138,42 @@ config:
   leafnodes:
     enabled: false
     port: 7422
+
+    # solicit connections to remote NATS servers as a leafnode
+    # https://docs.nats.io/running-a-nats-service/configuration/leafnodes/leafnode_conf
+    # each remote must set url or urls
+    # other remote options (hub, deny_imports, etc.) can be added with the leafnodes patch
+    # example - connect to Synadia Cloud:
+    #
+    # remotes:
+    # - url: tls://connect.ngs.global:7422
+    #   credentials:
+    #     secretName: ngs-creds
+    #
+    # remotes:
+    # - url or urls, the remote server(s) to connect to
+    #   url:
+    #   urls: []
+    #   # local account to bind to this remote
+    #   account:
+    #   # mount an existing secret containing a credentials file
+    #   credentials:
+    #     secretName:
+    #     # key in the secret that contains the credentials file
+    #     key: nats.creds
+    #     # defaults to /etc/nats-creds/leafnodes-remote-<index>
+    #     dir:
+    #   # client certificates for this remote
+    #   # note: tls:// urls use TLS with system CAs without needing this block
+    #   tls:
+    #     # set secretName in order to mount an existing secret to dir
+    #     secretName:
+    #     # defaults to /etc/nats-certs/leafnodes-remote-<index>
+    #     dir:
+    #     cert: tls.crt
+    #     key: tls.key
+    remotes: []
+
     tls:
       enabled: false
       # set secretName in order to mount an existing secret to dir


### PR DESCRIPTION
## Overview

This PR addresses all findings from the review of the leafnode remotes feature: both blocking issues (the no-op credentials reloader watch and the global `tlsCA` never reaching remotes), both follow-ups (the list-recursion side effect and the silent credentials misconfiguration), and the three nits. One reviewer suggestion is implemented differently than proposed, with rationale below.

## Changes

The per-remote `tls` block now requires `enabled: true`, matching every other tls block in the chart, and a bare `tls: {enabled: true}` applies the global `tlsCA` as `ca_file` — the private-CA hub case that previously rendered nothing. The review suggested rendering the block automatically whenever `tlsCA` is enabled, but that is not safe: `server/leafnode.go:3508` sets `tlsRequired := remote.TLS || remote.TLSConfig != nil`, so any rendered `tls` block, even one carrying only `ca_file`, forces a TLS handshake and would break plain `nats://` remotes; and since `ca_file` replaces the system root pool, injecting the private CA would also break remotes that rely on public CAs, such as NGS. The two cases cannot be distinguished automatically, so opting in per remote is the only correct general design, and it resolves the tls-block asymmetry nit as a side effect.

The `credentials` case is removed from `nats.reloaderConfig`. As the review demonstrated live and the source confirms, the server reads the creds file from disk on every connection attempt and a reload signal neither re-reads credentials nor affects established leafnode connections, so the watch could only ever send a signal the server ignores while logging as if rotation had been applied. Rotation semantics are now documented as next-reconnect in the README and values.yaml. The certificate watches remain, because remote `TLSConfig` is only rebuilt on reload, so those watches do real work for future reconnect attempts.

A `credentials` block without `secretName` now fails the render with `config.leafnodes.remotes credentials must set secretName`, matching the existing url guard, instead of silently emitting a remote that connects anonymously. Hand-mounted creds paths remain reachable through `config.leafnodes.patch`. The url-plus-urls combination is now documented in values.yaml and the README, and the stray double blank line in the README is fixed.

## Behavior

Default rendered output remains byte-identical to main, with one intentional and now-documented exception: configs that already reference certificate files inside config lists, for example `gateway.merge.gateways[].tls`, gain reloader watch args from the list recursion, which mutates the pod spec and causes one rolling restart on upgrade. Within this feature, a per-remote `tls` block that previously set only `secretName` must now also set `enabled: true` to render.

## Testing

Added `TestConfigLeafnodeRemoteTlsCA` rendering the exact missing-`ca_file` scenario from the review, `TestConfigLeafnodeRemotesRenderFail` covering both render guards through a new `HelmRenderError` harness helper, and `TestReloaderTlsInConfigList` pinning the list-recursion behavior with a gateway merge fixture. `TestConfigLeafnodeRemotes` is updated for the `enabled` flag and the removed creds watch. The full suite passes, the nindent check and `helm lint` are clean, and the default-render diff against main was verified empty both with leafnodes disabled and enabled with no remotes.
